### PR TITLE
Remove GraphQL nested input types

### DIFF
--- a/backend/lib/edgehog_web/resolvers/appliances.ex
+++ b/backend/lib/edgehog_web/resolvers/appliances.ex
@@ -39,13 +39,13 @@ defmodule EdgehogWeb.Resolvers.Appliances do
     {:ok, part_numbers}
   end
 
-  def create_hardware_type(_parent, %{hardware_type: attrs}, _context) do
+  def create_hardware_type(_parent, attrs, _context) do
     with {:ok, hardware_type} <- Appliances.create_hardware_type(attrs) do
       {:ok, %{hardware_type: hardware_type}}
     end
   end
 
-  def update_hardware_type(_parent, %{id: id, hardware_type: attrs}, _context) do
+  def update_hardware_type(_parent, %{hardware_type_id: id} = attrs, _context) do
     with {:ok, %HardwareType{} = hardware_type} <- Appliances.fetch_hardware_type(id),
          {:ok, %HardwareType{} = hardware_type} <-
            Appliances.update_hardware_type(hardware_type, attrs) do

--- a/backend/lib/edgehog_web/schema/appliances_types.ex
+++ b/backend/lib/edgehog_web/schema/appliances_types.ex
@@ -22,12 +22,6 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
 
   alias EdgehogWeb.Resolvers
 
-  input_object :hardware_type_input do
-    field :name, non_null(:string)
-    field :handle, non_null(:string)
-    field :part_numbers, non_null(list_of(non_null(:string)))
-  end
-
   node object(:hardware_type) do
     field :name, non_null(:string)
     field :handle, non_null(:string)
@@ -72,7 +66,9 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
   object :appliances_mutations do
     payload field :create_hardware_type do
       input do
-        field :hardware_type, non_null(:hardware_type_input)
+        field :name, non_null(:string)
+        field :handle, non_null(:string)
+        field :part_numbers, non_null(list_of(non_null(:string)))
       end
 
       output do
@@ -84,15 +80,17 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
 
     payload field :update_hardware_type do
       input do
-        field :id, non_null(:id)
-        field :hardware_type, non_null(:hardware_type_input)
+        field :hardware_type_id, non_null(:id)
+        field :name, :string
+        field :handle, :string
+        field :part_numbers, list_of(non_null(:string))
       end
 
       output do
         field :hardware_type, non_null(:hardware_type)
       end
 
-      middleware Absinthe.Relay.Node.ParseIDs, id: :hardware_type
+      middleware Absinthe.Relay.Node.ParseIDs, hardware_type_id: :hardware_type
       resolve &Resolvers.Appliances.update_hardware_type/3
     end
 

--- a/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
@@ -42,11 +42,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
 
       variables = %{
         input: %{
-          hardware_type: %{
-            name: name,
-            handle: handle,
-            part_numbers: [part_number]
-          }
+          name: name,
+          handle: handle,
+          part_numbers: [part_number]
         }
       }
 
@@ -75,11 +73,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
     test "fails with invalid data", %{conn: conn} do
       variables = %{
         input: %{
-          hardware_type: %{
-            name: nil,
-            handle: nil,
-            part_numbers: []
-          }
+          name: nil,
+          handle: nil,
+          part_numbers: []
         }
       }
 

--- a/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
@@ -50,12 +50,10 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
 
       variables = %{
         input: %{
-          id: id,
-          hardware_type: %{
-            name: name,
-            handle: handle,
-            part_numbers: [part_number]
-          }
+          hardware_type_id: id,
+          name: name,
+          handle: handle,
+          part_numbers: [part_number]
         }
       }
 
@@ -78,17 +76,74 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
                Appliances.fetch_hardware_type(hardware_type.id)
     end
 
