### PR TITLE
Configure backend URL at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
     image: edgehogdevicemanager/edgehog-frontend:snapshot
     build:
       context: frontend
-      args:
-        backend_url: http://localhost:4000/api
+    environment:
+      BACKEND_URL: http://localhost:4000/api
     ports:
       - 8080:80
     restart: on-failure

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,9 +5,9 @@ ADD package*.json ./
 RUN npm ci --production
 ADD . .
 ARG backend_url
-ENV REACT_APP_BACKEND_URL=$backend_url
 RUN npm run build
 
 FROM nginx:1
 COPY --from=builder /app/build/ /usr/share/nginx/html/
 ADD nginx.conf /etc/nginx/conf.d/default.conf
+ADD set-backend-url.sh /docker-entrypoint.d/set-backend-url.sh

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -18,6 +18,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="application-name" content="Edgehog" data-backend-url="http://localhost:4000/api" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/frontend/set-backend-url.sh
+++ b/frontend/set-backend-url.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i 's|data-backend-url=\"[^\"]*\"|data-backend-url=\"'"$BACKEND_URL"'\"|' /usr/share/nginx/html/index.html
+

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,7 +25,10 @@ import {
   UploadableMap,
 } from "relay-runtime";
 
-const backendUrl = process.env.REACT_APP_BACKEND_URL || "/api";
+const applicationMetatag: HTMLElement = document.head.querySelector(
+  "[name=application-name]"
+)!;
+const backendUrl = applicationMetatag.dataset?.backendUrl || "";
 
 const loadAuthToken = () => null; // TODO: implement authentication
 


### PR DESCRIPTION
Use envirorment variables to inject at runtime
the URL of the backend API

Signed-off-by: Mattia Pavinati <mattia.pavinati@secomind.com>