### PR TITLE
Fix typo in backend configuration referencing FreeGeoIp module

### DIFF
--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -54,7 +54,7 @@ defmodule Edgehog.Config do
   app_env :preferred_geolocation_providers, :edgehog, :preferred_geolocation_providers,
     os_env: "PREFERRED_GEOLOCATION_PROVIDERS",
     type: GeolocationProviders,
-    default: [Geolocation.Providers.GoogleGeolocation, Geolocation.Providers.FreeGeoIP]
+    default: [Geolocation.Providers.GoogleGeolocation, Geolocation.Providers.FreeGeoIp]
 
   @envdoc """
   A comma separated list of preferred geocoding providers.

--- a/backend/lib/edgehog/config/geolocation_providers.ex
+++ b/backend/lib/edgehog/config/geolocation_providers.ex
@@ -20,7 +20,7 @@ defmodule Edgehog.Config.GeolocationProviders do
   use Skogsra.Type
 
   @providers %{
-    "freegeoip" => Edgehog.Geolocation.Providers.FreeGeoIP,
+    "freegeoip" => Edgehog.Geolocation.Providers.FreeGeoIp,
     "google" => Edgehog.Geolocation.Providers.GoogleGeolocation
   }
 


### PR DESCRIPTION
Rename `FreeGeoIP` to `FreeGeoIp`.
