### PR TITLE
Fix uniqueness constraints for Hardware Types

### DIFF
--- a/backend/lib/edgehog/appliances/hardware_type.ex
+++ b/backend/lib/edgehog/appliances/hardware_type.ex
@@ -36,7 +36,7 @@ defmodule Edgehog.Appliances.HardwareType do
     hardware_type
     |> cast(attrs, [:name, :handle])
     |> validate_required([:name, :handle])
-    |> unique_constraint([:tenant_id, :name])
-    |> unique_constraint([:tenant_id, :handle])
+    |> unique_constraint([:name, :tenant_id])
+    |> unique_constraint([:handle, :tenant_id])
   end
 end

--- a/backend/lib/edgehog/appliances/hardware_type_part_number.ex
+++ b/backend/lib/edgehog/appliances/hardware_type_part_number.ex
@@ -35,5 +35,6 @@ defmodule Edgehog.Appliances.HardwareTypePartNumber do
     hardware_type_part_number
     |> cast(attrs, [:part_number])
     |> validate_required([:part_number])
+    |> unique_constraint([:part_number, :tenant_id])
   end
 end

--- a/backend/priv/repo/migrations/20211108141736_create_hardware_types.exs
+++ b/backend/priv/repo/migrations/20211108141736_create_hardware_types.exs
@@ -13,8 +13,8 @@ defmodule Edgehog.Repo.Migrations.CreateHardwareTypes do
     end
 
     create index(:hardware_types, [:tenant_id])
-    create unique_index(:hardware_types, [:tenant_id, :id])
-    create unique_index(:hardware_types, [:tenant_id, :name])
-    create unique_index(:hardware_types, [:tenant_id, :handle])
+    create unique_index(:hardware_types, [:id, :tenant_id])
+    create unique_index(:hardware_types, [:name, :tenant_id])
+    create unique_index(:hardware_types, [:handle, :tenant_id])
   end
 end

--- a/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
+++ b/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
@@ -14,5 +14,6 @@ defmodule Edgehog.Repo.Migrations.CreateHardwareTypePartNumbers do
 
     create index(:hardware_type_part_numbers, [:hardware_type_id])
     create index(:hardware_type_part_numbers, [:tenant_id])
+    create unique_index(:hardware_type_part_numbers, [:part_number, :tenant_id])
   end
 end


### PR DESCRIPTION
- Add a uniqueness constraint for part numbers in a tenant, fixing the behavior of adding duplicate rows since the `on_conflict` was not triggered
- Update the uniqueness constraints for hardware types, making sure Ecto produces understandable errors when failing the validation