### PR TITLE
Handle ApplianceInfo interface triggers

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -28,3 +28,6 @@ config :logger, level: :warn
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
+
+# Astarte mocks for tests
+config :edgehog, :astarte_device_status_module, Edgehog.DeviceStatusMock

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -28,6 +28,12 @@ defmodule Edgehog.Astarte do
   alias Edgehog.Astarte.Cluster
   alias Edgehog.Astarte.Device.{DeviceStatus, HardwareInfo}
 
+  @device_status_module Application.compile_env(
+                          :edgehog,
+                          :astarte_device_status_module,
+                          DeviceStatus
+                        )
+
   @doc """
   Returns the list of clusters.
 
@@ -410,7 +416,7 @@ defmodule Edgehog.Astarte do
 
   defp get_device_status(%Realm{} = realm, device_id) do
     with {:ok, client} <- appengine_client_from_realm(realm) do
-      DeviceStatus.get(client, device_id)
+      @device_status_module.get(client, device_id)
     end
   end
 

--- a/backend/lib/edgehog/astarte/device.ex
+++ b/backend/lib/edgehog/astarte/device.ex
@@ -21,6 +21,7 @@ defmodule Edgehog.Astarte.Device do
   import Ecto.Changeset
 
   alias Edgehog.Astarte.Realm
+  alias Edgehog.Appliances
 
   schema "devices" do
     field :device_id, :string
@@ -29,7 +30,15 @@ defmodule Edgehog.Astarte.Device do
     field :last_connection, :utc_datetime
     field :last_disconnection, :utc_datetime
     field :online, :boolean, default: false
+    field :serial_number, :string
     belongs_to :realm, Realm
+
+    belongs_to :appliance_model_part_number, Appliances.ApplianceModelPartNumber,
+      foreign_key: :part_number,
+      references: :part_number,
+      type: :string
+
+    has_one :appliance_model, through: [:appliance_model_part_number, :appliance_model]
 
     timestamps()
   end
@@ -42,7 +51,9 @@ defmodule Edgehog.Astarte.Device do
       :device_id,
       :online,
       :last_connection,
-      :last_disconnection
+      :last_disconnection,
+      :serial_number,
+      :part_number
     ])
     |> validate_required([:name, :device_id])
     |> unique_constraint([:device_id, :realm_id, :tenant_id])

--- a/backend/lib/edgehog/astarte/device/device_status.ex
+++ b/backend/lib/edgehog/astarte/device/device_status.ex
@@ -23,9 +23,12 @@ defmodule Edgehog.Astarte.Device.DeviceStatus do
     :online
   ]
 
+  @behaviour Edgehog.Astarte.Device.DeviceStatus.Behaviour
+
   alias Astarte.Client.AppEngine
   alias Edgehog.Astarte.Device.DeviceStatus
 
+  @impl true
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
            AppEngine.Devices.get_device_status(client, device_id) do

--- a/backend/lib/edgehog/astarte/device/device_status/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/device_status/behaviour.ex
@@ -1,0 +1,24 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.DeviceStatus.Behaviour do
+  alias Astarte.Client.AppEngine
+
+  @callback get(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, term()} | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/realm.ex
+++ b/backend/lib/edgehog/astarte/realm.ex
@@ -40,5 +40,6 @@ defmodule Edgehog.Astarte.Realm do
     |> validate_required([:name, :private_key])
     |> foreign_key_constraint(:cluster_id)
     |> unique_constraint([:name, :tenant_id])
+    |> validate_format(:name, ~r/^[a-z][a-z0-9]{0,47}$/)
   end
 end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -68,7 +68,9 @@ defmodule Edgehog.MixProject do
       # TODO: remove when tesla makes a new release compatible with mime ~> 2.0
       {:mime, "~> 2.0", override: true},
       {:astarte_client, github: "astarte-platform/astarte-client-elixir"},
-      {:cors_plug, "~> 2.0"}
+      {:cors_plug, "~> 2.0"},
+      {:x509, "~> 0.8"},
+      {:mox, "~> 1.0"}
     ]
   end
 

--- a/backend/mix.lock
+++ b/backend/mix.lock
@@ -21,6 +21,7 @@
   "jose": {:hex, :jose, "1.11.2", "f4c018ccf4fdce22c71e44d471f15f723cb3efab5d909ab2ba202b5bf35557b3", [:mix, :rebar3], [], "hexpm", "98143fbc48d55f3a18daba82d34fe48959d44538e9697c08f34200fa5f0947d2"},
   "mime": {:hex, :mime, "2.0.2", "0b9e1a4c840eafb68d820b0e2158ef5c49385d17fb36855ac6e7e087d4b1dcc5", [:mix], [], "hexpm", "e6a3f76b4c277739e36c2e21a2c640778ba4c3846189d5ab19f97f126df5f9b7"},
   "mint": {:hex, :mint, "1.4.0", "cd7d2451b201fc8e4a8fd86257fb3878d9e3752899eb67b0c5b25b180bde1212", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm", "10a99e144b815cbf8522dccbc8199d15802440fc7a64d67b6853adb6fa170217"},
+  "mox": {:hex, :mox, "1.0.1", "b651bf0113265cda0ba3a827fcb691f848b683c373b77e7d7439910a8d754d6e", [:mix], [], "hexpm", "35bc0dea5499d18db4ef7fe4360067a59b06c74376eb6ab3bd67e6295b133469"},
   "nimble_options": {:hex, :nimble_options, "0.3.7", "1e52dd7673d36138b1a5dede183b5d86dff175dc46d104a8e98e396b85b04670", [:mix], [], "hexpm", "2086907e6665c6b6579be54ef5001928df5231f355f71ed258f80a55e9f63633"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "nimble_pool": {:hex, :nimble_pool, "0.2.4", "1db8e9f8a53d967d595e0b32a17030cdb6c0dc4a451b8ac787bf601d3f7704c3", [:mix], [], "hexpm", "367e8071e137b787764e6a9992ccb57b276dc2282535f767a07d881951ebeac6"},

--- a/backend/priv/repo/migrations/20211103114700_create_tenants.exs
+++ b/backend/priv/repo/migrations/20211103114700_create_tenants.exs
@@ -4,7 +4,7 @@ defmodule Edgehog.Repo.Migrations.CreateTenants do
   def change do
     create table(:tenants, primary_key: false) do
       add :tenant_id, :bigserial, primary_key: true
-      add :name, :string
+      add :name, :string, null: false
 
       timestamps()
     end

--- a/backend/priv/repo/migrations/20211103115956_create_clusters.exs
+++ b/backend/priv/repo/migrations/20211103115956_create_clusters.exs
@@ -3,8 +3,8 @@ defmodule Edgehog.Repo.Migrations.CreateClusters do
 
   def change do
     create table(:clusters) do
-      add :name, :string
-      add :base_api_url, :string
+      add :name, :string, null: false
+      add :base_api_url, :string, null: false
 
       timestamps()
     end

--- a/backend/priv/repo/migrations/20211112111450_add_serial_and_part_number_to_devices.exs
+++ b/backend/priv/repo/migrations/20211112111450_add_serial_and_part_number_to_devices.exs
@@ -1,0 +1,17 @@
+defmodule Edgehog.Repo.Migrations.AddSerialAndPartNumberToDevices do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add :serial_number, :string
+
+      add :part_number,
+          references(:appliance_model_part_numbers,
+            column: :part_number,
+            type: :string,
+            with: [tenant_id: :tenant_id],
+            on_delete: :nothing
+          )
+    end
+  end
+end

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -99,10 +99,10 @@ defmodule Edgehog.AstarteTest do
     end
 
     test "create_realm/1 with valid data creates a realm", %{cluster: cluster} do
-      valid_attrs = %{name: "some name", private_key: "some private_key"}
+      valid_attrs = %{name: "somename", private_key: "some private_key"}
 
       assert {:ok, %Realm{} = realm} = Astarte.create_realm(cluster, valid_attrs)
-      assert realm.name == "some name"
+      assert realm.name == "somename"
       assert realm.private_key == "some private_key"
     end
 
@@ -112,10 +112,10 @@ defmodule Edgehog.AstarteTest do
 
     test "update_realm/2 with valid data updates the realm", %{cluster: cluster} do
       realm = realm_fixture(cluster)
-      update_attrs = %{name: "some updated name", private_key: "some updated private_key"}
+      update_attrs = %{name: "someupdatedname", private_key: "some updated private_key"}
 
       assert {:ok, %Realm{} = realm} = Astarte.update_realm(realm, update_attrs)
-      assert realm.name == "some updated name"
+      assert realm.name == "someupdatedname"
       assert realm.private_key == "some updated private_key"
     end
 

--- a/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
+++ b/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
@@ -1,0 +1,123 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
+  use EdgehogWeb.ConnCase
+  use Edgehog.AstarteMockCase
+
+  alias Edgehog.Astarte
+  alias Edgehog.Astarte.Device
+
+  import Edgehog.AstarteFixtures
+
+  describe "process_event" do
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+
+      {:ok, cluster: cluster, realm: realm, device: device}
+    end
+
+    test "creates an unexisting device when receiving a connection event", %{
+      conn: conn,
+      realm: realm,
+      tenant: %{slug: tenant_slug}
+    } do
+      device_id = "JCr8Q5F-QmyaEu19mUW9qw"
+
+      assert {:error, :device_not_found} == Astarte.fetch_realm_device(realm, device_id)
+
+      path = Routes.astarte_trigger_path(conn, :process_event, tenant_slug)
+
+      connection_event = %{
+        device_id: device_id,
+        event: %{
+          type: "device_connected"
+        },
+        timestamp: DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+
+      conn =
+        conn
+        |> put_req_header("astarte-realm", realm.name)
+        |> post(path, connection_event)
+
+      assert response(conn, 200)
+
+      assert {:ok, %Device{online: true}} = Astarte.fetch_realm_device(realm, device_id)
+    end
+
+    test "updates an existing device when receiving a connection event", %{
+      conn: conn,
+      realm: realm,
+      device: %{device_id: device_id},
+      tenant: %{slug: tenant_slug}
+    } do
+      assert {:ok, %Device{online: false}} = Astarte.fetch_realm_device(realm, device_id)
+
+      path = Routes.astarte_trigger_path(conn, :process_event, tenant_slug)
+
+      connection_event = %{
+        device_id: device_id,
+        event: %{
+          type: "device_connected"
+        },
+        timestamp: DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+
+      conn =
+        conn
+        |> put_req_header("astarte-realm", realm.name)
+        |> post(path, connection_event)
+
+      assert response(conn, 200)
+
+      assert {:ok, %Device{online: true}} = Astarte.fetch_realm_device(realm, device_id)
+    end
+
+    test "creates an unexisting device when receiving an unhandled event", %{
+      conn: conn,
+      realm: realm,
+      tenant: %{slug: tenant_slug}
+    } do
+      device_id = "JCr8Q5F-QmyaEu19mUW9qw"
+
+      assert {:error, :device_not_found} == Astarte.fetch_realm_device(realm, device_id)
+
+      path = Routes.astarte_trigger_path(conn, :process_event, tenant_slug)
+
+      connection_event = %{
+        device_id: device_id,
+        event: %{
+          type: "unhandled_event"
+        },
+        timestamp: DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+
+      conn =
+        conn
+        |> put_req_header("astarte-realm", realm.name)
+        |> post(path, connection_event)
+
+      assert response(conn, 200)
+
+      assert {:ok, %Device{online: false}} = Astarte.fetch_realm_device(realm, device_id)
+    end
+  end
+end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -1,0 +1,53 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.AstarteMockCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's data layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use Edgehog.DataCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Mox
+      import Edgehog.AstarteMockCase
+    end
+  end
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  setup do
+    Mox.stub_with(Edgehog.DeviceStatusMock, Edgehog.Mocks.DeviceStatus)
+
+    :ok
+  end
+end

--- a/backend/test/support/fixtures/astarte_fixtures.ex
+++ b/backend/test/support/fixtures/astarte_fixtures.ex
@@ -29,13 +29,15 @@ defmodule Edgehog.AstarteFixtures do
     {:ok, cluster} =
       attrs
       |> Enum.into(%{
-        base_api_url: "some base_api_url",
+        base_api_url: "https://api.astarte.example.com",
         name: "some name"
       })
       |> Edgehog.Astarte.create_cluster()
 
     cluster
   end
+
+  @private_key X509.PrivateKey.new_ec(:secp256r1) |> X509.PrivateKey.to_pem()
 
   @doc """
   Generate a realm.
