### PR TITLE
Move the API endpoint from `/api` to `/tenants/<tenant>/api`

### DIFF
--- a/backend/lib/edgehog/tenants.ex
+++ b/backend/lib/edgehog/tenants.ex
@@ -56,6 +56,27 @@ defmodule Edgehog.Tenants do
   def get_tenant!(id), do: Repo.get!(Tenant, id, skip_tenant_id: true)
 
   @doc """
+  Fetches a single tenant by its slug.
+
+  Returns `{:ok, tenant}` or `{:error, :not_found}`.
+
+  ## Examples
+
+  iex> fetch_tenant_by_slug("test")
+  {:ok, %Tenant{}}
+
+  iex> fetch_tenant_by_slug("unknown")
+  {:error, :not_found}
+
+  """
+  def fetch_tenant_by_slug(slug) do
+    case Repo.get_by(Tenant, [slug: slug], skip_tenant_id: true) do
+      %Tenant{} = tenant -> {:ok, tenant}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc """
   Creates a tenant.
 
   ## Examples

--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -30,18 +30,20 @@ defmodule EdgehogWeb.Router do
     plug EdgehogWeb.PopulateTenant
   end
 
-  scope "/api" do
-    pipe_through :api
+  scope "/tenants/:tenant_slug" do
+    scope "/api" do
+      pipe_through :api
 
-    forward "/graphiql", Absinthe.Plug.GraphiQL, schema: EdgehogWeb.Schema
+      forward "/graphiql", Absinthe.Plug.GraphiQL, schema: EdgehogWeb.Schema
 
-    forward "/", Absinthe.Plug, schema: EdgehogWeb.Schema
-  end
+      forward "/", Absinthe.Plug, schema: EdgehogWeb.Schema
+    end
 
-  scope "/tenants/:tenant_slug/triggers", EdgehogWeb do
-    pipe_through :triggers
+    scope "/triggers", EdgehogWeb do
+      pipe_through :triggers
 
-    post "/", AstarteTriggerController, :process_event
+      post "/", AstarteTriggerController, :process_event
+    end
   end
 
   # Enables the Swoosh mailbox preview in development.

--- a/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
@@ -35,7 +35,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
       }
     }
     """
-    test "creates hardware type with valid data", %{conn: conn} do
+    test "creates hardware type with valid data", %{conn: conn, api_path: api_path} do
       name = "Foobar"
       handle = "foobar"
       part_number = "12345/X"
@@ -48,7 +48,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -70,7 +70,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
                Devices.fetch_hardware_type(db_id)
     end
 
-    test "fails with invalid data", %{conn: conn} do
+    test "fails with invalid data", %{conn: conn, api_path: api_path} do
       variables = %{
         input: %{
           name: nil,
@@ -79,7 +79,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => _} = assert(json_response(conn, 200))
     end

--- a/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
@@ -52,7 +52,11 @@ defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
       }
     }
     """
-    test "creates OTA operation with valid data", %{conn: conn, device: device} do
+    test "creates OTA operation with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      device: device
+    } do
       fake_image = %Plug.Upload{path: "test/fixtures/image.bin", filename: "image.bin"}
 
       variables = %{
@@ -62,7 +66,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables, fake_image: fake_image)
+      conn = post(conn, api_path, query: @query, variables: variables, fake_image: fake_image)
 
       assert %{
                "data" => %{
@@ -90,7 +94,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
       assert device.device_id == device_id
     end
 
-    test "fails with invalid data", %{conn: conn} do
+    test "fails with invalid data", %{conn: conn, api_path: api_path} do
       variables = %{
         input: %{
           device_id: nil,
@@ -98,7 +102,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => _} = assert(json_response(conn, 200))
     end

--- a/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
@@ -48,7 +48,11 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
       }
     }
     """
-    test "creates system model with valid data", %{conn: conn, hardware_type: hardware_type} do
+    test "creates system model with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      hardware_type: hardware_type
+    } do
       name = "Foobar"
       handle = "foobar"
       part_number = "12345/X"
@@ -67,7 +71,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -92,7 +96,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
       assert {:ok, %SystemModel{name: ^name, handle: ^handle}} = Devices.fetch_system_model(db_id)
     end
 
