### PR TITLE
Display Storage Usage

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -33,6 +33,7 @@ config :tesla, adapter: Tesla.Mock
 
 # Astarte mocks for tests
 config :edgehog, :astarte_device_status_module, Edgehog.Astarte.Device.DeviceStatusMock
+config :edgehog, :astarte_storage_usage_module, Edgehog.Astarte.Device.StorageUsageMock
 config :edgehog, :astarte_wifi_scan_result_module, Edgehog.Astarte.Device.WiFiScanResultMock
 
 config :edgehog,

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -26,7 +26,7 @@ defmodule Edgehog.Astarte do
 
   alias Astarte.Client.AppEngine
   alias Edgehog.Astarte.Cluster
-  alias Edgehog.Astarte.Device.{DeviceStatus, HardwareInfo, WiFiScanResult}
+  alias Edgehog.Astarte.Device.{DeviceStatus, HardwareInfo, StorageUsage, WiFiScanResult}
 
   @appliance_info_interface "io.edgehog.devicemanager.ApplianceInfo"
 
@@ -34,6 +34,11 @@ defmodule Edgehog.Astarte do
                           :edgehog,
                           :astarte_device_status_module,
                           DeviceStatus
+                        )
+  @storage_usage_module Application.compile_env(
+                          :edgehog,
+                          :astarte_storage_usage_module,
+                          StorageUsage
                         )
   @wifi_scan_result_module Application.compile_env(
                              :edgehog,
@@ -539,6 +544,12 @@ defmodule Edgehog.Astarte do
   def get_hardware_info(%Device{} = device) do
     with {:ok, client} <- appengine_client_from_device(device) do
       HardwareInfo.get(client, device.device_id)
+    end
+  end
+
+  def fetch_storage_usage(%Device{} = device) do
+    with {:ok, client} <- appengine_client_from_device(device) do
+      @storage_usage_module.get(client, device.device_id)
     end
   end
 

--- a/backend/lib/edgehog/astarte/device/hardware_info.ex
+++ b/backend/lib/edgehog/astarte/device/hardware_info.ex
@@ -13,6 +13,9 @@ defmodule Edgehog.Astarte.Device.HardwareInfo do
   @interface "io.edgehog.devicemanager.HardwareInfo"
 
   def get(%AppEngine{} = client, device_id) do
+    # TODO: right now we request the whole interface at once, so `memory_total_bytes` can't
+    # be requested as string (see https://github.com/astarte-platform/astarte/issues/630).
+    # Request it as string as soon as that issue is solved.
     with {:ok, %{"data" => data}} <-
            AppEngine.Devices.get_properties_data(client, device_id, @interface) do
       hardware_info = %HardwareInfo{

--- a/backend/lib/edgehog/astarte/device/storage_usage.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage.ex
@@ -1,0 +1,58 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.StorageUsage do
+  @behaviour Edgehog.Astarte.Device.StorageUsage.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
+
+  @interface "io.edgehog.devicemanager.StorageUsage"
+
+  def get(%AppEngine{} = client, device_id) do
+    # TODO: right now we request the whole interface at once and longinteger
+    # values are returned as strings by Astarte, since the interface is of
+    # type Object Aggregrate.
+    # For details, see https://github.com/astarte-platform/astarte/issues/630
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface) do
+      storage_units =
+        data
+        |> Enum.map(fn {label, %{"totalBytes" => total_bytes, "freeBytes" => free_bytes}} ->
+          %StorageUnit{
+            label: label,
+            total_bytes: parse_longinteger(total_bytes),
+            free_bytes: parse_longinteger(free_bytes)
+          }
+        end)
+
+      {:ok, storage_units}
+    end
+  end
+
+  defp parse_longinteger(string) when is_binary(string) do
+    case Integer.parse(string) do
+      {integer, _remainder} -> integer
+      _ -> nil
+    end
+  end
+
+  defp parse_longinteger(_term) do
+    nil
+  end
+end

--- a/backend/lib/edgehog/astarte/device/storage_usage/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage/behaviour.ex
@@ -1,0 +1,25 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.StorageUsage.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
+
+  @callback get(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(StorageUnit.t())} | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/device/storage_usage/storage_unit.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage/storage_unit.ex
@@ -1,0 +1,32 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.StorageUsage.StorageUnit do
+  @enforce_keys [:label]
+  defstruct [
+    :label,
+    :total_bytes,
+    :free_bytes
+  ]
+
+  @type t() :: %__MODULE__{
+          label: String.t(),
+          total_bytes: integer() | nil,
+          free_bytes: integer() | nil
+        }
+end

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -37,6 +37,13 @@ defmodule EdgehogWeb.Resolvers.Astarte do
     Astarte.get_hardware_info(device)
   end
 
+  def fetch_storage_usage(%Device{} = device, _args, _context) do
+    case Astarte.fetch_storage_usage(device) do
+      {:ok, storage_units} -> {:ok, storage_units}
+      _ -> {:ok, nil}
+    end
+  end
+
   def fetch_wifi_scan_results(%Device{} = device, _args, _context) do
     case Astarte.fetch_wifi_scan_results(device) do
       {:ok, wifi_scan_results} -> {:ok, wifi_scan_results}

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -105,6 +105,18 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     field :memory_total_bytes, :integer
   end
 
+  @desc "Describes the current usage of a storage unit on a device."
+  object :storage_unit do
+    @desc "The label of the storage unit."
+    field :label, non_null(:string)
+
+    @desc "The total number of bytes of the storage unit."
+    field :total_bytes, :integer
+
+    @desc "The number of free bytes of the storage unit."
+    field :free_bytes, :integer
+  end
+
   @desc """
   Describes the position of a device.
 
@@ -184,6 +196,12 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     @desc "The estimated location of the device."
     field :location, :device_location do
       resolve &Resolvers.Astarte.fetch_device_location/3
+      middleware Middleware.ErrorHandler
+    end
+
+    @desc "The current usage of the storage units of the device."
+    field :storage_usage, list_of(non_null(:storage_unit)) do
+      resolve &Resolvers.Astarte.fetch_storage_usage/3
       middleware Middleware.ErrorHandler
     end
 

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -102,7 +102,6 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     field :cpu_vendor, :string
 
     @desc "The Bytes count of memory."
-    # TODO: since these is longinteger, should this be a string?
     field :memory_total_bytes, :integer
   end
 

--- a/backend/test/edgehog_web/resolvers/astarte_test.exs
+++ b/backend/test/edgehog_web/resolvers/astarte_test.exs
@@ -21,6 +21,7 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
   use Edgehog.AstarteMockCase
   use Edgehog.GeolocationMockCase
 
+  alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
   alias Edgehog.Astarte.Device.WiFiScanResult
   alias Edgehog.Geolocation
   alias EdgehogWeb.Resolvers.Astarte
@@ -48,6 +49,20 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
                longitude: 11.8788231,
                timestamp: ~U[2021-11-15 11:44:57.432516Z]
              } == location
+    end
+
+    test "fetch_storage_usage/3 returns the storage usage for a device", %{
+      device: device
+    } do
+      assert {:ok, storage_units} = Astarte.fetch_storage_usage(device, %{}, %{})
+
+      assert [
+               %StorageUnit{
+                 label: "Disk 0",
+                 total_bytes: 348_360_704,
+                 free_bytes: 281_360_704
+               }
+             ] == storage_units
     end
 
     test "fetch_wifi_scan_results/3 returns the wifi scans for a device", %{

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -1,0 +1,101 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule EdgehogWeb.Schema.Query.DeviceTest do
+  use EdgehogWeb.ConnCase
+  use Edgehog.AstarteMockCase
+
+  import Edgehog.AstarteFixtures
+
+  alias Edgehog.Astarte.Device
+
+  describe "device query" do
+    setup do
+      cluster = cluster_fixture()
+
+      {:ok, realm: realm_fixture(cluster)}
+    end
+
+    @query """
+    query ($id: ID!) {
+      device(id: $id) {
+        name
+        deviceId
+        online
+      }
+    }
+    """
+
+    @storage_usage_query """
+    query ($id: ID!) {
+      device(id: $id) {
+        storageUsage {
+          label
+          totalBytes
+          freeBytes
+        }
+      }
+    }
+    """
+
+    test "returns the device if it's present", %{conn: conn, realm: realm} do
+      %Device{
+        id: id,
+        name: name,
+        device_id: device_id,
+        online: online
+      } = device_fixture(realm)
+
+      variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
+
+      conn = get(conn, "/api", query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "device" => device
+               }
+             } = json_response(conn, 200)
+
+      assert device["name"] == name
+      assert device["deviceId"] == device_id
+      assert device["online"] == online
+    end
+
+    test "returns the storage usage if available", %{conn: conn, realm: realm} do
+      %Device{
+        id: id
+      } = device_fixture(realm)
+
+      variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
+
+      conn = get(conn, "/api", query: @storage_usage_query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "device" => %{
+                   "storageUsage" => [storage]
+                 }
+               }
+             } = json_response(conn, 200)
+
+      assert storage["label"] == "Disk 0"
+      assert storage["totalBytes"] == 348_360_704
+      assert storage["freeBytes"] == 281_360_704
+    end
+  end
+end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -52,6 +52,11 @@ defmodule Edgehog.AstarteMockCase do
     )
 
     Mox.stub_with(
+      Edgehog.Astarte.Device.StorageUsageMock,
+      Edgehog.Mocks.Astarte.Device.StorageUsage
+    )
+
+    Mox.stub_with(
       Edgehog.Astarte.Device.WiFiScanResultMock,
       Edgehog.Mocks.Astarte.Device.WiFiScanResult
     )

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -20,6 +20,10 @@ Mox.defmock(Edgehog.Astarte.Device.DeviceStatusMock,
   for: Edgehog.Astarte.Device.DeviceStatus.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.StorageUsageMock,
+  for: Edgehog.Astarte.Device.StorageUsage.Behaviour
+)
+
 Mox.defmock(Edgehog.Astarte.Device.WiFiScanResultMock,
   for: Edgehog.Astarte.Device.WiFiScanResult.Behaviour
 )

--- a/backend/test/support/mocks/astarte/device/storage_usage.ex
+++ b/backend/test/support/mocks/astarte/device/storage_usage.ex
@@ -1,0 +1,37 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.StorageUsage do
+  @behaviour Edgehog.Astarte.Device.StorageUsage.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
+
+  @impl true
+  def get(%AppEngine{} = _client, _device_id) do
+    storage_units = [
+      %StorageUnit{
+        label: "Disk 0",
+        total_bytes: 348_360_704,
+        free_bytes: 281_360_704
+      }
+    ]
+
+    {:ok, storage_units}
+  end
+end

--- a/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
+++ b/frontend/src/api/__generated__/Device_getDevice_Query.graphql.ts
@@ -22,7 +22,7 @@ export type Device_getDevice_QueryResponse = {
                 readonly name: string;
             };
         } | null;
-        readonly " $fragmentRefs": FragmentRefs<"Device_hardwareInfo" | "Device_location" | "Device_wifiScanResults">;
+        readonly " $fragmentRefs": FragmentRefs<"Device_hardwareInfo" | "Device_location" | "Device_storageUsage" | "Device_wifiScanResults">;
     } | null;
 };
 export type Device_getDevice_Query = {
@@ -53,6 +53,7 @@ query Device_getDevice_Query(
     }
     ...Device_hardwareInfo
     ...Device_location
+    ...Device_storageUsage
     ...Device_wifiScanResults
   }
 }
@@ -74,6 +75,14 @@ fragment Device_location on Device {
     accuracy
     address
     timestamp
+  }
+}
+
+fragment Device_storageUsage on Device {
+  storageUsage {
+    label
+    totalBytes
+    freeBytes
   }
 }
 
@@ -206,6 +215,11 @@ return {
             "args": null,
             "kind": "FragmentSpread",
             "name": "Device_location"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Device_storageUsage"
           },
           {
             "args": null,
@@ -354,6 +368,38 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "StorageUnit",
+            "kind": "LinkedField",
+            "name": "storageUsage",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "label",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalBytes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "freeBytes",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "WifiScanResult",
             "kind": "LinkedField",
             "name": "wifiScanResults",
@@ -397,14 +443,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "91f132510af2bc4231c707351afb41ed",
+    "cacheID": "04b777a1bfa10bd674ef5570f3450194",
     "id": null,
     "metadata": {},
     "name": "Device_getDevice_Query",
     "operationKind": "query",
-    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n    applianceModel {\n      name\n      hardwareType {\n        name\n        id\n      }\n      id\n    }\n    ...Device_hardwareInfo\n    ...Device_location\n    ...Device_wifiScanResults\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n\nfragment Device_location on Device {\n  location {\n    latitude\n    longitude\n    accuracy\n    address\n    timestamp\n  }\n}\n\nfragment Device_wifiScanResults on Device {\n  wifiScanResults {\n    channel\n    essid\n    macAddress\n    rssi\n    timestamp\n  }\n}\n"
+    "text": "query Device_getDevice_Query(\n  $id: ID!\n) {\n  device(id: $id) {\n    id\n    deviceId\n    lastConnection\n    lastDisconnection\n    name\n    online\n    applianceModel {\n      name\n      hardwareType {\n        name\n        id\n      }\n      id\n    }\n    ...Device_hardwareInfo\n    ...Device_location\n    ...Device_storageUsage\n    ...Device_wifiScanResults\n  }\n}\n\nfragment Device_hardwareInfo on Device {\n  hardwareInfo {\n    cpuArchitecture\n    cpuModel\n    cpuModelName\n    cpuVendor\n    memoryTotalBytes\n  }\n}\n\nfragment Device_location on Device {\n  location {\n    latitude\n    longitude\n    accuracy\n    address\n    timestamp\n  }\n}\n\nfragment Device_storageUsage on Device {\n  storageUsage {\n    label\n    totalBytes\n    freeBytes\n  }\n}\n\nfragment Device_wifiScanResults on Device {\n  wifiScanResults {\n    channel\n    essid\n    macAddress\n    rssi\n    timestamp\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '2a034ffb2a975c0d2bad3bb09e888dab';
+(node as any).hash = 'f82db7aed4bca7cb8442aa1dbd78004d';
 export default node;

--- a/frontend/src/api/__generated__/Device_storageUsage.graphql.ts
+++ b/frontend/src/api/__generated__/Device_storageUsage.graphql.ts
@@ -1,0 +1,67 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type Device_storageUsage = {
+    readonly storageUsage: ReadonlyArray<{
+        readonly label: string;
+        readonly totalBytes: number | null;
+        readonly freeBytes: number | null;
+    }> | null;
+    readonly " $refType": "Device_storageUsage";
+};
+export type Device_storageUsage$data = Device_storageUsage;
+export type Device_storageUsage$key = {
+    readonly " $data"?: Device_storageUsage$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"Device_storageUsage">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Device_storageUsage",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "StorageUnit",
+      "kind": "LinkedField",
+      "name": "storageUsage",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "label",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalBytes",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "freeBytes",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Device",
+  "abstractKey": null
+};
+(node as any).hash = '6869a83bfcf699299226ebc744289ed6';
+export default node;

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -61,6 +61,11 @@ type Device implements Node {
   location: DeviceLocation
   name: String!
   online: Boolean!
+
+  """
+  The current usage of the storage units of the device.
+  """
+  storageUsage: [StorageUnit!]
   wifiScanResults: [WifiScanResult!]
 }
 
@@ -141,6 +146,26 @@ type RootQueryType {
     """
     id: ID!
   ): Node
