### PR TITLE
Display device wifi scan results

### DIFF
--- a/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
+++ b/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
@@ -22,7 +22,7 @@ export type Device_getDevice_QueryResponse = {
                 readonly name: string;
             };
         } | null;
-        readonly " $fragmentRefs": FragmentRefs<"Device_hardwareInfo" | "Device_location">;
+        readonly " $fragmentRefs": FragmentRefs<"Device_hardwareInfo" | "Device_location" | "Device_wifiScanResults">;
     } | null;
 };
 export type Device_getDevice_Query = {
@@ -53,6 +53,7 @@ query Device_getDevice_Query(
     }
     ...Device_hardwareInfo
     ...Device_location
+    ...Device_wifiScanResults
   }
 }
 
@@ -72,6 +73,16 @@ fragment Device_location on Device {
     longitude
     accuracy
     address
+    timestamp
+  }
+}
+
+fragment Device_wifiScanResults on Device {
+  wifiScanResults {
+    channel
+    essid
+    macAddress
+    rssi
     timestamp
   }
 }
@@ -133,6 +144,13 @@ v7 = {
   "kind": "ScalarField",
   "name": "online",
   "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "timestamp",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -188,6 +206,11 @@ return {
             "args": null,
             "kind": "FragmentSpread",
             "name": "Device_location"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Device_wifiScanResults"
           }
         ],
         "storageKey": null
@@ -324,13 +347,47 @@ return {
                 "name": "address",
                 "storageKey": null
               },
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "WifiScanResult",
+            "kind": "LinkedField",
+            "name": "wifiScanResults",
+            "plural": true,
+            "selections": [
               {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "timestamp",
+                "name": "channel",
                 "storageKey": null
-              }
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "essid",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "macAddress",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "rssi",
+                "storageKey": null
+              },
+              (v8/*: any*/)
             ],
             "storageKey": null
           }
@@ -340,14 +397,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "89831941bd6285468fe43264c791bd17",
+    "cacheID": "91f132510af2bc4231c707351afb41ed",
     "id": null,
     "metadata": {},
     "name": "Device_getDevice_Query",
     "operationKind": "query",
