### PR TITLE
Add descriptions to fields of the GraphQL schema

### DIFF
--- a/backend/lib/edgehog_web/schema/appliances_types.ex
+++ b/backend/lib/edgehog_web/schema/appliances_types.ex
@@ -22,71 +22,132 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
 
   alias EdgehogWeb.Resolvers
 
+  @desc """
+  Denotes a type of hardware that devices can have.
+
+  It refers to the physical components embedded in an appliance.
+  This can represent, e.g., multiple revisions of a PCB (each with a \
+  different part number) which are functionally equivalent from the appliance \
+  point of view.
+  """
   node object(:hardware_type) do
+    @desc "The display name of the hardware type."
     field :name, non_null(:string)
+
+    @desc "The identifier of the hardware type."
     field :handle, non_null(:string)
 
+    @desc "The list of part numbers associated with the hardware type."
     field :part_numbers, non_null(list_of(non_null(:string))) do
       resolve &Resolvers.Appliances.extract_hardware_type_part_numbers/3
     end
   end
 
+  @desc """
+  Represents a specific appliance model.
+
+  An appliance model corresponds to what the users thinks as functionally \
+  equivalent appliances (e.g. two revisions of an appliance containing two \
+  different embedded chips but that have the same enclosure and the same \
+  functionality).
+  Each ApplianceModel must be associated to a specific HardwareType.
+  """
   node object(:appliance_model) do
+    @desc "The display name of the appliance model."
     field :name, non_null(:string)
+
+    @desc "The identifier of the appliance model."
     field :handle, non_null(:string)
+
+    @desc "The type of hardware that can be plugged into the appliance model."
     field :hardware_type, non_null(:hardware_type)
 
+    @desc "The list of part numbers associated with the appliance model."
     field :part_numbers, non_null(list_of(non_null(:string))) do
       resolve &Resolvers.Appliances.extract_appliance_model_part_numbers/3
     end
   end
 
   object :appliances_queries do
+    @desc "Fetches the list of all hardware types."
     field :hardware_types, non_null(list_of(non_null(:hardware_type))) do
       resolve &Resolvers.Appliances.list_hardware_types/3
     end
 
+    @desc "Fetches a single hardware type."
     field :hardware_type, :hardware_type do
+      @desc "The ID of the hardware type."
       arg :id, non_null(:id)
+
       middleware Absinthe.Relay.Node.ParseIDs, id: :hardware_type
       resolve &Resolvers.Appliances.find_hardware_type/2
     end
 
+    @desc "Fetches the list of all appliance models."
     field :appliance_models, non_null(list_of(non_null(:appliance_model))) do
       resolve &Resolvers.Appliances.list_appliance_models/3
     end
 
+    @desc "Fetches a single appliance model."
     field :appliance_model, :appliance_model do
+      @desc "The ID of the appliance model."
       arg :id, non_null(:id)
+
       middleware Absinthe.Relay.Node.ParseIDs, id: :appliance_model
       resolve &Resolvers.Appliances.find_appliance_model/2
     end
   end
 
   object :appliances_mutations do
+    @desc "Creates a new hardware type."
     payload field :create_hardware_type do
       input do
+        @desc "The display name of the hardware type."
         field :name, non_null(:string)
+
+        @desc """
+        The identifier of the hardware type.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
         field :handle, non_null(:string)
+
+        @desc "The list of part numbers associated with the hardware type."
         field :part_numbers, non_null(list_of(non_null(:string)))
       end
 
       output do
+        @desc "The created hardware type."
         field :hardware_type, non_null(:hardware_type)
       end
 
       resolve &Resolvers.Appliances.create_hardware_type/3
     end
 
+    @desc "Updates a hardware type."
     payload field :update_hardware_type do
       input do
+        @desc "The ID of the hardware type to be updated."
         field :hardware_type_id, non_null(:id)
+
+        @desc "The display name of the hardware type."
         field :name, :string
+
+        @desc """
+        The identifier of the hardware type.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
         field :handle, :string
