### PR TITLE
[backend] Device cellular connection

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -41,6 +41,10 @@ config :edgehog, :astarte_base_image_module, Edgehog.Astarte.Device.BaseImageMoc
 config :edgehog, :astarte_os_info_module, Edgehog.Astarte.Device.OSInfoMock
 config :edgehog, :astarte_ota_request_module, Edgehog.Astarte.Device.OTARequestMock
 
+config :edgehog,
+       :astarte_cellular_connection_module,
+       Edgehog.Astarte.Device.CellularConnectionMock
+
 # Storage mocks for tests
 config :edgehog, :assets_system_model_picture_module, Edgehog.Assets.SystemModelPictureMock
 config :edgehog, :os_management_ephemeral_image_module, Edgehog.OSManagement.EphemeralImageMock

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -30,6 +30,7 @@ defmodule Edgehog.Astarte do
   alias Edgehog.Astarte.Device.{
     BaseImage,
     BatteryStatus,
+    CellularConnection,
     DeviceStatus,
     HardwareInfo,
     OSInfo,
@@ -68,8 +69,12 @@ defmodule Edgehog.Astarte do
                          )
   @base_image_module Application.compile_env(:edgehog, :astarte_base_image_module, BaseImage)
   @os_info_module Application.compile_env(:edgehog, :astarte_os_info_module, OSInfo)
-
   @ota_request_module Application.compile_env(:edgehog, :astarte_ota_request_module, OTARequest)
