### PR TITLE
Handle optional configuration for geolocation providers

### DIFF
--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -45,19 +45,42 @@ if config_env() == :prod do
     ],
     secret_key_base: secret_key_base
 
+  freegeoip_api_key = System.get_env("FREEGEOIP_API_KEY")
+
+  freegeoip_provider = %{
+    module: Edgehog.Geolocation.Providers.FreeGeoIp,
+    enabled?: !is_nil(freegeoip_api_key),
+    config: [api_key: freegeoip_api_key]
+  }
+
+  google_geolocation_api_key = System.get_env("GOOGLE_GEOLOCATION_API_KEY")
+
+  google_geolocation_provider = %{
+    module: Edgehog.Geolocation.Providers.GoogleGeolocation,
+    enabled?: !is_nil(google_geolocation_api_key),
+    config: [api_key: google_geolocation_api_key]
+  }
+
+  google_geocoding_api_key = System.get_env("GOOGLE_GEOCODING_API_KEY")
+
+  google_geocoding_provider = %{
+    module: Edgehog.Geolocation.Providers.GoogleGeocoding,
+    enabled?: !is_nil(google_geocoding_api_key),
+    config: [api_key: google_geocoding_api_key]
+  }
+
+  geolocation_providers = [google_geolocation_provider, freegeoip_provider]
+  geocoding_providers = [google_geocoding_provider]
+
   config :edgehog,
-    ip_geolocation_provider: Edgehog.Geolocation.Providers.FreeGeoIp,
-    wifi_geolocation_provider: Edgehog.Geolocation.Providers.GoogleGeolocation,
-    geocoding_provider: Edgehog.Geolocation.Providers.GoogleGeocoding
+    geolocation_providers:
+      geolocation_providers |> Enum.filter(& &1.enabled?) |> Enum.map(& &1.module),
+    geocoding_providers:
+      geocoding_providers |> Enum.filter(& &1.enabled?) |> Enum.map(& &1.module)
 
-  config :edgehog, Edgehog.Geolocation.Providers.FreeGeoIp,
-    api_key: System.fetch_env!("FREEGEOIP_API_KEY")
-
-  config :edgehog, Edgehog.Geolocation.Providers.GoogleGeolocation,
-    api_key: System.fetch_env!("GOOGLE_GEOLOCATION_API_KEY")
-
-  config :edgehog, Edgehog.Geolocation.Providers.GoogleGeocoding,
-    api_key: System.fetch_env!("GOOGLE_GEOCODING_API_KEY")
+  Enum.each(geolocation_providers ++ geocoding_providers, fn provider ->
+    config :edgehog, provider.module, provider.config
+  end)
 
   # TODO: while you can use access key + secret key with S3-compatible storages,
   # Waffle's default S3 adapter doesn't work well with Google Cloud Storage.

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -54,9 +54,8 @@ config :edgehog, enable_s3_storage?: true
 
 # Geolocation mocks for tests
 config :edgehog,
-  ip_geolocation_provider: Edgehog.Geolocation.IPGeolocationProviderMock,
-  wifi_geolocation_provider: Edgehog.Geolocation.WiFiGeolocationProviderMock,
-  geocoding_provider: Edgehog.Geolocation.GeocodingProviderMock
+  geolocation_providers: [Edgehog.Geolocation.GeolocationProviderMock],
+  geocoding_providers: [Edgehog.Geolocation.GeocodingProviderMock]
 
 config :edgehog, Edgehog.Geolocation.Providers.FreeGeoIp, api_key: "test_api_key"
 

--- a/backend/lib/edgehog/geolocation/coordinates.ex
+++ b/backend/lib/edgehog/geolocation/coordinates.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +16,12 @@
 # limitations under the License.
 #
 
-defmodule Edgehog.Mocks.Geolocation.IPGeolocationProvider do
-  @behaviour Edgehog.Geolocation.IPGeolocationProvider
+defmodule Edgehog.Geolocation.Coordinates do
+  @type t :: %__MODULE__{
+          latitude: float,
+          longitude: float
+        }
 
-  @impl true
-  def geolocate(nil = _ip_address) do
-    {:error, :coordinates_not_found}
-  end
-
-  @impl true
-  def geolocate(_ip_address) do
-    coordinates = %{accuracy: nil, latitude: 45.4019498, longitude: 11.8706081}
-
-    {:ok, coordinates}
-  end
+  @enforce_keys [:latitude, :longitude]
+  defstruct @enforce_keys
 end

--- a/backend/lib/edgehog/geolocation/geocoding_provider.ex
+++ b/backend/lib/edgehog/geolocation/geocoding_provider.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,12 +17,9 @@
 #
 
 defmodule Edgehog.Geolocation.GeocodingProvider do
-  @type coordinates :: %{
-          latitude: float,
-          longitude: float
-        }
+  alias Edgehog.Geolocation.Coordinates
 
   @type address :: String.t()
 
-  @callback reverse_geocode(coordinates) :: {:ok, address} | {:error, term}
+  @callback reverse_geocode(Coordinates.t()) :: {:ok, address} | {:error, term}
 end