+
+        @desc "The list of part numbers associated with the hardware type."
         field :part_numbers, list_of(non_null(:string))
       end
 
       output do
+        @desc "The updated hardware type."
         field :hardware_type, non_null(:hardware_type)
       end
 
@@ -94,15 +155,32 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
       resolve &Resolvers.Appliances.update_hardware_type/3
     end
 
+    @desc "Creates a new appliance model."
     payload field :create_appliance_model do
       input do
+        @desc "The display name of the appliance model."
         field :name, non_null(:string)
+
+        @desc """
+        The identifier of the appliance model.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
         field :handle, non_null(:string)
+
+        @desc "The list of part numbers associated with the appliance model."
         field :part_numbers, non_null(list_of(non_null(:string)))
+
+        @desc """
+        The ID of the hardware type that can be plugged into the appliance \
+        model.
+        """
         field :hardware_type_id, non_null(:id)
       end
 
       output do
+        @desc "The created appliance model."
         field :appliance_model, non_null(:appliance_model)
       end
 
@@ -111,15 +189,29 @@ defmodule EdgehogWeb.Schema.AppliancesTypes do
       resolve &Resolvers.Appliances.create_appliance_model/3
     end
 
+    @desc "Updates an appliance model."
     payload field :update_appliance_model do
       input do
+        @desc "The ID of the appliance model to be updated."
         field :appliance_model_id, non_null(:id)
+
+        @desc "The display name of the appliance model."
         field :name, :string
+
+        @desc """
+        The identifier of the appliance model.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
         field :handle, :string
+
+        @desc "The list of part numbers associated with the appliance model."
         field :part_numbers, list_of(non_null(:string))
       end
 
       output do
+        @desc "The updated appliance model."
         field :appliance_model, non_null(:appliance_model)
       end
 

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -23,62 +23,172 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
   alias EdgehogWeb.Middleware
   alias EdgehogWeb.Resolvers
 
+  @desc """
+  Describes a set of filters to apply when fetching a list of devices.
+
+  When multiple filters are specified, they are applied in an AND fashion to \
+  further refine the results.
+  """
   input_object :device_filter do
+    @desc "Whether to return devices connected or not to Astarte."
     field :online, :boolean
+
+    @desc """
+    A string to match against the device ID. The match is case-insensitive \
+    and tests whether the string is included in the device ID.
+    """
     field :device_id, :string
+
+    @desc """
+    A string to match against the part number of the device's appliance model.
+    The match is case-insensitive and tests whether the string is included in \
+    the part number of the device's appliance model.
+    """
     field :appliance_model_part_number, :string
+
+    @desc """
+    A string to match against the handle of the device's appliance model.
+    The match is case-insensitive and tests whether the string is included in \
+    the handle of the device's appliance model.
+    """
     field :appliance_model_handle, :string
+
+    @desc """
+    A string to match against the name of the device's appliance model.
+    The match is case-insensitive and tests whether the string is included in \
+    the name of the device's appliance model.
+    """
     field :appliance_model_name, :string
+
+    @desc """
+    A string to match against the part number of the device's hardware type.
+    The match is case-insensitive and tests whether the string is included in \
+    the part number of the device's hardware type.
+    """
     field :hardware_type_part_number, :string
+
+    @desc """
+    A string to match against the handle of the device's hardware type.
+    The match is case-insensitive and tests whether the string is included in \
+    the handle of the device's hardware type.
+    """
     field :hardware_type_handle, :string
+
+    @desc """
+    A string to match against the name of the device's hardware type.
+    The match is case-insensitive and tests whether the string is included in \
+    the name of the device's hardware type.
+    """
     field :hardware_type_name, :string
   end
 
+  @desc """
+  Describes hardware-related info of a device.
+
+  It exposes data read by a device's operating system about the underlying \
+  hardware.
+  """
   object :hardware_info do
