### PR TITLE
Fix warning about wrong cookie params when logging out

### DIFF
--- a/frontend/src/contexts/Auth.tsx
+++ b/frontend/src/contexts/Auth.tsx
@@ -50,14 +50,15 @@ function saveAuthConfig(
   authConfig?: AuthConfig | null,
   persistConfig: boolean = false
 ): void {
+  // If expires is undefined, closing the browser/session will delete the cookie
+  const cookieOptions = {
+    secure: true,
+    expires: persistConfig ? 365 : undefined,
+  } as const;
+
   if (!authConfig) {
-    Cookies.remove("authConfig");
+    Cookies.remove("authConfig", cookieOptions);
   } else {
-    // If expires is undefined, closing the browser/session will delete the cookie
-    const cookieOptions = {
-      secure: true,
-      expires: persistConfig ? 365 : undefined,
-    };
     Cookies.set(
       "authConfig",
       JSON.stringify({ ...authConfig, _version: AUTH_CONFIG_VERSION }),


### PR DESCRIPTION
When removing the cookie, use the same options that were used to create it, as recommended by the [Cookie.js library](https://github.com/js-cookie/js-cookie#basic-usage).