-    test "fails with invalid data", %{conn: conn} do
+    test "fails with invalid data", %{conn: conn, api_path: api_path} do
       variables = %{
         input: %{
           system_model: %{
@@ -103,13 +107,14 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => _} = assert(json_response(conn, 200))
     end
 
     test "allows settings a description for the default locale", %{
       conn: conn,
+      api_path: api_path,
       hardware_type: hardware_type,
       tenant: tenant
     } do
@@ -137,7 +142,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -167,6 +172,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
 
     test "fails when trying to set a description for non default locale", %{
       conn: conn,
+      api_path: api_path,
       hardware_type: hardware_type
     } do
       name = "Foobar"
@@ -189,7 +195,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => [%{"code" => "not_default_locale"}]} = assert(json_response(conn, 200))
     end

--- a/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
@@ -41,7 +41,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
       }
     }
     """
-    test "updates hardware type with valid data", %{conn: conn, hardware_type: hardware_type} do
+    test "updates hardware type with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      hardware_type: hardware_type
+    } do
       name = "Foobaz"
       handle = "foobaz"
       part_number = "12345/Z"
@@ -57,7 +61,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -76,7 +80,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
                Devices.fetch_hardware_type(hardware_type.id)
     end
 
-    test "updates hardware type with partial data", %{conn: conn, hardware_type: hardware_type} do
+    test "updates hardware type with partial data", %{
+      conn: conn,
+      api_path: api_path,
+      hardware_type: hardware_type
+    } do
       %HardwareType{name: initial_name, handle: initial_handle} = hardware_type
 
       name = "Foobaz"
@@ -91,7 +99,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -116,7 +124,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -135,7 +143,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
                Devices.fetch_hardware_type(hardware_type.id)
     end
 
-    test "fails with invalid data", %{conn: conn, hardware_type: hardware_type} do
+    test "fails with invalid data", %{
+      conn: conn,
+      api_path: api_path,
+      hardware_type: hardware_type
+    } do
       id = Absinthe.Relay.Node.to_global_id(:hardware_type, hardware_type.id, EdgehogWeb.Schema)
 
       variables = %{
@@ -147,12 +159,12 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => _} = assert(json_response(conn, 200))
     end
 
-    test "fails with non-existing id", %{conn: conn} do
+    test "fails with non-existing id", %{conn: conn, api_path: api_path} do
       name = "Foobaz"
       handle = "foobaz"
       part_number = "12345/Z"
@@ -168,7 +180,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => [%{"code" => "not_found", "status_code" => 404}]} =
                assert(json_response(conn, 200))

--- a/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
@@ -54,6 +54,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
     """
     test "updates system model with valid data", %{
       conn: conn,
+      api_path: api_path,
       system_model: system_model
     } do
       name = "Foobaz"
@@ -71,7 +72,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -90,7 +91,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
                Devices.fetch_system_model(system_model.id)
     end
 
-    test "fails with invalid data", %{conn: conn, system_model: system_model} do
+    test "fails with invalid data", %{
+      conn: conn,
+      api_path: api_path,
+      system_model: system_model
+    } do
       id = Absinthe.Relay.Node.to_global_id(:system_model, system_model.id, EdgehogWeb.Schema)
 
       variables = %{
@@ -102,13 +107,14 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => _} = assert(json_response(conn, 200))
     end
 
     test "updates system model with partial data", %{
       conn: conn,
+      api_path: api_path,
       system_model: system_model
     } do
       name = "Foobarbaz"
@@ -122,7 +128,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -137,7 +143,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
       assert {:ok, %SystemModel{name: ^name}} = Devices.fetch_system_model(system_model.id)
     end
 
-    test "fails with non-existing id", %{conn: conn} do
+    test "fails with non-existing id", %{conn: conn, api_path: api_path} do
       name = "Foobaz"
       handle = "foobaz"
       part_number = "12345/Z"
@@ -153,7 +159,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => [%{"code" => "not_found", "status_code" => 404}]} =
                assert(json_response(conn, 200))
@@ -161,6 +167,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
 
     test "updates default locale description, without touching the others", %{
       conn: conn,
+      api_path: api_path,
       system_model: system_model,
       tenant: tenant
     } do