+    test "updates hardware type with partial data", %{conn: conn, hardware_type: hardware_type} do
+      %HardwareType{name: initial_name, handle: initial_handle} = hardware_type
+
+      name = "Foobaz"
+      part_number = "12345/Z"
+
+      id = Absinthe.Relay.Node.to_global_id(:hardware_type, hardware_type.id, EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          hardware_type_id: id,
+          part_numbers: [part_number]
+        }
+      }
+
+      conn = post(conn, "/api", query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "updateHardwareType" => %{
+                   "hardwareType" => %{
+                     "id" => ^id,
+                     "name" => ^initial_name,
+                     "handle" => ^initial_handle,
+                     "partNumbers" => [^part_number]
+                   }
+                 }
+               }
+             } = assert(json_response(conn, 200))
+
+      assert {:ok, %HardwareType{name: ^initial_name, handle: ^initial_handle}} =
+               Appliances.fetch_hardware_type(hardware_type.id)
+
+      variables = %{
+        input: %{
+          hardware_type_id: id,
+          name: name
+        }
+      }
+
+      conn = post(conn, "/api", query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "updateHardwareType" => %{
+                   "hardwareType" => %{
+                     "id" => ^id,
+                     "name" => ^name,
+                     "handle" => ^initial_handle,
+                     "partNumbers" => [^part_number]
+                   }
+                 }
+               }
+             } = assert(json_response(conn, 200))
+
+      assert {:ok, %HardwareType{name: ^name, handle: ^initial_handle}} =
+               Appliances.fetch_hardware_type(hardware_type.id)
+    end
+
     test "fails with invalid data", %{conn: conn, hardware_type: hardware_type} do
       id = Absinthe.Relay.Node.to_global_id(:hardware_type, hardware_type.id, EdgehogWeb.Schema)
 
       variables = %{
         input: %{
-          id: id,
-          hardware_type: %{
-            name: nil,
-            handle: nil,
-            part_numbers: []
-          }
+          hardware_type_id: id,
+          name: nil,
+          handle: nil,
+          part_numbers: []
         }
       }
 
@@ -106,12 +161,10 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
 
       variables = %{
         input: %{
-          id: id,
-          hardware_type: %{
-            name: name,
-            handle: handle,
-            part_numbers: [part_number]
-          }
+          hardware_type_id: id,
+          name: name,
+          handle: handle,
+          part_numbers: [part_number]
         }
       }
 

--- a/frontend/src/api/__generated__/HardwareTypeCreate_createHardwareType_Mutation.graphql.ts
+++ b/frontend/src/api/__generated__/HardwareTypeCreate_createHardwareType_Mutation.graphql.ts
@@ -5,9 +5,6 @@
 import { ConcreteRequest } from "relay-runtime";
 
 export type CreateHardwareTypeInput = {
-    hardwareType: HardwareTypeInput;
-};
-export type HardwareTypeInput = {
     handle: string;
     name: string;
     partNumbers: Array<string>;

--- a/frontend/src/api/__generated__/HardwareType_updateHardwareType_Mutation.graphql.ts
+++ b/frontend/src/api/__generated__/HardwareType_updateHardwareType_Mutation.graphql.ts
@@ -5,11 +5,8 @@
 import { ConcreteRequest } from "relay-runtime";
 
 export type UpdateHardwareTypeInput = {
-    hardwareType: HardwareTypeInput;
-    id: string;
-};
-export type HardwareTypeInput = {
     handle: string;
+    hardwareTypeId: string;
     name: string;
     partNumbers: Array<string>;
 };

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -27,7 +27,9 @@ type CreateApplianceModelPayload {
 }
 
 input CreateHardwareTypeInput {
-  hardwareType: HardwareTypeInput!
+  handle: String!
+  name: String!
+  partNumbers: [String!]!
 }
 
 type CreateHardwareTypePayload {
@@ -71,12 +73,6 @@ type HardwareType implements Node {
   The ID of an object
   """
   id: ID!
-  name: String!
-  partNumbers: [String!]!
-}
-
-input HardwareTypeInput {
-  handle: String!
   name: String!
   partNumbers: [String!]!
 }
@@ -134,8 +130,10 @@ type UpdateApplianceModelPayload {
 }
 
 input UpdateHardwareTypeInput {
-  hardwareType: HardwareTypeInput!
-  id: ID!
+  handle: String
+  hardwareTypeId: ID!
+  name: String
+  partNumbers: [String!]
 }
 
 type UpdateHardwareTypePayload {

--- a/frontend/src/pages/HardwareType.tsx
+++ b/frontend/src/pages/HardwareType.tsx
@@ -99,8 +99,12 @@ const HardwareTypeContent = ({
 
   const handleUpdateHardwareType = useCallback(
     (hardwareType: HardwareTypeData) => {
+      const input = {
+        hardwareTypeId,
+        ...hardwareType,
+      };
       updateHardwareType({
-        variables: { input: { hardwareType, id: hardwareTypeId } },
+        variables: { input },
         onCompleted(data, errors) {
           if (errors) {
             const errorFeedback = errors

--- a/frontend/src/pages/HardwareTypeCreate.tsx
+++ b/frontend/src/pages/HardwareTypeCreate.tsx
@@ -55,7 +55,7 @@ const HardwareTypeCreatePage = () => {
   const handleCreateHardwareType = useCallback(
     (hardwareType: HardwareTypeData) => {
       createHardwareType({
-        variables: { input: { hardwareType } },
+        variables: { input: hardwareType },
         onCompleted(data, errors) {
           if (errors) {
             const errorFeedback = errors


### PR DESCRIPTION
Remove nested input type in create and update hardware type mutations

Signed-off-by: Mattia Pavinati <mattia.pavinati@secomind.com>