+}
+
+"""
+Describes the current usage of a storage unit on a device.
+"""
+type StorageUnit {
+  """
+  The number of free bytes of the storage unit.
+  """
+  freeBytes: Int
+
+  """
+  The label of the storage unit.
+  """
+  label: String!
+
+  """
+  The total number of bytes of the storage unit.
+  """
+  totalBytes: Int
 }
 
 input UpdateApplianceModelInput {

--- a/frontend/src/components/StorageTable.tsx
+++ b/frontend/src/components/StorageTable.tsx
@@ -1,0 +1,97 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2021 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { FormattedMessage } from "react-intl";
+
+import Table from "components/Table";
+import type { Column } from "components/Table";
+
+const formatBytes = (bytes: number, decimals = 2) => {
+  if (bytes === 0) return "0 B";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+};
+
+type StorageProps = {
+  label: string;
+  totalBytes: number | null;
+  freeBytes: number | null;
+};
+
+const columns: Column<StorageProps>[] = [
+  {
+    accessor: "label",
+    Header: (
+      <FormattedMessage
+        id="components.StorageTable.labelTitle"
+        defaultMessage="Storage Unit"
+      />
+    ),
+  },
+  {
+    accessor: "totalBytes",
+    Header: (
+      <FormattedMessage
+        id="components.StorageTable.totalSpaceTitle"
+        defaultMessage="Total Space"
+      />
+    ),
+    Cell: ({ value }) =>
+      value == null ? (
+        ""
+      ) : (
+        <span className="text-nowrap">{formatBytes(value)}</span>
+      ),
+  },
+  {
+    accessor: "freeBytes",
+    Header: (
+      <FormattedMessage
+        id="components.StorageTable.freeSpaceTitle"
+        defaultMessage="Free Space"
+      />
+    ),
+    Cell: ({ value }) =>
+      value == null ? (
+        ""
+      ) : (
+        <span className="text-nowrap">{formatBytes(value)}</span>
+      ),
+  },
+];
+
+interface Props {
+  className?: string;
+  data: StorageProps[];
+}
+
+const StorageTable = ({ className, data }: Props) => {
+  return (
+    <Table className={className} columns={columns} data={data} hideSearch />
+  );
+};
+
+export type { StorageProps };
+
+export default StorageTable;

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -107,6 +107,7 @@ type TableProps<T extends Object> = {
     columnIds: string[],
     globalFilterValue: any
   ) => Row<T>[];
+  hideSearch?: boolean;
 };
 
 const Table = <T extends Object>({
@@ -116,6 +117,7 @@ const Table = <T extends Object>({
   hiddenColumns = [],
   maxPageRows = 10,
   searchFunction,
+  hideSearch = false,
 }: TableProps<T>) => {
   const tableParams = {
     columns,
@@ -158,9 +160,11 @@ const Table = <T extends Object>({
 
   return (
     <div className={className}>
-      <div className="py-2 mb-3">
-        <SearchBox onChange={setGlobalFilter} />
-      </div>
+      {hideSearch || (
+        <div className="py-2 mb-3">
+          <SearchBox onChange={setGlobalFilter} />
+        </div>
+      )}
       <RBTable {...getTableProps()} responsive hover>
         <thead>
           {headerGroups.map((headerGroup) => (

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -139,6 +139,15 @@
   "components.Sidebar.modelsLabel": {
     "defaultMessage": "Appliance Models"
   },
+  "components.StorageTable.freeSpaceTitle": {
+    "defaultMessage": "Free Space"
+  },
+  "components.StorageTable.labelTitle": {
+    "defaultMessage": "Storage Unit"
+  },
+  "components.StorageTable.totalSpaceTitle": {
+    "defaultMessage": "Total Space"
+  },
   "components.Topbar.userMenu.logoutLabel": {
     "defaultMessage": "Logout"
   },
@@ -237,6 +246,15 @@
   },
   "pages.Device.location.lastUpdateAt": {
     "defaultMessage": "Last known location, updated at {date}"
+  },
+  "pages.Device.storageTab": {
+    "defaultMessage": "Storage"
+  },
+  "pages.Device.storageTab.noResults.message": {
+    "defaultMessage": "The device has not detected any storage unit yet."
+  },
+  "pages.Device.storageTab.noStorage.title": {
+    "defaultMessage": "No storage"
   },
   "pages.Device.wifiScanResultsTab": {
     "defaultMessage": "WiFi APs"

--- a/frontend/src/mocks/relay.ts
+++ b/frontend/src/mocks/relay.ts
@@ -58,6 +58,13 @@ const relayMockResolvers: MockPayloadGenerator.MockResolvers = {
       timestamp: "2021-11-11T09:43:54.437Z",
     };
   },
+  StorageUnit() {
+    return {
+      label: "Disk 0",
+      totalBytes: 268435456,
+      freeBytes: 128435456,
+    };
+  },
   WifiScanResult() {
     return {
       channel: 1,


### PR DESCRIPTION
Fetch Storage data from AppEngine and display the info in a tab on the Device page.

Storage tab displaying some storage units:

![Screenshot 2021-11-24 at 12-25-29 Edgehog](https://user-images.githubusercontent.com/60540759/143233239-b97ee456-9347-483c-b43f-fedfd0e1cb97.png)

Storage tab with no storage unit found:

![Screenshot 2021-11-24 at 12-28-41 Edgehog](https://user-images.githubusercontent.com/60540759/143233352-96879a64-8c76-4d05-962e-06ea933a1f1c.png)

Closes #35 