### PR TITLE
Handle device connection triggers

### DIFF
--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -393,6 +393,16 @@ defmodule Edgehog.Astarte do
     end
   end
 
+  defp update_device_with_event(%Device{} = device, %{"type" => "device_connected"}, timestamp) do
+    change_device(device, %{online: true, last_connection: timestamp})
+    |> Repo.update()
+  end
+
+  defp update_device_with_event(%Device{} = device, %{"type" => "device_disconnected"}, timestamp) do
+    change_device(device, %{online: false, last_disconnection: timestamp})
+    |> Repo.update()
+  end
+
   defp update_device_with_event(%Device{} = device, _unhandled_event, _timestamp) do
     # Just return the same device
     {:ok, device}

--- a/backend/lib/edgehog/astarte/device.ex
+++ b/backend/lib/edgehog/astarte/device.ex
@@ -26,6 +26,9 @@ defmodule Edgehog.Astarte.Device do
     field :device_id, :string
     field :name, :string
     field :tenant_id, :id
+    field :last_connection, :utc_datetime
+    field :last_disconnection, :utc_datetime
+    field :online, :boolean, default: false
     belongs_to :realm, Realm
 
     timestamps()
@@ -34,7 +37,13 @@ defmodule Edgehog.Astarte.Device do
   @doc false
   def changeset(device, attrs) do
     device
-    |> cast(attrs, [:name, :device_id])
+    |> cast(attrs, [
+      :name,
+      :device_id,
+      :online,
+      :last_connection,
+      :last_disconnection
+    ])
     |> validate_required([:name, :device_id])
     |> unique_constraint([:device_id, :realm_id, :tenant_id])
   end

--- a/backend/lib/edgehog/astarte/device/device_status.ex
+++ b/backend/lib/edgehog/astarte/device/device_status.ex
@@ -1,0 +1,52 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.DeviceStatus do
+  defstruct [
+    :last_connection,
+    :last_disconnection,
+    :online
+  ]
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.DeviceStatus
+
+  def get(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_device_status(client, device_id) do
+      device_status = %DeviceStatus{
+        last_connection: parse_datetime(data["last_connection"]),
+        last_disconnection: parse_datetime(data["last_disconnection"]),
+        online: data["connected"] || false
+      }
+
+      {:ok, device_status}
+    end
+  end
+
+  defp parse_datetime(nil) do
+    nil
+  end
+
+  defp parse_datetime(datetime_string) do
+    case DateTime.from_iso8601(datetime_string) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+end

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -21,6 +21,7 @@ defmodule EdgehogWeb.Schema do
   use Absinthe.Relay.Schema, :modern
   import_types EdgehogWeb.Schema.AstarteTypes
   import_types EdgehogWeb.Schema.AppliancesTypes
+  import_types Absinthe.Type.Custom
 
   alias EdgehogWeb.Middleware
   alias EdgehogWeb.Resolvers

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -35,6 +35,9 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
   node object(:device) do
     field :name, non_null(:string)
     field :device_id, non_null(:string)
+    field :online, non_null(:boolean)
+    field :last_connection, :datetime
+    field :last_disconnection, :datetime
 
     field :hardware_info, :hardware_info do
       resolve &Resolvers.Astarte.get_hardware_info/3

--- a/backend/priv/repo/migrations/20211105185233_add_connection_info_to_devices.exs
+++ b/backend/priv/repo/migrations/20211105185233_add_connection_info_to_devices.exs
@@ -1,0 +1,11 @@
+defmodule Edgehog.Repo.Migrations.AddConnectionInfoToDevices do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add :online, :boolean, default: false, null: false
+      add :last_connection, :utc_datetime
+      add :last_disconnection, :utc_datetime
+    end
+  end
+end

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -200,7 +200,7 @@ defmodule Edgehog.AstarteTest do
 
     test "ensure_device_exists/1 creates a device if not existent", %{realm: realm} do
       device_id = "does_not_exist"
-      {:ok, device} = Astarte.ensure_device_exists(realm, device_id)
+      {:ok, device} = Astarte.ensure_device_exists(realm, device_id, init_from_astarte: false)
       assert %Device{device_id: ^device_id} = device
     end
 

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -219,5 +219,41 @@ defmodule Edgehog.AstarteTest do
 
       assert ^device = Astarte.get_device!(device.id)
     end
+
+    test "process_device_event/4 updates online and last_connection on device_connected event", %{
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: false, last_connection: nil})
+      assert device.online == false
+      assert device.last_connection == nil
+
+      device_id = device.device_id
+      event = %{"type" => "device_connected"}
+      timestamp = DateTime.utc_now()
+      timestamp_string = DateTime.to_iso8601(timestamp)
+      assert :ok = Astarte.process_device_event(realm, device_id, event, timestamp_string)
+
+      assert device = Astarte.get_device!(device.id)
+      assert device.online == true
+      assert device.last_connection == timestamp |> DateTime.truncate(:second)
+    end
+
+    test "process_device_event/4 updates online and last_disconnection on device_disconnected event",
+         %{realm: realm} do
+      device = device_fixture(realm, %{online: true, last_disconnection: nil})
+
+      assert device.online == true
+      assert device.last_disconnection == nil
+
+      device_id = device.device_id
+      event = %{"type" => "device_disconnected"}
+      timestamp = DateTime.utc_now()
+      timestamp_string = DateTime.to_iso8601(timestamp)
+      assert :ok = Astarte.process_device_event(realm, device_id, event, timestamp_string)
+
+      assert device = Astarte.get_device!(device.id)
+      assert device.online == false
+      assert device.last_disconnection == timestamp |> DateTime.truncate(:second)
+    end
   end
 end

