### PR TITLE
[frontend] Device Led behavior

### DIFF
--- a/frontend/src/api/__generated__/LedBehaviorDropdown_setLedBehavior_Mutation.graphql.ts
+++ b/frontend/src/api/__generated__/LedBehaviorDropdown_setLedBehavior_Mutation.graphql.ts
@@ -1,0 +1,94 @@
+/**
+ * @generated SignedSource<<8eb8a88c8baf1db69dca63d191404d93>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type LedBehavior = "BLINK" | "DOUBLE_BLINK" | "SLOW_BLINK" | "%future added value";
+export type SetLedBehaviorInput = {
+  deviceId: string;
+  behavior: LedBehavior;
+};
+export type LedBehaviorDropdown_setLedBehavior_Mutation$variables = {
+  input: SetLedBehaviorInput;
+};
+export type LedBehaviorDropdown_setLedBehavior_Mutation$data = {
+  readonly setLedBehavior: {
+    readonly behavior: LedBehavior;
+  } | null;
+};
+export type LedBehaviorDropdown_setLedBehavior_Mutation = {
+  variables: LedBehaviorDropdown_setLedBehavior_Mutation$variables;
+  response: LedBehaviorDropdown_setLedBehavior_Mutation$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "SetLedBehaviorPayload",
+    "kind": "LinkedField",
+    "name": "setLedBehavior",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "behavior",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "LedBehaviorDropdown_setLedBehavior_Mutation",
+    "selections": (v1/*: any*/),
+    "type": "RootMutationType",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "LedBehaviorDropdown_setLedBehavior_Mutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "45e4760b91f125e9438362654d06ec0c",
+    "id": null,
+    "metadata": {},
+    "name": "LedBehaviorDropdown_setLedBehavior_Mutation",
+    "operationKind": "mutation",
+    "text": "mutation LedBehaviorDropdown_setLedBehavior_Mutation(\n  $input: SetLedBehaviorInput!\n) {\n  setLedBehavior(input: $input) {\n    behavior\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "20fbb73638f1245c58fb2800a2547a6f";
+
+export default node;