+    @desc "The architecture of the CPU."
     field :cpu_architecture, :string
+
+    @desc "The reference code of the CPU model."
     field :cpu_model, :string
+
+    @desc "The display name of the CPU model."
     field :cpu_model_name, :string
+
+    @desc "The vendor's name."
     field :cpu_vendor, :string
+
+    @desc "The Bytes count of memory."
     # TODO: since these is longinteger, should this be a string?
     field :memory_total_bytes, :integer
   end
 
+  @desc """
+  Describes the position of a device.
+
+  The position is estimated by means of Edgehog's Geolocation modules and the \
+  data published by the device.
+  """
   object :device_location do
+    @desc "The latitude coordinate."
     field :latitude, non_null(:float)
+
+    @desc "The longitude coordinate."
     field :longitude, non_null(:float)
+
+    @desc "The accuracy of the measurement, in meters."
     field :accuracy, :float
+
+    @desc "The formatted address estimated for the position."
     field :address, :string
+
+    @desc "The date at which the measurement was made."
     field :timestamp, non_null(:datetime)
   end
 
+  @desc """
+  Describes the list of WiFi Access Points found by the device.
+  """
   object :wifi_scan_result do
+    @desc "The channel used by the Access Point."
     field :channel, :integer
+
+    @desc "The ESSID advertised by the Access Point."
     field :essid, :string
+
+    @desc "The MAC address advertised by the Access Point."
     field :mac_address, :string
+
+    @desc "The power of the radio signal, measured in dBm."
     field :rssi, :integer
+
+    @desc "The date at which the device found the Access Point."
     field :timestamp, non_null(:datetime)
   end
 
+  @desc """
+  Denotes a device instance that connects and exchanges data.
+
+  Each Device is associated to a specific ApplianceModel, which in turn is \
+  associated to a specific HardwareType.
+  A Device also exposes info about its connection status and some sets of \
+  data read by its operating system.
+  """
   node object(:device) do
+    @desc "The display name of the device."
     field :name, non_null(:string)
+
+    @desc "The device ID used to connect to the Astarte cluster."
     field :device_id, non_null(:string)
+
+    @desc "Tells whether the device is connected or not to Astarte."
     field :online, non_null(:boolean)
+
+    @desc "The date at which the device last connected to Astarte."
     field :last_connection, :datetime
+
+    @desc "The date at which the device last disconnected from Astarte."
     field :last_disconnection, :datetime
 
     @desc "The appliance model of the device."
     field :appliance_model, :appliance_model
 
+    @desc "Info read from the device's hardware."
     field :hardware_info, :hardware_info do
       resolve &Resolvers.Astarte.get_hardware_info/3
       middleware Middleware.ErrorHandler
     end
 
+    @desc "The estimated location of the device."
     field :location, :device_location do
       resolve &Resolvers.Astarte.fetch_device_location/3
       middleware Middleware.ErrorHandler
     end
 
+    @desc "The list of WiFi Access Points found by the device."
     field :wifi_scan_results, list_of(non_null(:wifi_scan_result)) do
       resolve &Resolvers.Astarte.fetch_wifi_scan_results/3
       middleware Middleware.ErrorHandler
@@ -86,15 +196,18 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
   end
 
   object :astarte_queries do
-    @desc "List devices"
+    @desc "Fetches the list of all devices."
     field :devices, non_null(list_of(non_null(:device))) do
+      @desc "An optional set of filters to apply when fetching the devices."
       arg :filter, :device_filter
       resolve &Resolvers.Astarte.list_devices/3
     end
 
-    @desc "Get a single device"
+    @desc "Fetches a single device."
     field :device, :device do
+      @desc "The ID of the device."
       arg :id, non_null(:id)
+
       middleware Absinthe.Relay.Node.ParseIDs, id: :device
       resolve &Resolvers.Astarte.find_device/2
     end


### PR DESCRIPTION
Add `@desc` annotations to document the meaning and purpose of fields in the GraphQL schema.