@@ -44,8 +46,8 @@ defmodule Edgehog.AstarteFixtures do
     attrs =
       attrs
       |> Enum.into(%{
-        name: "some name",
-        private_key: "some private_key"
+        name: "somename",
+        private_key: @private_key
       })
 
     {:ok, realm} = Edgehog.Astarte.create_realm(cluster, attrs)

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -1,0 +1,19 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Mox.defmock(Edgehog.DeviceStatusMock, for: Edgehog.Astarte.Device.DeviceStatus.Behaviour)

--- a/backend/test/support/mocks/device_status.ex
+++ b/backend/test/support/mocks/device_status.ex
@@ -1,0 +1,37 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Mocks.DeviceStatus do
+  @behaviour Edgehog.Astarte.Device.DeviceStatus.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.DeviceStatus
+
+  @impl true
+  def get(%AppEngine{} = _client, _device_id) do
+    now = DateTime.utc_now()
+
+    device_status = %DeviceStatus{
+      last_connection: DateTime.add(now, -3600),
+      last_disconnection: DateTime.add(now, -60),
+      online: false
+    }
+
+    {:ok, device_status}
+  end
+end


### PR DESCRIPTION
Populate serial_number and part_number, associating a Device with an ApplianceModel.
Caveat: right now the ApplianceModel must be existing _before_ the trigger is received, otherwise part_number fails the foreign key constraint.
Close #42 