--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021 SECO Mind Srl
+  Copyright 2021-2022 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import {
   faTabletAlt,
   faTrash,
   faUser,
+  faCheck,
 } from "@fortawesome/free-solid-svg-icons";
 
 const icons = {
@@ -45,6 +46,7 @@ const icons = {
   plus: faPlus,
   profile: faUser,
   search: faSearch,
+  check: faCheck,
 } as const;
 
 type FontAwesomeIconProps = React.ComponentProps<typeof FontAwesomeIcon>;

--- a/frontend/src/components/LedBehaviorDropdown.tsx
+++ b/frontend/src/components/LedBehaviorDropdown.tsx
@@ -1,0 +1,130 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2022 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useCallback } from "react";
+import graphql from "babel-plugin-relay/macro";
+import { useMutation } from "react-relay/hooks";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+import type { MessageDescriptor } from "react-intl";
+
+import ButtonGroup from "react-bootstrap/ButtonGroup";
+import Dropdown from "react-bootstrap/Dropdown";
+
+import Spinner from "components/Spinner";
+
+import type { LedBehaviorDropdown_setLedBehavior_Mutation } from "api/__generated__/LedBehaviorDropdown_setLedBehavior_Mutation.graphql";
+
+const SET_LED_BEHAVIOR_MUTATION = graphql`
+  mutation LedBehaviorDropdown_setLedBehavior_Mutation(
+    $input: SetLedBehaviorInput!
+  ) {
+    setLedBehavior(input: $input) {
+      behavior
+    }
+  }
+`;
+
+const SUPPORTED_LED_BEHAVIORS = [
+  "BLINK",
+  "DOUBLE_BLINK",
+  "SLOW_BLINK",
+] as const;
+type SupportedLedBehavior = typeof SUPPORTED_LED_BEHAVIORS[number];
+
+const supportedBehaviorMessages: Record<
+  SupportedLedBehavior,
+  MessageDescriptor
+> = defineMessages({
+  BLINK: {
+    id: "components.LedBehaviorDropdown.behavior.blinkLED",
+    defaultMessage: "Blink LED",
+  },
+  DOUBLE_BLINK: {
+    id: "components.LedBehaviorDropdown.behavior.doubleBlinkLED",
+    defaultMessage: "Double blink LED",
+  },
+  SLOW_BLINK: {
+    id: "components.LedBehaviorDropdown.behavior.slowBlinkLED",
+    defaultMessage: "Slow blink LED",
+  },
+});
+
+function isSupportedLedBehavior(value: unknown): value is SupportedLedBehavior {
+  return (
+    typeof value === "string" &&
+    SUPPORTED_LED_BEHAVIORS.includes(value as SupportedLedBehavior)
+  );
+}
+
+interface Props {
+  deviceId: string;
+  disabled: boolean;
+}
+
+const LedBehaviorDropdown = ({ deviceId, disabled }: Props) => {
+  const intl = useIntl();
+
+  const [setLedBehavior, isSettingLedBehavior] =
+    useMutation<LedBehaviorDropdown_setLedBehavior_Mutation>(
+      SET_LED_BEHAVIOR_MUTATION
+    );
+
+  const handleSetLedBehavior = useCallback(
+    (ledBehavior: unknown) => {
+      if (!isSupportedLedBehavior(ledBehavior)) {
+        return;
+      }
+
+      setLedBehavior({
+        variables: {
+          input: {
+            deviceId,
+            behavior: ledBehavior,
+          },
+        },
+      });
+    },
+    [setLedBehavior, deviceId]
+  );
+
+  return (
+    <Dropdown as={ButtonGroup} onSelect={handleSetLedBehavior}>
+      <Dropdown.Toggle
+        variant="secondary"
+        disabled={disabled || isSettingLedBehavior}
+      >
+        {isSettingLedBehavior && (
+          <Spinner as="span" size="sm" className="me-2" aria-hidden="true" />
+        )}
+        <FormattedMessage
+          id="components.LedBehaviorDropdown.identify"
+          defaultMessage="Identify"
+        />
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        {SUPPORTED_LED_BEHAVIORS.map((behavior) => (
+          <Dropdown.Item eventKey={behavior} key={behavior}>
+            {intl.formatMessage(supportedBehaviorMessages[behavior])}
+          </Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+export default LedBehaviorDropdown;

--- a/frontend/src/components/LedBehaviorDropdown.tsx
+++ b/frontend/src/components/LedBehaviorDropdown.tsx
@@ -24,6 +24,8 @@ import type { MessageDescriptor } from "react-intl";
 
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Dropdown from "react-bootstrap/Dropdown";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Tooltip from "react-bootstrap/Tooltip";
 
 import Button from "components/Button";
 import Icon from "components/Icon";
@@ -150,27 +152,38 @@ const LedBehaviorDropdown = ({ deviceId, disabled, onError }: Props) => {
   }
 
   return (
-    <Dropdown as={ButtonGroup} onSelect={handleSetLedBehavior}>
-      <Dropdown.Toggle
-        variant="secondary"
-        disabled={disabled || isSettingLedBehavior}
-      >
-        {isSettingLedBehavior && (
-          <Spinner as="span" size="sm" className="me-2" aria-hidden="true" />
-        )}
-        <FormattedMessage
-          id="components.LedBehaviorDropdown.identify"
-          defaultMessage="Identify"
-        />
-      </Dropdown.Toggle>
-      <Dropdown.Menu>
-        {SUPPORTED_LED_BEHAVIORS.map((behavior) => (
-          <Dropdown.Item eventKey={behavior} key={behavior}>
-            {intl.formatMessage(supportedBehaviorMessages[behavior])}
-          </Dropdown.Item>
-        ))}
-      </Dropdown.Menu>
-    </Dropdown>
+    <OverlayTrigger
+      overlay={
+        <Tooltip>
+          <FormattedMessage
+            id="components.LedBehaviorDropdown.tooltip"
+            defaultMessage="The device LED will blink for 60s."
+          />
+        </Tooltip>
+      }
+    >
+      <Dropdown as={ButtonGroup} onSelect={handleSetLedBehavior}>
+        <Dropdown.Toggle
+          variant="secondary"
+          disabled={disabled || isSettingLedBehavior}
+        >
+          {isSettingLedBehavior && (
+            <Spinner as="span" size="sm" className="me-2" aria-hidden="true" />
+          )}
+          <FormattedMessage
+            id="components.LedBehaviorDropdown.identify"
+            defaultMessage="Identify"
+          />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {SUPPORTED_LED_BEHAVIORS.map((behavior) => (
+            <Dropdown.Item eventKey={behavior} key={behavior}>
+              {intl.formatMessage(supportedBehaviorMessages[behavior])}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </OverlayTrigger>
   );
 };
 

--- a/frontend/src/components/LedBehaviorDropdown.tsx
+++ b/frontend/src/components/LedBehaviorDropdown.tsx
@@ -74,9 +74,10 @@ function isSupportedLedBehavior(value: unknown): value is SupportedLedBehavior {
 interface Props {
   deviceId: string;
   disabled: boolean;
+  onError: (error: React.ReactNode) => void;
 }
 
-const LedBehaviorDropdown = ({ deviceId, disabled }: Props) => {
+const LedBehaviorDropdown = ({ deviceId, disabled, onError }: Props) => {
   const intl = useIntl();
 
   const [setLedBehavior, isSettingLedBehavior] =
@@ -97,9 +98,25 @@ const LedBehaviorDropdown = ({ deviceId, disabled }: Props) => {
             behavior: ledBehavior,
           },
         },
+        onCompleted(data, errors) {
+          if (errors) {
+            const errorFeedback = errors
+              .map((error) => error.message)
+              .join(". \n");
+            return onError(errorFeedback);
+          }
+        },
+        onError(error) {
+          onError(
+            <FormattedMessage
+              id="components.LedBehaviorDropdown.genericErrorFeedback"
+              defaultMessage="The request could not reach the server, please try again."
+            />
+          );
+        },
       });
     },
-    [setLedBehavior, deviceId]
+    [setLedBehavior, deviceId, onError]
   );
 
   return (

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021 SECO Mind Srl
+  Copyright 2021-2022 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ import BoostrapSpinner from "react-bootstrap/Spinner";
 
 type BoostrapSpinnerProps = React.ComponentProps<typeof BoostrapSpinner>;
 
-type Props = Pick<BoostrapSpinnerProps, "className" | "size" | "variant">;
+type Props = Pick<
+  BoostrapSpinnerProps,
+  "className" | "size" | "variant" | "as" | "aria-hidden"
+>;
 
 const Spinner = (props: Props) => {
   return <BoostrapSpinner animation="border" role="status" {...props} />;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -11,6 +11,9 @@
   "Device.baseImage.version": {
     "defaultMessage": "Version"
   },
+  "Device.checkMyDevice": {
+    "defaultMessage": "Check my Device"
+  },
   "Device.connectionStatus": {
     "defaultMessage": "Connection"
   },
@@ -218,6 +221,24 @@
   },
   "components.LastSeen.now": {
     "defaultMessage": "Now"
+  },
+  "components.LedBehaviorDropdown.behavior.blinkLED": {
+    "defaultMessage": "Blink LED"
+  },
+  "components.LedBehaviorDropdown.behavior.doubleBlinkLED": {
+    "defaultMessage": "Double blink LED"
+  },
+  "components.LedBehaviorDropdown.behavior.slowBlinkLED": {
+    "defaultMessage": "Slow blink LED"
+  },
+  "components.LedBehaviorDropdown.genericErrorFeedback": {
+    "defaultMessage": "The request could not reach the server, please try again."
+  },
+  "components.LedBehaviorDropdown.identify": {
+    "defaultMessage": "Identify"
+  },
+  "components.LedBehaviorDropdown.tooltip": {
+    "defaultMessage": "The device LED will blink for 60s."
   },
   "components.OperationTable.baseImage": {
     "defaultMessage": "Base Image"

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -62,6 +62,7 @@ import Col from "components/Col";
 import Figure from "components/Figure";
 import Form from "components/Form";
 import LastSeen from "components/LastSeen";
+import LedBehaviorDropdown from "components/LedBehaviorDropdown";
 import Map from "components/Map";
 import OperationTable from "components/OperationTable";
 import Page from "components/Page";
@@ -1294,6 +1295,20 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
                         online={device.online}
                       />
                     </FormValue>
+                  </FormRow>
+                  <FormRow
+                    id="form-device-check-my-device"
+                    label={
+                      <FormattedMessage
+                        id="Device.checkMyDevice"
+                        defaultMessage="Check my Device"
+                      />
+                    }
+                  >
+                    <LedBehaviorDropdown
+                      deviceId={device.id}
+                      disabled={!device.online}
+                    />
                   </FormRow>
                 </Stack>
               </Form>

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -1104,8 +1104,7 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
 
   const [deviceDraft, setDeviceDraft] = useState(_.pick(device, ["name"]));
 
-  const [updateErrorFeedback, setUpdateErrorFeedback] =
-    useState<React.ReactNode>(null);
+  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
 
   const [updateDevice] = useMutation<Device_updateDevice_Mutation>(
     UPDATE_DEVICE_MUTATION
@@ -1123,15 +1122,15 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
             onCompleted(data, errors) {
               if (errors) {
                 setDeviceDraft(draft);
-                const updateErrorFeedback = errors
+                const errorFeedback = errors
                   .map((error) => error.message)
                   .join(". \n");
-                return setUpdateErrorFeedback(updateErrorFeedback);
+                return setErrorFeedback(errorFeedback);
               }
             },
             onError(error) {
               setDeviceDraft(draft);
-              setUpdateErrorFeedback(
+              setErrorFeedback(
                 <FormattedMessage
                   id="pages.Device.updateDeviceErrorFeedback"
                   defaultMessage="Could not update the device, please try again."
@@ -1181,12 +1180,12 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
       <Page.Main>
         <Stack gap={3}>
           <Alert
-            show={!!updateErrorFeedback}
+            show={!!errorFeedback}
             variant="danger"
-            onClose={() => setUpdateErrorFeedback(null)}
+            onClose={() => setErrorFeedback(null)}
             dismissible
           >
-            {updateErrorFeedback}
+            {errorFeedback}
           </Alert>
           <Row>
             <Col md="5" lg="4" xl="3">
@@ -1308,6 +1307,7 @@ const DeviceContent = ({ getDeviceQuery }: DeviceContentProps) => {
                     <LedBehaviorDropdown
                       deviceId={device.id}
                       disabled={!device.online}
+                      onError={setErrorFeedback}
                     />
                   </FormRow>
                 </Stack>


### PR DESCRIPTION
Closes #105 

Adds `Identify` dropdown on Device page.
![device_connected](https://user-images.githubusercontent.com/26611935/156815563-0a33d66b-d29a-421f-ab96-ec4efa8cb742.png)

Disables dropdown for disconnected device.
![device_disconnected](https://user-images.githubusercontent.com/26611935/156815617-64817db5-3d29-403a-852a-4064afef6acd.png)

Shows tooltip
![tooltip](https://user-images.githubusercontent.com/26611935/156815699-93513d39-7b7f-4c13-a9d0-4629d62cc157.png)

Disables dropdown while mutation in flight and maybe shows error

https://user-images.githubusercontent.com/26611935/156815870-3fcff0e3-118c-4e05-a012-e0ee46a76543.mp4

Shows selected LED behavior after mutation success for 10 seconds.

https://user-images.githubusercontent.com/26611935/156816027-3febd1fc-8c04-4af3-a8a0-35ee53aae9a4.mp4