-    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n    applianceModel {\n      name\n      hardwareType {\n        name\n        id\n      }\n      id\n    }\n    ...Device_hardwareInfo\n    ...Device_location\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n\nfragment Device_location on Device {\n  location {\n    latitude\n    longitude\n    accuracy\n    address\n    timestamp\n  }\n}\n"
+    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n    applianceModel {\n      name\n      hardwareType {\n        name\n        id\n      }\n      id\n    }\n    ...Device_hardwareInfo\n    ...Device_location\n    ...Device_wifiScanResults\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n\nfragment Device_location on Device {\n  location {\n    latitude\n    longitude\n    accuracy\n    address\n    timestamp\n  }\n}\n\nfragment Device_wifiScanResults on Device {\n  wifiScanResults {\n    channel\n    essid\n    macAddress\n    rssi\n    timestamp\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '459ff9d7db3b20242da30cf4088cff44';
+(node as any).hash = '2a034ffb2a975c0d2bad3bb09e888dab';
 export default node;

--- a/frontend/src/api/__generated__/Device_wifiScanResults.graphql.ts
+++ b/frontend/src/api/__generated__/Device_wifiScanResults.graphql.ts
@@ -1,0 +1,83 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type Device_wifiScanResults = {
+    readonly wifiScanResults: ReadonlyArray<{
+        readonly channel: number | null;
+        readonly essid: string | null;
+        readonly macAddress: string | null;
+        readonly rssi: number | null;
+        readonly timestamp: string;
+    }> | null;
+    readonly " $refType": "Device_wifiScanResults";
+};
+export type Device_wifiScanResults$data = Device_wifiScanResults;
+export type Device_wifiScanResults$key = {
+    readonly " $data"?: Device_wifiScanResults$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"Device_wifiScanResults">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Device_wifiScanResults",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "WifiScanResult",
+      "kind": "LinkedField",
+      "name": "wifiScanResults",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "channel",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "essid",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "macAddress",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "rssi",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Device",
+  "abstractKey": null
+};
+(node as any).hash = '1cce4cb6523924adbe1f5188d91b3208';
+export default node;

--- a/frontend/src/components/WiFiScanResultsTable.tsx
+++ b/frontend/src/components/WiFiScanResultsTable.tsx
@@ -1,0 +1,102 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2021 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { FormattedDate, FormattedMessage } from "react-intl";
+
+import Table from "components/Table";
+import type { Column } from "components/Table";
+
+type WiFiScanResultProps = {
+  channel: number | null;
+  essid: string | null;
+  macAddress: string | null;
+  rssi: number | null;
+  timestamp: string;
+};
+
+const columns: Column<WiFiScanResultProps>[] = [
+  {
+    accessor: "essid",
+    Header: (
+      <FormattedMessage
+        id="components.WiFiScanResultsTable.apEssidTitle"
+        defaultMessage="ESSID"
+      />
+    ),
+  },
+  {
+    accessor: "channel",
+    Header: (
+      <FormattedMessage
+        id="components.WiFiScanResultsTable.apChannelTitle"
+        defaultMessage="Channel"
+      />
+    ),
+  },
+  {
+    accessor: "macAddress",
+    Header: (
+      <FormattedMessage
+        id="components.WiFiScanResultsTable.apMacAddressTitle"
+        defaultMessage="MAC Address"
+      />
+    ),
+  },
+  {
+    accessor: "rssi",
+    Header: (
+      <FormattedMessage
+        id="components.WiFiScanResultsTable.apRssiTitle"
+        defaultMessage="RSSI"
+      />
+    ),
+    Cell: ({ value }) => (value ? `${value} dBm` : ""),
+  },
+  {
+    accessor: "timestamp",
+    Header: (
+      <FormattedMessage
+        id="components.WiFiScanResultsTable.seenAtTitle"
+        defaultMessage="Seen at"
+      />
+    ),
+    Cell: ({ value }) => (
+      <FormattedDate
+        value={new Date(value)}
+        year="numeric"
+        month="long"
+        day="numeric"
+        hour="numeric"
+        minute="numeric"
+      />
+    ),
+  },
+];
+
+interface Props {
+  className?: string;
+  data: WiFiScanResultProps[];
+}
+
+const WiFiScanResultsTable = ({ className, data }: Props) => {
+  return <Table className={className} columns={columns} data={data} />;
+};
+
+export type { WiFiScanResultProps };
+
+export default WiFiScanResultsTable;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -175,6 +175,21 @@
   "components.UpdateHardwareTypeForm.submitButton": {
     "defaultMessage": "Update"
   },
+  "components.WiFiScanResultsTable.apChannelTitle": {
+    "defaultMessage": "Channel"
+  },
+  "components.WiFiScanResultsTable.apEssidTitle": {
+    "defaultMessage": "ESSID"
+  },
+  "components.WiFiScanResultsTable.apMacAddressTitle": {
+    "defaultMessage": "MAC Address"
+  },
+  "components.WiFiScanResultsTable.apRssiTitle": {
+    "defaultMessage": "RSSI"
+  },
+  "components.WiFiScanResultsTable.seenAtTitle": {
+    "defaultMessage": "Seen at"
+  },
   "pages.ApplianceModel.applianceModelNotFound.message": {
     "defaultMessage": "Return to the appliance model list."
   },
@@ -222,6 +237,15 @@
   },
   "pages.Device.location.lastUpdateAt": {
     "defaultMessage": "Last known location, updated at {date}"
+  },
+  "pages.Device.wifiScanResultsTab": {
+    "defaultMessage": "WiFi APs"
+  },
+  "pages.Device.wifiScanResultsTab.noResults.message": {
+    "defaultMessage": "The device has not detected any WiFi AP yet."
+  },
+  "pages.Device.wifiScanResultsTab.noResults.title": {
+    "defaultMessage": "No results"
   },
   "pages.Devices.title": {
     "defaultMessage": "Devices"

--- a/frontend/src/mocks/relay.ts
+++ b/frontend/src/mocks/relay.ts
@@ -58,6 +58,15 @@ const relayMockResolvers: MockPayloadGenerator.MockResolvers = {
       timestamp: "2021-11-11T09:43:54.437Z",
     };
   },
+  WifiScanResult() {
+    return {
+      channel: 1,
+      essid: "MyWifi",
+      macAddress: "00:11:22:33:44:55",
+      rssi: -50,
+      timestamp: "2021-11-16T10:43:54.437Z",
+    };
+  },
 };
 
 export { relayMockResolvers };


### PR DESCRIPTION
Add a WiFi APs tab in the Device page to display wifi scan results for each device, if supported.

When the device has not messaged any WiFi AP yet:

![Screenshot 2021-11-16 at 12-05-05 Edgehog](https://user-images.githubusercontent.com/60540759/141975879-614918bc-a0db-48a9-be56-0e85b8cc2040.png)

When the device has published a list of WiFi APs nearby:

![Screenshot 2021-11-19 at 17-33-29 Edgehog](https://user-images.githubusercontent.com/60540759/142658208-0a2e73ad-3384-4f8c-9373-a8cdf85f3139.png)


Closes #2