+  @cellular_connection_module Application.compile_env(
+                                :edgehog,
+                                :astarte_cellular_connection_module,
+                                CellularConnection
+                              )
 
   @doc """
   Returns the list of clusters.
@@ -620,6 +625,18 @@ defmodule Edgehog.Astarte do
   def send_ota_request(%Device{} = device, uuid, url) do
     with {:ok, client} <- appengine_client_from_device(device) do
       @ota_request_module.post(client, device.device_id, uuid, url)
+    end
+  end
+
+  def fetch_cellular_connection_properties(%Device{} = device) do
+    with {:ok, client} <- appengine_client_from_device(device) do
+      @cellular_connection_module.get_modem_properties(client, device.device_id)
+    end
+  end
+
+  def fetch_cellular_connection_status(%Device{} = device) do
+    with {:ok, client} <- appengine_client_from_device(device) do
+      @cellular_connection_module.get_modem_status(client, device.device_id)
     end
   end
 

--- a/backend/lib/edgehog/astarte/device/cellular_connection.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection.ex
@@ -1,0 +1,89 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.CellularConnection do
+  @behaviour Edgehog.Astarte.Device.CellularConnection.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.CellularConnection.{ModemProperties, ModemStatus}
+
+  @properties_interface "io.edgehog.devicemanager.CellularConnectionProperties"
+  @status_interface "io.edgehog.devicemanager.CellularConnectionStatus"
+
+  @impl true
+  def get_modem_properties(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_properties_data(client, device_id, @properties_interface) do
+      modems = parse_properties_data(data)
+
+      {:ok, modems}
+    end
+  end
+
+  def parse_properties_data(data), do: Enum.map(data, &parse_modem_properties/1)
+
+  def parse_modem_properties({slot, properties_data}) do
+    %ModemProperties{
+      slot: slot,
+      apn: properties_data["apn"],
+      imei: properties_data["imei"],
+      imsi: properties_data["imsi"]
+    }
+  end
+
+  @impl true
+  def get_modem_status(%AppEngine{} = client, device_id) do
+    # TODO: right now we request the whole interface at once and longinteger
+    # values are returned as strings by Astarte, since the interface is of
+    # type Object Aggregrate.
+    # For details, see https://github.com/astarte-platform/astarte/issues/630
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_datastream_data(client, device_id, @status_interface, limit: 1) do
+      modems = parse_status_data(data)
+
+      {:ok, modems}
+    end
+  end
+
+  def parse_status_data(data), do: Enum.map(data, &parse_modem_status/1)
+
+  def parse_modem_status({slot, [status_data]}) do
+    %ModemStatus{
+      slot: slot,
+      carrier: status_data["carrier"],
+      cell_id: parse_longinteger(status_data["cellId"]),
+      mobile_country_code: status_data["mobileCountryCode"],
+      mobile_network_code: status_data["mobileNetworkCode"],
+      local_area_code: status_data["localAreaCode"],
+      registration_status: status_data["registrationStatus"],
+      rssi: status_data["rssi"],
+      technology: status_data["technology"]
+    }
+  end
+
+  defp parse_longinteger(string) when is_binary(string) do
+    case Integer.parse(string) do
+      {integer, _remainder} -> integer
+      _ -> nil
+    end
+  end
+
+  defp parse_longinteger(_term) do
+    nil
+  end
+end

--- a/backend/lib/edgehog/astarte/device/cellular_connection/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/behaviour.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.CellularConnection.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.CellularConnection.{ModemProperties, ModemStatus}
+
+  @callback get_modem_properties(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(ModemProperties.t())} | {:error, term()}
+
+  @callback get_modem_status(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(ModemStatus.t())} | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/device/cellular_connection/modem_properties.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/modem_properties.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.CellularConnection.ModemProperties do
+  @type t :: %__MODULE__{
+          slot: String.t(),
+          apn: String.t() | nil,
+          imei: String.t() | nil,
+          imsi: String.t() | nil
+        }
+
+  @enforce_keys [:slot, :apn, :imei, :imsi]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog/astarte/device/cellular_connection/modem_status.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/modem_status.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.CellularConnection.ModemStatus do
+  @type t :: %__MODULE__{
+          slot: String.t(),
+          carrier: String.t() | nil,
+          cell_id: integer() | nil,
+          mobile_country_code: integer() | nil,
+          mobile_network_code: integer() | nil,
+          local_area_code: integer() | nil,
+          registration_status: String.t() | nil,
+          rssi: float() | nil,
+          technology: String.t() | nil
+        }
+
+  @enforce_keys [
+    :slot,
+    :carrier,
+    :cell_id,
+    :mobile_country_code,
+    :mobile_network_code,
+    :local_area_code,
+    :registration_status,
+    :rssi,
+    :technology
+  ]
+  defstruct @enforce_keys
+end

--- a/backend/test/edgehog/astarte/device/cellular_connection_test.exs
+++ b/backend/test/edgehog/astarte/device/cellular_connection_test.exs
@@ -1,0 +1,124 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.CellularConnectionTest do
+  use ExUnit.Case
+
+  alias Edgehog.Astarte.Device.CellularConnection
+  alias Edgehog.Astarte.Device.CellularConnection.{ModemProperties, ModemStatus}
+
+  @modem1_properties_data %{
+    "apn" => "company.com",
+    "imei" => "509504877678976",
+    "imsi" => "313460000000001"
+  }
+  @modem1_propetries %ModemProperties{
+    slot: "modem_1",
+    apn: "company.com",
+    imei: "509504877678976",
+    imsi: "313460000000001"
+  }
+
+  describe "parse_modem_properties/1" do
+    test "correctly parses ModemProperties" do
+      assert @modem1_propetries ==
+               CellularConnection.parse_modem_properties({"modem_1", @modem1_properties_data})
+    end
+  end
+
+  describe "parse_properties_data/1" do
+    test "correctly parses CellularConnectionProperties interface data" do
+      data = %{
+        "modem_1" => @modem1_properties_data,
+        "modem_2" => %{
+          "apn" => "internet",
+          "imei" => "338897112874161"
+        }
+      }
+
+      assert [
+               @modem1_propetries,
+               %ModemProperties{
+                 slot: "modem_2",
+                 apn: "internet",
+                 imei: "338897112874161",
+                 imsi: nil
+               }
+             ] == CellularConnection.parse_properties_data(data)
+    end
+  end
+
+  @modem1_status_data %{
+    "carrier" => "Carrier",
+    "cellId" => "170402199",
+    "mobileCountryCode" => 310,
+    "mobileNetworkCode" => 410,
+    "localAreaCode" => 35632,
+    "registrationStatus" => "Registered",
+    "rssi" => -60,
+    "technology" => "GSM",
+    "timestamp" => "2022-01-19T12:00:00.000Z"
+  }
+  @modem1_status %ModemStatus{
+    slot: "modem_1",
+    carrier: "Carrier",
+    cell_id: 170_402_199,
+    mobile_country_code: 310,
+    mobile_network_code: 410,
+    local_area_code: 35632,
+    registration_status: "Registered",
+    rssi: -60,
+    technology: "GSM"
+  }
+
+  describe "parse_modem_status/1" do
+    test "correctly parses ModemStatus" do
+      assert @modem1_status ==
+               CellularConnection.parse_modem_status({"modem_1", [@modem1_status_data]})
+    end
+  end
+
+  describe "parse_status_data/1" do
+    test "correctly parses CellularConnectionStatus interface data" do
+      data = %{
+        "modem_1" => [@modem1_status_data],
+        "modem_2" => [
+          %{
+            "registrationStatus" => "NotRegistered",
+            "timestamp" => "2022-01-19T12:00:00.000Z"
+          }
+        ]
+      }
+
+      assert [
+               @modem1_status,
+               %ModemStatus{
+                 slot: "modem_2",
+                 carrier: nil,
+                 cell_id: nil,
+                 mobile_country_code: nil,
+                 mobile_network_code: nil,
+                 local_area_code: nil,
+                 registration_status: "NotRegistered",
+                 rssi: nil,
+                 technology: nil
+               }
+             ] == CellularConnection.parse_status_data(data)
+    end
+  end
+end

--- a/backend/test/edgehog_web/resolvers/astarte_test.exs
+++ b/backend/test/edgehog_web/resolvers/astarte_test.exs
@@ -123,5 +123,56 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
                fingerprint: "b14c1457dc10469418b4154fef29a90e1ffb4dddd308bf0f2456d436963ef5b3"
              } == base_image
     end
+
+    test "fetch_cellular_connection/3 returns the cellular_connection for a device", %{
+      device: device
+    } do
+      assert {:ok, cellular_connection} = Astarte.fetch_cellular_connection(device, %{}, %{})
+
+      assert [
+               %{
+                 slot: "modem_1",
+                 apn: "company.com",
+                 imei: "509504877678976",
+                 imsi: "313460000000001",
+                 carrier: "Carrier",
+                 cell_id: 170_402_199,
+                 mobile_country_code: 310,
+                 mobile_network_code: 410,
+                 local_area_code: 35632,
+                 registration_status: "Registered",
+                 rssi: -60,
+                 technology: "GSM"
+               },
+               %{
+                 slot: "modem_2",
+                 apn: "internet",
+                 imei: "338897112874161",
+                 imsi: nil,
+                 carrier: nil,
+                 cell_id: nil,
+                 mobile_country_code: nil,
+                 mobile_network_code: nil,
+                 local_area_code: nil,
+                 registration_status: "NotRegistered",
+                 rssi: nil,
+                 technology: nil
+               },
+               %{
+                 slot: "modem_3",
+                 apn: "internet",
+                 imei: "338897112874162",
+                 imsi: nil,
+                 carrier: nil,
+                 cell_id: nil,
+                 mobile_country_code: nil,
+                 mobile_network_code: nil,
+                 local_area_code: nil,
+                 registration_status: nil,
+                 rssi: nil,
+                 technology: nil
+               }
+             ] == cellular_connection
+    end
   end
 end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -86,6 +86,11 @@ defmodule Edgehog.AstarteMockCase do
       Edgehog.Mocks.Astarte.Device.BatteryStatus
     )
 
+    Mox.stub_with(
+      Edgehog.Astarte.Device.CellularConnectionMock,
+      Edgehog.Mocks.Astarte.Device.CellularConnection
+    )
+
     :ok
   end
 end

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -48,6 +48,10 @@ Mox.defmock(Edgehog.Astarte.Device.BatteryStatusMock,
   for: Edgehog.Astarte.Device.BatteryStatus.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.CellularConnectionMock,
+  for: Edgehog.Astarte.Device.CellularConnection.Behaviour
+)
+
 Mox.defmock(Edgehog.Geolocation.IPGeolocationProviderMock,
   for: Edgehog.Geolocation.IPGeolocationProvider
 )

--- a/backend/test/support/mocks/astarte/device/cellular_connection.ex
+++ b/backend/test/support/mocks/astarte/device/cellular_connection.ex
@@ -1,0 +1,80 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.CellularConnection do
+  @behaviour Edgehog.Astarte.Device.CellularConnection.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.CellularConnection.{ModemProperties, ModemStatus}
+
+  @impl true
+  def get_modem_properties(%AppEngine{} = _client, _device_id) do
+    modem_properties_list = [
+      %ModemProperties{
+        slot: "modem_1",
+        apn: "company.com",
+        imei: "509504877678976",
+        imsi: "313460000000001"
+      },
+      %ModemProperties{
+        slot: "modem_2",
+        apn: "internet",
+        imei: "338897112874161",
+        imsi: nil
+      },
+      %ModemProperties{
+        slot: "modem_3",
+        apn: "internet",
+        imei: "338897112874162",
+        imsi: nil
+      }
+    ]
+
+    {:ok, modem_properties_list}
+  end
+
+  @impl true
+  def get_modem_status(%AppEngine{} = _client, _device_id) do
+    modem_status_list = [
+      %ModemStatus{
+        slot: "modem_1",
+        carrier: "Carrier",
+        cell_id: 170_402_199,
+        mobile_country_code: 310,
+        mobile_network_code: 410,
+        local_area_code: 35632,
+        registration_status: "Registered",
+        rssi: -60,
+        technology: "GSM"
+      },
+      %ModemStatus{
+        slot: "modem_2",
+        carrier: nil,
+        cell_id: nil,
+        mobile_country_code: nil,
+        mobile_network_code: nil,
+        local_area_code: nil,
+        registration_status: "NotRegistered",
+        rssi: nil,
+        technology: nil
+      }
+    ]
+
+    {:ok, modem_status_list}
+  end
+end


### PR DESCRIPTION
Fetch CellularConnectionProperties and CellularConnectionStatus data from AppEngine and expose it via GraphQL

Closes #104 