### PR TITLE
Update runtime docker image to debian:bullseye-slim

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,7 @@ ADD lib lib
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Update the docker image to be in sync with the one used
by erlang.
See https://github.com/erlang/docker-erlang-otp/blob/master/24/Dockerfile#L1

Signed-off-by: Mattia Pavinati <mattia.pavinati@secomind.com>