### PR TITLE
Remove :init_from_astarte opts and rely on mocks for testing

### DIFF
--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -380,25 +380,20 @@ defmodule Edgehog.Astarte do
     end
   end
 
-  def ensure_device_exists(%Realm{} = realm, device_id, opts \\ []) do
+  def ensure_device_exists(%Realm{} = realm, device_id) do
     device_attrs = %{device_id: device_id, name: device_id}
 
     with {:error, :device_not_found} <- fetch_realm_device(realm, device_id),
          {:ok, device_attrs} <-
-           maybe_populate_device_status(
+           populate_device_status(
              realm,
-             device_attrs,
-             Keyword.get(opts, :init_from_astarte, true)
+             device_attrs
            ) do
       create_device(realm, device_attrs)
     end
   end
 
-  defp maybe_populate_device_status(%Realm{} = _realm, device_attrs, false = _populate) do
-    {:ok, device_attrs}
-  end
-
-  defp maybe_populate_device_status(%Realm{} = realm, device_attrs, true = _populate) do
+  defp populate_device_status(%Realm{} = realm, device_attrs) do
     with {:ok, device_status} <- get_device_status(realm, device_attrs.device_id) do
       device_attrs =
         device_status

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -18,6 +18,7 @@
 
 defmodule Edgehog.AstarteTest do
   use Edgehog.DataCase
+  use Edgehog.AstarteMockCase
 
   alias Edgehog.Astarte
 
@@ -201,7 +202,7 @@ defmodule Edgehog.AstarteTest do
 
     test "ensure_device_exists/1 creates a device if not existent", %{realm: realm} do
       device_id = "does_not_exist"
-      {:ok, device} = Astarte.ensure_device_exists(realm, device_id, init_from_astarte: false)
+      {:ok, device} = Astarte.ensure_device_exists(realm, device_id)
       assert %Device{device_id: ^device_id} = device
     end
 


### PR DESCRIPTION
Instead of passing opts to modify the behavior of methods, simplify the logic by relying on existing mocks to stub network responses.
