### PR TITLE
wifi_scan_result: do not crash if no data is present

### DIFF
--- a/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
+++ b/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
@@ -27,7 +27,7 @@ defmodule Edgehog.Astarte.Device.WiFiScanResult do
     with {:ok, %{"data" => data}} <-
            AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1000) do
       wifi_scan_results =
-        data["ap"]
+        Map.get(data, "ap", [])
         |> Enum.map(fn ap ->
           %WiFiScanResult{
             channel: ap["channel"],


### PR DESCRIPTION
Add an empty list default when retrieving data from the interface

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>