### PR TITLE
Update CI workflow to generate docs for Edgehog's Astarte Interfaces

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -27,6 +27,18 @@ jobs:
       with:
         repository: edgehog-device-manager/docs
         path: docs
+    # Checkout the interfaces repository
+    - uses: actions/checkout@v2
+      with:
+        repository: edgehog-device-manager/edgehog-astarte-interfaces
+        path: edgehog-astarte-interfaces
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+    - name: Install astarte-docs-cli
+      run: npm install -g @astarte-platform/astarte-docs-cli@0.0.7
+    - name: Generate Interfaces Docs
+      run: astarte-docs interfaces gen-markdown -d ./edgehog-astarte-interfaces -o ./edgehog/doc/pages/integrating/astarte_interfaces.md
     - uses: erlef/setup-beam@v1.7.0
       with:
         otp-version: "23.2"

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -28,7 +28,8 @@ defmodule Doc.MixProject do
       api_reference: false,
       groups_for_extras: [
         "User Guide": ~r"/user/",
-        Architecture: ~r"/architecture/"
+        Architecture: ~r"/architecture/",
+        "Integrating with Edgehog": ~r"/integrating/"
       ],
       groups_for_modules: []
     ]
@@ -41,8 +42,9 @@ defmodule Doc.MixProject do
       "pages/user/hardware_types.md",
       "pages/user/appliance_models.md",
       "pages/user/devices.md",
-      "pages/user/interacting_with_edgehog.md",
-      "pages/architecture/overview.md"
+      "pages/architecture/overview.md",
+      "pages/integrating/interacting_with_edgehog.md",
+      "pages/integrating/astarte_interfaces.md"
     ]
   end
 end

--- a/doc/pages/integrating/interacting_with_edgehog.md
+++ b/doc/pages/integrating/interacting_with_edgehog.md
@@ -34,8 +34,8 @@ are automatically understood, collected and reported by Edgehog.
 Each Device is supposed to notify Astarte, e.g. on each connection, about the Appliance Model it is
 plugged into.
 
-To do so, the Device can use the `io.edgehog.devicemanager.ApplianceInfo` Astarte Interface to
-specify:
+To do so, the Device can use the [io.edgehog.devicemanager.ApplianceInfo](astarte_interfaces.html)
+Astarte Interface to specify:
 
 - the Serial Number: a code that uniquely identifies the Appliance
 - the Part Number: a code that uniquely identifies the Appliance Model
@@ -48,8 +48,8 @@ matching the Device's Part Number with the ones of the registered Appliance Mode
 Each Device can notify Astarte about the general capabilities of the Device. These info are
 hardware-related and are usually not intended to change over time.
 
-A Device can expose this set of data via the `io.edgehog.devicemanager.HardwareInfo` Astarte
-Interface.
+A Device can expose this set of data via the
+[io.edgehog.devicemanager.HardwareInfo](astarte_interfaces.html) Astarte Interface.
 
 ### Publishing info about the Device status
 
@@ -58,8 +58,10 @@ already defined for Edgehog. Their adoption is optional but recommended.
 
 This section reports an overview on the current system status of the Device.
 
-- `io.edgehog.devicemanager.SystemStatus`: reports the current OS status.
-- `io.edgehog.devicemanager.StorageUsage`: reports the capacity and usage of the storage units.
-- `io.edgehog.devicemanager.BatteryStatus`: reports the current status of the battery slots.
-- `io.edgehog.devicemanager.WiFiScanResults`: reports the list of nearby Access Points that the
-  Device found while scanning for WiFi signals.
+- [io.edgehog.devicemanager.SystemStatus](astarte_interfaces.html): reports the current OS status.
+- [io.edgehog.devicemanager.StorageUsage](astarte_interfaces.html): reports the capacity and usage
+  of the storage units.
+- [io.edgehog.devicemanager.BatteryStatus](astarte_interfaces.html): reports the current status of
+  the battery slots.
+- [io.edgehog.devicemanager.WiFiScanResults](astarte_interfaces.html): reports the list of nearby
+  Access Points that the Device found while scanning for WiFi signals.


### PR DESCRIPTION
Use astarte-docs-cli to generate Markdown files from Edgehog's Astarte Interfaces and include them amongst the other doc pages.