--- a/backend/lib/edgehog/geolocation/geolocation_provider.ex
+++ b/backend/lib/edgehog/geolocation/geolocation_provider.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,9 @@
 # limitations under the License.
 #
 
-defmodule Edgehog.Geolocation.IPGeolocationProvider do
-  @type ip_address :: String.t()
+defmodule Edgehog.Geolocation.GeolocationProvider do
+  alias Edgehog.Astarte.Device
+  alias Edgehog.Geolocation.Position
 
-  @type coordinates :: %{
-          latitude: float,
-          longitude: float,
-          accuracy: number | nil
-        }
-
-  @callback geolocate(ip_address) :: {:ok, coordinates} | {:error, term}
+  @callback geolocate(%Device{}) :: {:ok, Position.t()} | {:error, term}
 end

--- a/backend/lib/edgehog/geolocation/position.ex
+++ b/backend/lib/edgehog/geolocation/position.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +16,14 @@
 # limitations under the License.
 #
 
-defmodule Edgehog.Mocks.Geolocation.WiFiGeolocationProvider do
-  @behaviour Edgehog.Geolocation.WiFiGeolocationProvider
+defmodule Edgehog.Geolocation.Position do
+  @type t :: %__MODULE__{
+          latitude: float,
+          longitude: float,
+          accuracy: number | nil,
+          timestamp: DateTime.t()
+        }
 
-  @impl true
-  def geolocate([_wifi_scan_result | _] = _wifi_scan_results) do
-    coordinates = %{accuracy: 12, latitude: 45.4095285, longitude: 11.8788231}
-
-    {:ok, coordinates}
-  end
-
-  @impl true
-  def geolocate(_empty_scan_results) do
-    {:error, :coordinates_not_found}
-  end
+  @enforce_keys [:latitude, :longitude, :accuracy, :timestamp]
+  defstruct @enforce_keys
 end

--- a/backend/lib/edgehog/geolocation/providers/google_geocoding.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geocoding.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@
 defmodule Edgehog.Geolocation.Providers.GoogleGeocoding do
   @behaviour Edgehog.Geolocation.GeocodingProvider
 
+  alias Edgehog.Geolocation.Coordinates
   use Tesla
 
   plug Tesla.Middleware.BaseUrl, "https://maps.googleapis.com/maps/api/geocode/json"
   plug Tesla.Middleware.JSON
 
   @impl Edgehog.Geolocation.GeocodingProvider
-  def reverse_geocode(%{latitude: latitude, longitude: longitude}) do
+  def reverse_geocode(%Coordinates{latitude: latitude, longitude: longitude}) do
     config = Application.fetch_env!(:edgehog, Edgehog.Geolocation.Providers.GoogleGeocoding)
     api_key = Keyword.fetch!(config, :api_key)
 

--- a/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
@@ -42,7 +42,10 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeolocation do
     latest_scan = Enum.max_by(wifi_scan_results, & &1.timestamp, DateTime)
 
     latest_wifi_scan_results =
-      Enum.filter(wifi_scan_results, &(&1.timestamp == latest_scan.timestamp))
+      Enum.filter(
+        wifi_scan_results,
+        &(DateTime.diff(latest_scan.timestamp, &1.timestamp, :second) < 1)
+      )
 
     {:ok, latest_wifi_scan_results}
   end

--- a/backend/test/edgehog/geolocation/providers/google_geocoding_test.exs
+++ b/backend/test/edgehog/geolocation/providers/google_geocoding_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeocodingTest do
   use Edgehog.DataCase
 
   import Tesla.Mock
+  alias Edgehog.Geolocation.Coordinates
   alias Edgehog.Geolocation.Providers.GoogleGeocoding
 
   describe "geocoding" do
     test "reverse_geocode/1 returns an address from coordinates" do
