### PR TITLE
Fix possible null operation list

### DIFF
--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -987,7 +987,7 @@ const SoftwareUpdateTab = ({ deviceRef }: SoftwareUpdateTabProps) => {
             defaultMessage="History"
           />
         </h5>
-        {pastOperations.length === 0 ? (
+        {!pastOperations || pastOperations.length === 0 ? (
           <div>
             <FormattedMessage
               id="pages.Device.SoftwareUpdateTab.noPreviousUpdates"


### PR DESCRIPTION
_.groupBy returns null if no element matches

Signed-off-by: Mattia Pavinati <mattia.pavinati@secomind.com>