### PR TITLE
Validate format for 'handle' of Hardware Types

### DIFF
--- a/backend/lib/edgehog/appliances/hardware_type.ex
+++ b/backend/lib/edgehog/appliances/hardware_type.ex
@@ -38,5 +38,8 @@ defmodule Edgehog.Appliances.HardwareType do
     |> validate_required([:name, :handle])
     |> unique_constraint([:name, :tenant_id])
     |> unique_constraint([:handle, :tenant_id])
+    |> validate_format(:handle, ~r/^[a-z][a-z\d\-]*$/,
+      message: "should only contain lower case ASCII letters (from a to z), digits and -"
+    )
   end
 end

--- a/backend/test/edgehog/appliances_test.exs
+++ b/backend/test/edgehog/appliances_test.exs
@@ -40,10 +40,10 @@ defmodule Edgehog.AppliancesTest do
     end
 
     test "create_hardware_type/1 with valid data creates a hardware_type" do
-      valid_attrs = %{handle: "some handle", name: "some name", part_numbers: ["ABC123"]}
+      valid_attrs = %{handle: "some-handle", name: "some name", part_numbers: ["ABC123"]}
 
       assert {:ok, %HardwareType{} = hardware_type} = Appliances.create_hardware_type(valid_attrs)
-      assert hardware_type.handle == "some handle"
+      assert hardware_type.handle == "some-handle"
       assert hardware_type.name == "some name"
       assert [%HardwareTypePartNumber{part_number: "ABC123"}] = hardware_type.part_numbers
     end
@@ -56,7 +56,7 @@ defmodule Edgehog.AppliancesTest do
       hardware_type = hardware_type_fixture()
 
       update_attrs = %{
-        handle: "some updated handle",
+        handle: "some-updated-handle",
         name: "some updated name",
         part_numbers: ["DEF456"]
       }
@@ -64,7 +64,7 @@ defmodule Edgehog.AppliancesTest do
       assert {:ok, %HardwareType{} = hardware_type} =
                Appliances.update_hardware_type(hardware_type, update_attrs)
 
-      assert hardware_type.handle == "some updated handle"
+      assert hardware_type.handle == "some-updated-handle"
       assert hardware_type.name == "some updated name"
       assert [%HardwareTypePartNumber{part_number: "DEF456"}] = hardware_type.part_numbers
     end
@@ -87,6 +87,12 @@ defmodule Edgehog.AppliancesTest do
     test "change_hardware_type/1 returns a hardware_type changeset" do
       hardware_type = hardware_type_fixture()
       assert %Ecto.Changeset{} = Appliances.change_hardware_type(hardware_type)
+    end
+
+    test "create_hardware_type/1 with invalid handle returns error changeset" do
+      attrs = %{handle: "INVALID HANDLE !", name: "some name", part_numbers: ["ABC123"]}
+
+      assert {:error, %Ecto.Changeset{}} = Appliances.create_hardware_type(attrs)
     end
   end
 end

--- a/backend/test/support/fixtures/appliances_fixtures.ex
+++ b/backend/test/support/fixtures/appliances_fixtures.ex
@@ -29,7 +29,7 @@ defmodule Edgehog.AppliancesFixtures do
     {:ok, hardware_type} =
       attrs
       |> Enum.into(%{
-        handle: "some handle",
+        handle: "some-handle",
         name: "some name",
         part_numbers: ["ABC123"]
       })


### PR DESCRIPTION
Pattern match 'handle' property of Hardware Types to only allow lower case ASCII letters (from a to z), digits and -