-      coords = %{latitude: 40.714224, longitude: -73.961452}
+      coords = %Coordinates{latitude: 40.714224, longitude: -73.961452}
 
       response = %{
         "results" => [
@@ -44,7 +45,7 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeocodingTest do
     end
 
     test "reverse_geocode/1 returns error without results from Google" do
-      coords = %{latitude: 40.714224, longitude: -73.961452}
+      coords = %Coordinates{latitude: 40.714224, longitude: -73.961452}
 
       response = %{
         "garbage" => "error"

--- a/backend/test/edgehog/geolocation_test.exs
+++ b/backend/test/edgehog/geolocation_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2022 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ defmodule Edgehog.GeolocationTest do
 
   describe "device_location" do
     import Edgehog.AstarteFixtures
-    alias Edgehog.Astarte.Device.DeviceStatus
 
     setup do
       cluster = cluster_fixture()
@@ -49,63 +48,11 @@ defmodule Edgehog.GeolocationTest do
              } == location
     end
 
-    test "fetch_location/1 fails without wifi scans and device IP", %{
-      device: device
-    } do
-      Edgehog.Astarte.Device.WiFiScanResultMock
-      |> expect(:get, fn _appengine_client, _device_id -> {:ok, []} end)
+    test "fetch_location/1 fails without coordinates", %{device: device} do
+      Edgehog.Geolocation.GeolocationProviderMock
+      |> expect(:geolocate, fn _device -> {:error, :position_not_found} end)
 
-      Edgehog.Astarte.Device.DeviceStatusMock
-      |> expect(:get, fn _appengine_client, _device_id ->
-        {:ok,
-         %DeviceStatus{
-           last_connection: nil,
-           last_disconnection: nil,
-           online: false,
-           last_seen_ip: nil
-         }}
-      end)
-
-      assert {:error, :device_coordinates_not_found} = Geolocation.fetch_location(device)
-    end
-
-    test "fetch_location/1 prefers geolocation from wifi scans", %{
-      device: device
-    } do
-      Edgehog.Geolocation.WiFiGeolocationProviderMock
-      |> expect(:geolocate, fn _wifi_scans ->
-        {:ok, %{accuracy: 1, latitude: 1, longitude: 1}}
-      end)
-
-      assert {:ok, location} = Geolocation.fetch_location(device)
-
-      assert %Geolocation{
-               accuracy: 1,
-               latitude: 1,
-               longitude: 1
-             } = location
-    end
-
-    test "fetch_location/1 uses IP geolocation when WiFi geolocation fails", %{
-      device: device
-    } do
-      Edgehog.Geolocation.WiFiGeolocationProviderMock
-      |> expect(:geolocate, fn _wifi_scans ->
-        {:error, :coordinates_not_found}
-      end)
-
-      Edgehog.Geolocation.IPGeolocationProviderMock
-      |> expect(:geolocate, fn _ip_address ->
-        {:ok, %{accuracy: 2, latitude: 2, longitude: 2}}
-      end)
-
-      assert {:ok, location} = Geolocation.fetch_location(device)
-
-      assert %Geolocation{
-               accuracy: 2,
-               latitude: 2,
-               longitude: 2
-             } = location
+      assert {:error, :device_position_not_found} = Geolocation.fetch_location(device)
     end
 
     test "fetch_location/1 returns coordinates even if geocoding fails", %{

--- a/backend/test/support/geolocation_mock_case.ex
+++ b/backend/test/support/geolocation_mock_case.ex
@@ -47,13 +47,8 @@ defmodule Edgehog.GeolocationMockCase do
 
   setup do
     Mox.stub_with(
-      Edgehog.Geolocation.IPGeolocationProviderMock,
-      Edgehog.Mocks.Geolocation.IPGeolocationProvider
-    )
-
-    Mox.stub_with(
-      Edgehog.Geolocation.WiFiGeolocationProviderMock,
-      Edgehog.Mocks.Geolocation.WiFiGeolocationProvider
+      Edgehog.Geolocation.GeolocationProviderMock,
+      Edgehog.Mocks.Geolocation.GeolocationProvider
     )
 
     Mox.stub_with(

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -52,12 +52,8 @@ Mox.defmock(Edgehog.Astarte.Device.CellularConnectionMock,
   for: Edgehog.Astarte.Device.CellularConnection.Behaviour
 )
 
-Mox.defmock(Edgehog.Geolocation.IPGeolocationProviderMock,
-  for: Edgehog.Geolocation.IPGeolocationProvider
-)
-
-Mox.defmock(Edgehog.Geolocation.WiFiGeolocationProviderMock,
-  for: Edgehog.Geolocation.WiFiGeolocationProvider
+Mox.defmock(Edgehog.Geolocation.GeolocationProviderMock,
+  for: Edgehog.Geolocation.GeolocationProvider
 )
 
 Mox.defmock(Edgehog.Geolocation.GeocodingProviderMock, for: Edgehog.Geolocation.GeocodingProvider)

--- a/backend/test/support/mocks/geolocation/geolocation_provider.ex
+++ b/backend/test/support/mocks/geolocation/geolocation_provider.ex
@@ -16,16 +16,18 @@
 # limitations under the License.
 #
 
-defmodule Edgehog.Geolocation.WiFiGeolocationProvider do
-  alias Edgehog.Astarte.Device.WiFiScanResult
+defmodule Edgehog.Mocks.Geolocation.GeolocationProvider do
+  @behaviour Edgehog.Geolocation.GeolocationProvider
 
-  @type wifi_scan_results :: list(WiFiScanResult.t())
+  @impl true
+  def geolocate(_device) do
+    coordinates = %{
+      accuracy: 12,
+      latitude: 45.4095285,
+      longitude: 11.8788231,
+      timestamp: ~U[2021-11-15 11:44:57.432516Z]
+    }
 
-  @type coordinates :: %{
-          latitude: float,
-          longitude: float,
-          accuracy: number | nil
-        }
-
-  @callback geolocate(wifi_scan_results) :: {:ok, coordinates} | {:error, term}
+    {:ok, coordinates}
+  end
 end


### PR DESCRIPTION
Use an optional and general config to define geolocation/geocoding providers.
- The list of providers to use is directly defined via Config
- Providers are enabled only if properly configured via environment variables, otherwise they are not used.
- a Device instance is given directly to Geolocation providers and they are free to implement the logic to fetch device's info and compute its location
