### PR TITLE
Use composite foreign keys in part number relationship with parents

### DIFF
--- a/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
+++ b/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
@@ -7,7 +7,9 @@ defmodule Edgehog.Repo.Migrations.CreateHardwareTypePartNumbers do
         null: false
 
       add :part_number, :string, null: false
-      add :hardware_type_id, references(:hardware_types, on_delete: :delete_all)
+
+      add :hardware_type_id,
+          references(:hardware_types, with: [tenant_id: :tenant_id], on_delete: :delete_all)
 
       timestamps()
     end

--- a/backend/priv/repo/migrations/20211110165401_create_appliance_model_part_numbers.exs
+++ b/backend/priv/repo/migrations/20211110165401_create_appliance_model_part_numbers.exs
@@ -7,7 +7,9 @@ defmodule Edgehog.Repo.Migrations.CreateApplianceModelPartNumbers do
         null: false
 
       add :part_number, :string, null: false
-      add :appliance_model_id, references(:appliance_models, on_delete: :delete_all)
+
+      add :appliance_model_id,
+          references(:appliance_models, with: [tenant_id: :tenant_id], on_delete: :delete_all)
 
       timestamps()
     end


### PR DESCRIPTION
Make sure we always stay within a specific tenant.
Note that we cannot use `match: :full` here because the foreign key gets
populated afterwards (since we create the part numbers first and then associate
them with their parent)

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>