--- a/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
+++ b/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
@@ -12,7 +12,10 @@ export type Device_getDevice_QueryResponse = {
     readonly device: {
         readonly id: string;
         readonly deviceId: string;
+        readonly lastConnection: string | null;
+        readonly lastDisconnection: string | null;
         readonly name: string;
+        readonly online: boolean;
         readonly " $fragmentRefs": FragmentRefs<"Device_hardwareInfo">;
     } | null;
 };
@@ -30,7 +33,10 @@ query Device_getDevice_Query(
   device(id: $id) {
     id
     deviceId
+    lastConnection
+    lastDisconnection
     name
+    online
     ...Device_hardwareInfo
   }
 }
@@ -79,7 +85,28 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "lastConnection",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastDisconnection",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "online",
   "storageKey": null
 };
 return {
@@ -100,6 +127,9 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -129,6 +159,9 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -181,14 +214,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ecf8295df3b12b8033644834f38a6de8",
+    "cacheID": "785dbc84cc8b693f346c0130823c35ad",
     "id": null,
     "metadata": {},
     "name": "Device_getDevice_Query",
     "operationKind": "query",
-    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    name\n    ...Device_hardwareInfo\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n"
+    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n    ...Device_hardwareInfo\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '23b7ea334e427de2fff737225e182246';
+(node as any).hash = '2cf91aa68b82d3e725c105e349c7c802';
 export default node;

--- a/frontend/src/api/__generated__/Devices_getDevices_Query.graphql.ts
+++ b/frontend/src/api/__generated__/Devices_getDevices_Query.graphql.ts
@@ -9,7 +9,10 @@ export type Devices_getDevices_QueryResponse = {
     readonly devices: ReadonlyArray<{
         readonly id: string;
         readonly deviceId: string;
+        readonly lastConnection: string | null;
+        readonly lastDisconnection: string | null;
         readonly name: string;
+        readonly online: boolean;
     }>;
 };
 export type Devices_getDevices_Query = {
@@ -24,7 +27,10 @@ query Devices_getDevices_Query {
   devices {
     id
     deviceId
+    lastConnection
+    lastDisconnection
     name
+    online
   }
 }
 */
@@ -57,7 +63,28 @@ var v0 = [
         "alias": null,
         "args": null,
         "kind": "ScalarField",
+        "name": "lastConnection",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "lastDisconnection",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
         "name": "name",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "online",
         "storageKey": null
       }
     ],
@@ -82,14 +109,14 @@ return {
     "selections": (v0/*: any*/)
   },
   "params": {
-    "cacheID": "177a433a3dad04bb67c1650985a8eeb9",
+    "cacheID": "4af51fd4b7571ef99553422e4a8555f2",
     "id": null,
     "metadata": {},
     "name": "Devices_getDevices_Query",
     "operationKind": "query",
-    "text": "query Devices_getDevices_Query {\n  devices {\n    id\n    deviceId\n    name\n  }\n}\n"
+    "text": "query Devices_getDevices_Query {\n  devices {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '57e2bf5ffc288d9b21f85a5e0128146c';
+(node as any).hash = '390c4a179e214f3640d4f3285db26746';
 export default node;

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -2,6 +2,14 @@ schema {
   query: RootQueryType
 }
 
+"""
+The `DateTime` scalar type represents a date and time in the UTC
+timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+string, including UTC timezone ("Z"). The parsed date and time string will
+be converted to UTC if there is an offset.
+"""
+scalar DateTime
+
 type Device implements Node {
   deviceId: String!
   hardwareInfo: HardwareInfo
@@ -10,7 +18,10 @@ type Device implements Node {
   The ID of an object
   """
   id: ID!
+  lastConnection: DateTime
+  lastDisconnection: DateTime
   name: String!
+  online: Boolean!
 }
 
 type HardwareInfo {

--- a/frontend/src/components/ConnectionStatus.test.tsx
+++ b/frontend/src/components/ConnectionStatus.test.tsx
@@ -32,6 +32,6 @@ it("renders correctly", () => {
     connectedStatus.container.querySelector(".text-success")
   ).toBeInTheDocument();
   expect(
-    disconnectedStatus.container.querySelector(".text-gray")
+    disconnectedStatus.container.querySelector(".text-secondary")
   ).toBeInTheDocument();
 });

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -34,7 +34,7 @@ const ConnectionStatus = ({ connected, icon = true }: Props) => {
     defaultMessage: "Connected",
   });
   if (!connected) {
-    color = "text-gray";
+    color = "text-secondary";
     label = intl.formatMessage({
       id: "components.ConnectionStatus.statusDisconnected",
       defaultMessage: "Disconnected",

--- a/frontend/src/components/DevicesTable.tsx
+++ b/frontend/src/components/DevicesTable.tsx
@@ -19,14 +19,17 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import LastSeen from "components/LastSeen";
 import Table from "components/Table";
-import type { Column } from "components/Table";
+import type { Column, Row } from "components/Table";
 import ConnectionStatus from "components/ConnectionStatus";
 import { Link, Route } from "Navigation";
 
 type DeviceProps = {
   deviceId: string;
   id: string;
+  lastConnection: string | null;
+  lastDisconnection: string | null;
   name: string;
   online: boolean;
 };
@@ -73,6 +76,30 @@ const columns: Column<DeviceProps>[] = [
       />
     ),
     sortType: "basic",
+  },
+  {
+    id: "lastSeen",
+    accessor: (device) => {
+      if (device.online) {
+        return "now";
+      } else {
+        return device.lastDisconnection || "never";
+      }
+    },
+    Header: (
+      <FormattedMessage
+        id="components.DevicesTable.lastSeenTitle"
+        defaultMessage="Last Seen"
+        description="Title for the Last Seen column of the devices table"
+      />
+    ),
+    Cell: ({ row }: { row: Row<DeviceProps> }) => (
+      <LastSeen
+        lastConnection={row.original.lastConnection}
+        lastDisconnection={row.original.lastDisconnection}
+        online={row.original.online}
+      />
+    ),
   },
 ];
 

--- a/frontend/src/components/LastSeen.test.tsx
+++ b/frontend/src/components/LastSeen.test.tsx
@@ -1,0 +1,52 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2021 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from "react";
+
+import { renderWithProviders } from "setupTests";
+import LastSeen from "./LastSeen";
+
+it("displays Now for a device that is connected", () => {
+  const props = {
+    lastConnection: "2021-11-08T15:43:34.706Z",
+    lastDisconnection: null,
+    online: true,
+  };
+  const { container } = renderWithProviders(<LastSeen {...props} />);
+  expect(container).toHaveTextContent("Now");
+});
+
+it("displays Never for a device that never connected", () => {
+  const props = {
+    lastConnection: null,
+    lastDisconnection: null,
+    online: false,
+  };
+  const { container } = renderWithProviders(<LastSeen {...props} />);
+  expect(container).toHaveTextContent("Never");
+});
+
+it("displays date of last disconnection for a device that was once connected", () => {
+  const props = {
+    lastConnection: "2021-11-05T15:43:34.706Z",
+    lastDisconnection: "2021-11-08T15:43:34.706Z",
+    online: false,
+  };
+  const { container } = renderWithProviders(<LastSeen {...props} />);
+  expect(container).toHaveTextContent("November 8, 2021, 3:43 PM");
+});

--- a/frontend/src/components/LastSeen.tsx
+++ b/frontend/src/components/LastSeen.tsx
@@ -1,0 +1,50 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2021 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { FormattedDate, FormattedMessage } from "react-intl";
+
+type Props = {
+  lastConnection: string | null;
+  lastDisconnection: string | null;
+  online: boolean;
+};
+
+const LastSeen = ({ lastConnection, lastDisconnection, online }: Props) => {
+  if (online) {
+    return (
+      <FormattedMessage id="components.LastSeen.now" defaultMessage="Now" />
+    );
+  } else if (lastDisconnection) {
+    return (
+      <FormattedDate
+        value={new Date(lastDisconnection)}
+        year="numeric"
+        month="long"
+        day="numeric"
+        hour="numeric"
+        minute="numeric"
+      />
+    );
+  } else {
+    return (
+      <FormattedMessage id="components.LastSeen.never" defaultMessage="Never" />
+    );
+  }
+};
+
+export default LastSeen;

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -208,4 +208,4 @@ const Table = <T extends Object>({
 };
 
 export default Table;
-export type { Column };
+export type { Column, Row };

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -36,6 +36,7 @@ import ConnectionStatus from "components/ConnectionStatus";
 import Col from "components/Col";
 import Figure from "components/Figure";
 import Form from "components/Form";
+import LastSeen from "components/LastSeen";
 import Page from "components/Page";
 import Result from "components/Result";
 import Row from "components/Row";
@@ -59,7 +60,10 @@ const GET_DEVICE_QUERY = graphql`
     device(id: $id) {
       id
       deviceId
+      lastConnection
+      lastDisconnection
       name
+      online
       ...Device_hardwareInfo
     }
   }
@@ -198,11 +202,7 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
 
   // TODO: handle readonly type without mapping to mutable type
   const device = useMemo(
-    () =>
-      deviceData.device && {
-        ...deviceData.device,
-        online: true,
-      },
+    () => deviceData.device && { ...deviceData.device },
     [deviceData.device]
   );
 
@@ -270,6 +270,23 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
                 >
                   <FormValue>
                     <ConnectionStatus connected={device.online} />
+                  </FormValue>
+                </FormRow>
+                <FormRow
+                  id="form-device-last-seen"
+                  label={
+                    <FormattedMessage
+                      id="Device.lastSeen"
+                      defaultMessage="Last seen"
+                    />
+                  }
+                >
+                  <FormValue>
+                    <LastSeen
+                      lastConnection={device.lastConnection}
+                      lastDisconnection={device.lastDisconnection}
+                      online={device.online}
+                    />
                   </FormValue>
                 </FormRow>
               </Stack>

--- a/frontend/src/pages/Devices.tsx
+++ b/frontend/src/pages/Devices.tsx
@@ -37,7 +37,10 @@ const GET_DEVICES_QUERY = graphql`
     devices {
       id
       deviceId
+      lastConnection
+      lastDisconnection
       name
+      online
     }
   }
 `;
@@ -51,7 +54,7 @@ const DevicesContent = ({ getDevicesQuery }: DevicesContentProps) => {
 
   // TODO: handle readonly type without mapping to mutable type
   const devices = useMemo(
-    () => devicesData.devices.map((device) => ({ ...device, online: true })),
+    () => devicesData.devices.map((device) => ({ ...device })),
     [devicesData]
   );
 


### PR DESCRIPTION
On the backend-side:
- Handle connection/disconnection triggers, updating the Device in the database accordingly to persist the status
- If the device does not already exist, create it and fetch its status from Astarte
- Update the GraphQL queries to expose the connection status of devices

On the frontend-side:
- Update the Device and Devices pages to display whether the device is connected or disconnected, and the date of the last connection

![Screenshot 2021-11-08 at 16-48-47 Edgehog](https://user-images.githubusercontent.com/60540759/140775127-5830f3fe-a45f-45f9-90a6-855ca32687d6.png)

