### PR TITLE
Fix backend modules that fetch and parse Astarte data

### DIFF
--- a/backend/lib/edgehog/astarte/device/storage_usage.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage.ex
@@ -30,10 +30,12 @@ defmodule Edgehog.Astarte.Device.StorageUsage do
     # type Object Aggregrate.
     # For details, see https://github.com/astarte-platform/astarte/issues/630
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
       storage_units =
         data
-        |> Enum.map(fn {label, %{"totalBytes" => total_bytes, "freeBytes" => free_bytes}} ->
+        |> Enum.map(fn {label, [storage_unit_info]} ->
+          %{"totalBytes" => total_bytes, "freeBytes" => free_bytes} = storage_unit_info
+
           %StorageUnit{
             label: label,
             total_bytes: parse_longinteger(total_bytes),

--- a/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
+++ b/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
@@ -25,7 +25,7 @@ defmodule Edgehog.Astarte.Device.WiFiScanResult do
 
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1000) do
       wifi_scan_results =
         data["ap"]
         |> Enum.map(fn ap ->

--- a/backend/test/edgehog/astarte/device/storage_usage_test.exs
+++ b/backend/test/edgehog/astarte/device/storage_usage_test.exs
@@ -1,0 +1,75 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.StorageUsageTest do
+  use Edgehog.DataCase
+
+  alias Edgehog.Astarte.Device.StorageUsage
+  alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
+  alias Astarte.Client.AppEngine
+
+  describe "storage_usage" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+      {:ok, appengine_client} = AppEngine.new(cluster.base_api_url, realm.name, realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "get/2 correctly parses storage usage data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "nvs1" => [
+            %{
+              "freeBytes" => "7000",
+              "timestamp" => "2021-11-30T10:45:00.575Z",
+              "totalBytes" => "16128"
+            }
+          ],
+          "nvs2" => [
+            %{
+              "freeBytes" => "5000",
+              "timestamp" => "2021-11-30T10:41:48.575Z",
+              "totalBytes" => "8064"
+            }
+          ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, storage_units} = StorageUsage.get(appengine_client, device.device_id)
+
+      assert storage_units == [
+               %StorageUnit{free_bytes: 7000, label: "nvs1", total_bytes: 16128},
+               %StorageUnit{free_bytes: 5000, label: "nvs2", total_bytes: 8064}
+             ]
+    end
+  end
+end

--- a/backend/test/edgehog/astarte/device/system_status_test.exs
+++ b/backend/test/edgehog/astarte/device/system_status_test.exs
@@ -1,0 +1,72 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.SystemStatusTest do
+  use Edgehog.DataCase
+
+  alias Edgehog.Astarte.Device.SystemStatus
+  alias Astarte.Client.AppEngine
+
+  describe "system_status" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+      {:ok, appengine_client} = AppEngine.new(cluster.base_api_url, realm.name, realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "get/2 correctly parses system status data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "systemStatus" => [
+            %{
+              "availMemoryBytes" => "166772",
+              "bootId" => "779f8022-21a0-4c3d-8f37-b1cf2424f111",
+              "taskCount" => 32,
+              "timestamp" => "2021-11-11T10:44:42.942Z",
+              "uptimeMillis" => "5621"
+            }
+          ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, system_status} = SystemStatus.get(appengine_client, device.device_id)
+
+      assert system_status == %SystemStatus{
+               boot_id: "779f8022-21a0-4c3d-8f37-b1cf2424f111",
+               memory_free_bytes: 166_772,
+               task_count: 32,
+               uptime_milliseconds: 5621,
+               timestamp: ~U[2021-11-11T10:44:42.942Z]
+             }
+    end
+  end
+end

--- a/backend/test/edgehog/astarte/device/wifi_scan_result_test.exs
+++ b/backend/test/edgehog/astarte/device/wifi_scan_result_test.exs
@@ -1,0 +1,102 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.WiFiScanResultTest do
+  use Edgehog.DataCase
+
+  alias Edgehog.Astarte.Device.WiFiScanResult
+  alias Astarte.Client.AppEngine
+
+  describe "system_status" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+      {:ok, appengine_client} = AppEngine.new(cluster.base_api_url, realm.name, realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "get/2 correctly parses wifi scan result data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "ap" => [
+            %{
+              "channel" => 11,
+              "essid" => nil,
+              "macAddress" => "01:23:45:67:89:ab",
+              "rssi" => -43,
+              "timestamp" => "2021-11-15 11:44:57.432516Z"
+            },
+            %{
+              "channel" => 12,
+              "essid" => "My WiFi",
+              "macAddress" => "11:22:33:44:55:66",
+              "rssi" => -32,
+              "timestamp" => "2021-11-15 11:44:57.432516Z"
+            },
+            %{
+              "channel" => 4,
+              "essid" => "Old WiFi",
+              "macAddress" => "aa:bb:cc:ee:dd:ff",
+              "rssi" => -40,
+              "timestamp" => "2021-11-14 11:44:57.432516Z"
+            }
+          ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, wifi_scan_results} = WiFiScanResult.get(appengine_client, device.device_id)
+
+      assert wifi_scan_results == [
+               %WiFiScanResult{
+                 channel: 11,
+                 essid: nil,
+                 mac_address: "01:23:45:67:89:ab",
+                 rssi: -43,
+                 timestamp: ~U[2021-11-15 11:44:57.432516Z]
+               },
+               %WiFiScanResult{
+                 channel: 12,
+                 essid: "My WiFi",
+                 mac_address: "11:22:33:44:55:66",
+                 rssi: -32,
+                 timestamp: ~U[2021-11-15 11:44:57.432516Z]
+               },
+               %WiFiScanResult{
+                 channel: 4,
+                 essid: "Old WiFi",
+                 mac_address: "aa:bb:cc:ee:dd:ff",
+                 rssi: -40,
+                 timestamp: ~U[2021-11-14 11:44:57.432516Z]
+               }
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Fix parsing of Astarte data for the modules:
- StorageUsage: correctly parse data that are wrapped in an array. Use `limit: 1` query option to be sure to fetch the latest data
- SystemStatus: use `limit: 1` query option to be sure to fetch the latest data
- WiFiScanResult: use `limit: 1000` query option to avoid heavy results and to ensure the results are already DESC-ordered by timestamp