@@ -180,7 +187,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -212,6 +219,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
 
     test "fails when trying to update a non default locale", %{
       conn: conn,
+      api_path: api_path,
       system_model: system_model
     } do
       description = %{
@@ -228,7 +236,7 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
         }
       }
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{"errors" => [%{"code" => "not_default_locale"}]} = assert(json_response(conn, 200))
     end

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -43,7 +43,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
     }
     """
 
-    test "returns the device if it's present", %{conn: conn, realm: realm} do
+    test "returns the device if it's present", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         id: id,
         name: name,
@@ -53,7 +53,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -78,14 +78,14 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
     }
     """
 
-    test "returns the storage usage if available", %{conn: conn, realm: realm} do
+    test "returns the storage usage if available", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         id: id
       } = device_fixture(realm)
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @storage_usage_query, variables: variables)
+      conn = get(conn, api_path, query: @storage_usage_query, variables: variables)
 
       assert %{
                "data" => %{
@@ -111,7 +111,11 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
     }
     """
 
-    test "returns the OTA operations if available", %{conn: conn, realm: realm} do
+    test "returns the OTA operations if available", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
       device = device_fixture(realm)
 
       %Device{
@@ -122,7 +126,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @ota_operations_query, variables: variables)
+      conn = get(conn, api_path, query: @ota_operations_query, variables: variables)
 
       assert %{
                "data" => %{

--- a/backend/test/edgehog_web/schema/query/devices_test.exs
+++ b/backend/test/edgehog_web/schema/query/devices_test.exs
@@ -48,8 +48,8 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
       }
     }
     """
-    test "returns empty devices", %{conn: conn} do
-      conn = get(conn, "/api", query: @query)
+    test "returns empty devices", %{conn: conn, api_path: api_path} do
+      conn = get(conn, api_path, query: @query)
 
       assert json_response(conn, 200) == %{
                "data" => %{
@@ -58,14 +58,14 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
              }
     end
 
-    test "returns devices if they're present", %{conn: conn, realm: realm} do
+    test "returns devices if they're present", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         name: name,
         device_id: device_id,
         online: online
       } = device_fixture(realm)
 
-      conn = get(conn, "/api", query: @query)
+      conn = get(conn, api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -78,7 +78,11 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
       assert device["online"] == online
     end
 
-    test "filters devices when a filter is provided", %{conn: conn, realm: realm} do
+    test "filters devices when a filter is provided", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
       %Device{
         name: name,
         device_id: device_id,
@@ -89,7 +93,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
 
       variables = %{filter: %{online: true}}
 
-      conn = post(conn, "/api", query: @query, variables: variables)
+      conn = post(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -104,6 +108,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
 
     test "returns system model description with default locale", %{
       conn: conn,
+      api_path: api_path,
       realm: realm,
       tenant: tenant
     } do
@@ -124,7 +129,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
       part_number = pn.part_number
       _device = device_fixture(realm, part_number: part_number)
 
-      conn = get(conn, "/api", query: @query)
+      conn = get(conn, api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -139,6 +144,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
 
     test "returns system model description with explicit locale", %{
       conn: conn,
+      api_path: api_path,
       realm: realm,
       tenant: tenant
     } do
@@ -163,7 +169,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
       conn =
         conn
         |> put_req_header("accept-language", "it-IT")
-        |> get("/api", query: @query)
+        |> get(api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -197,14 +203,14 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
     }
     """
 
-    test "returns battery status if available", %{conn: conn, realm: realm} do
+    test "returns battery status if available", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         id: id
       } = device_fixture(realm)
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @battery_status_query, variables: variables)
+      conn = get(conn, api_path, query: @battery_status_query, variables: variables)
 
       assert %{
                "data" => %{
@@ -239,14 +245,14 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
     }
     """
 
-    test "returns OS info if available", %{conn: conn, realm: realm} do
+    test "returns OS info if available", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         id: id
       } = device_fixture(realm)
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @os_info_query, variables: variables)
+      conn = get(conn, api_path, query: @os_info_query, variables: variables)
 
       assert %{
                "data" => %{
@@ -281,14 +287,14 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
     }
     """
 
-    test "returns OS info if available", %{conn: conn, realm: realm} do
+    test "returns OS info if available", %{conn: conn, api_path: api_path, realm: realm} do
       %Device{
         id: id
       } = device_fixture(realm)
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @base_image_query, variables: variables)
+      conn = get(conn, api_path, query: @base_image_query, variables: variables)
 
       assert %{
                "data" => %{
@@ -335,14 +341,18 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
     }
     """
 
-    test "returns cellular connection if available", %{conn: conn, realm: realm} do
+    test "returns cellular connection if available", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
       %Device{
         id: id
       } = device_fixture(realm)
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:device, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @cellular_connection_query, variables: variables)
+      conn = get(conn, api_path, query: @cellular_connection_query, variables: variables)
 
       assert %{
                "data" => %{

--- a/backend/test/edgehog_web/schema/query/hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/query/hardware_type_test.exs
@@ -36,7 +36,7 @@ defmodule EdgehogWeb.Schema.Query.HardwareTypeTest do
       }
     }
     """
-    test "returns hardware type if present", %{conn: conn} do
+    test "returns hardware type if present", %{conn: conn, api_path: api_path} do
       %HardwareType{
         id: id,
         name: name,
@@ -46,7 +46,7 @@ defmodule EdgehogWeb.Schema.Query.HardwareTypeTest do
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:hardware_type, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert json_response(conn, 200) == %{
                "data" => %{
@@ -59,10 +59,10 @@ defmodule EdgehogWeb.Schema.Query.HardwareTypeTest do
              }
     end
 
-    test "raises if non existing", %{conn: conn} do
+    test "raises if non existing", %{conn: conn, api_path: api_path} do
       variables = %{id: Absinthe.Relay.Node.to_global_id(:hardware_type, 1, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{"hardwareType" => nil},

--- a/backend/test/edgehog_web/schema/query/hardware_types_test.exs
+++ b/backend/test/edgehog_web/schema/query/hardware_types_test.exs
@@ -36,8 +36,8 @@ defmodule EdgehogWeb.Schema.Query.HardwareTypesTest do
       }
     }
     """
-    test "returns empty hardware types", %{conn: conn} do
-      conn = get(conn, "/api", query: @query)
+    test "returns empty hardware types", %{conn: conn, api_path: api_path} do
+      conn = get(conn, api_path, query: @query)
 
       assert json_response(conn, 200) == %{
                "data" => %{
@@ -46,14 +46,14 @@ defmodule EdgehogWeb.Schema.Query.HardwareTypesTest do
              }
     end
 
-    test "returns hardware types if they're present", %{conn: conn} do
+    test "returns hardware types if they're present", %{conn: conn, api_path: api_path} do
       %HardwareType{
         name: name,
         handle: handle,
         part_numbers: [%HardwareTypePartNumber{part_number: part_number}]
       } = hardware_type_fixture()
 
-      conn = get(conn, "/api", query: @query)
+      conn = get(conn, api_path, query: @query)
 
       assert %{
                "data" => %{

--- a/backend/test/edgehog_web/schema/query/system_model_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_model_test.exs
@@ -43,7 +43,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
       }
     }
     """
-    test "returns system model if present", %{conn: conn} do
+    test "returns system model if present", %{conn: conn, api_path: api_path} do
       hardware_type = hardware_type_fixture()
 
       %SystemModel{
@@ -55,7 +55,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:system_model, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert json_response(conn, 200) == %{
                "data" => %{
@@ -72,10 +72,10 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
              }
     end
 
-    test "returns not found if non existing", %{conn: conn} do
+    test "returns not found if non existing", %{conn: conn, api_path: api_path} do
       variables = %{id: Absinthe.Relay.Node.to_global_id(:system_model, 1, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{"systemModel" => nil},
@@ -83,7 +83,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
              } = json_response(conn, 200)
     end
 
-    test "returns the default locale description", %{conn: conn, tenant: tenant} do
+    test "returns the default locale description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -97,7 +101,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
 
       variables = %{id: Absinthe.Relay.Node.to_global_id(:system_model, id, EdgehogWeb.Schema)}
 
-      conn = get(conn, "/api", query: @query, variables: variables)
+      conn = get(conn, api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -111,7 +115,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
              } = json_response(conn, 200)
     end
 
-    test "returns the explicit locale description", %{conn: conn, tenant: tenant} do
+    test "returns the explicit locale description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -128,7 +136,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
       conn =
         conn
         |> put_req_header("accept-language", "it-IT")
-        |> get("/api", query: @query, variables: variables)
+        |> get(api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{
@@ -142,7 +150,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
              } = json_response(conn, 200)
     end
 
-    test "returns empty description for not existing locale", %{conn: conn, tenant: tenant} do
+    test "returns empty description for not existing locale", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -159,7 +171,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
       conn =
         conn
         |> put_req_header("accept-language", "fr-FR")
-        |> get("/api", query: @query, variables: variables)
+        |> get(api_path, query: @query, variables: variables)
 
       assert %{
                "data" => %{

--- a/backend/test/edgehog_web/schema/query/system_models_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_models_test.exs
@@ -43,8 +43,8 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       }
     }
     """
-    test "returns empty system models", %{conn: conn} do
-      conn = get(conn, "/api", query: @query)
+    test "returns empty system models", %{conn: conn, api_path: api_path} do
+      conn = get(conn, api_path, query: @query)
 
       assert json_response(conn, 200) == %{
                "data" => %{
@@ -53,7 +53,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
              }
     end
 
-    test "returns system models if they're present", %{conn: conn} do
+    test "returns system models if they're present", %{conn: conn, api_path: api_path} do
       hardware_type = hardware_type_fixture()
 
       %SystemModel{
@@ -62,7 +62,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
         part_numbers: [%SystemModelPartNumber{part_number: part_number}]
       } = system_model_fixture(hardware_type)
 
-      conn = get(conn, "/api", query: @query)
+      conn = get(conn, api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -76,7 +76,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       assert system_model["hardwareType"]["name"] == hardware_type.name
     end
 
-    test "returns the default locale description", %{conn: conn, tenant: tenant} do
+    test "returns the default locale description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -88,7 +92,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
 
       _system_model = system_model_fixture(hardware_type, descriptions: descriptions)
 
-      conn = get(conn, "/api", query: @query)
+      conn = get(conn, api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -100,7 +104,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       assert system_model["description"]["text"] == "A system model"
     end
 
-    test "returns an explicit locale description", %{conn: conn, tenant: tenant} do
+    test "returns an explicit locale description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -115,7 +123,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       conn =
         conn
         |> put_req_header("accept-language", "it-IT")
-        |> get("/api", query: @query)
+        |> get(api_path, query: @query)
 
       assert %{
                "data" => %{
@@ -127,7 +135,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       assert system_model["description"]["text"] == "Un modello di sistema"
     end
 
-    test "returns empty description for non existing locale", %{conn: conn, tenant: tenant} do
+    test "returns empty description for non existing locale", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant
+    } do
       hardware_type = hardware_type_fixture()
 
       default_locale = tenant.default_locale
@@ -142,7 +154,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       conn =
         conn
         |> put_req_header("accept-language", "fr-FR")
-        |> get("/api", query: @query)
+        |> get(api_path, query: @query)
 
       assert %{
                "data" => %{

--- a/backend/test/edgehog_web/schema/query/tenant_info_test.exs
+++ b/backend/test/edgehog_web/schema/query/tenant_info_test.exs
@@ -32,8 +32,8 @@ defmodule EdgehogWeb.Schema.Query.TenantInfoTest do
     }
     """
 
-    test "returns the tenant info", %{conn: conn, tenant: tenant} do
-      conn = get(conn, "/api", query: @query)
+    test "returns the tenant info", %{conn: conn, api_path: api_path, tenant: tenant} do
+      conn = get(conn, api_path, query: @query)
 
       %Tenant{name: name, slug: slug, default_locale: default_locale} = tenant
 

--- a/backend/test/support/conn_case.ex
+++ b/backend/test/support/conn_case.ex
@@ -63,7 +63,10 @@ defmodule EdgehogWeb.ConnCase do
       tenant = Edgehog.TenantsFixtures.tenant_fixture()
       _ = Edgehog.Repo.put_tenant_id(tenant.tenant_id)
 
-      {:ok, conn: conn, tenant: tenant}
+      # Populate the API path since it's tenant-specific
+      api_path = "/tenants/#{tenant.slug}/api"
+
+      {:ok, conn: conn, tenant: tenant, api_path: api_path}
     end
   end
 end


### PR DESCRIPTION
Lay down the groundwork to add authentication, since we need to know which
tenant are we authenticating for by looking at path params

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>