### PR TITLE
[backend] Add device Geolocation module

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -42,6 +42,7 @@ config :edgehog, :astarte_os_info_module, Edgehog.Astarte.Device.OSInfoMock
 config :edgehog, :astarte_ota_request_module, Edgehog.Astarte.Device.OTARequestMock
 config :edgehog, :astarte_runtime_info_module, Edgehog.Astarte.Device.RuntimeInfoMock
 config :edgehog, :astarte_led_behavior_module, Edgehog.Astarte.Device.LedBehaviorMock
+config :edgehog, :astarte_geolocation_module, Edgehog.Astarte.Device.GeolocationMock
 
 config :edgehog,
        :astarte_cellular_connection_module,

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -32,6 +32,7 @@ defmodule Edgehog.Astarte do
     BatteryStatus,
     CellularConnection,
     DeviceStatus,
+    Geolocation,
     HardwareInfo,
     LedBehavior,
     OSInfo,
@@ -87,6 +88,7 @@ defmodule Edgehog.Astarte do
                          :astarte_led_behavior_module,
                          LedBehavior
                        )
+  @geolocation_module Application.compile_env(:edgehog, :astarte_geolocation_module, Geolocation)
 
   @doc """
   Returns the list of clusters.
@@ -607,6 +609,12 @@ defmodule Edgehog.Astarte do
   def fetch_system_status(%Device{} = device) do
     with {:ok, client} <- appengine_client_from_device(device) do
       @system_status_module.get(client, device.device_id)
+    end
+  end
+
+  def fetch_geolocation(%Device{} = device) do
+    with {:ok, client} <- appengine_client_from_device(device) do
+      @geolocation_module.get(client, device.device_id)
     end
   end
 

--- a/backend/lib/edgehog/astarte/device/geolocation.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation.ex
@@ -1,0 +1,65 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.Geolocation do
+  @behaviour Edgehog.Astarte.Device.Geolocation.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+
+  @interface "io.edgehog.devicemanager.Geolocation"
+
+  def get(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1),
+         {:ok, sensors_positions} <- parse_data(data) do
+      {:ok, sensors_positions}
+    end
+  end
+
+  def parse_data(data) do
+    sensors_positions =
+      data
+      |> Enum.map(fn {sensor_id, [sensor_data]} ->
+        %SensorPosition{
+          sensor_id: sensor_id,
+          latitude: sensor_data["latitude"],
+          longitude: sensor_data["longitude"],
+          altitude: sensor_data["altitude"],
+          accuracy: sensor_data["accuracy"],
+          altitude_accuracy: sensor_data["altitudeAccuracy"],
+          heading: sensor_data["heading"],
+          speed: sensor_data["speed"],
+          timestamp: parse_datetime(sensor_data["timestamp"])
+        }
+      end)
+
+    {:ok, sensors_positions}
+  end
+
+  defp parse_datetime(nil) do
+    nil
+  end
+
+  defp parse_datetime(datetime_string) do
+    case DateTime.from_iso8601(datetime_string) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+end

--- a/backend/lib/edgehog/astarte/device/geolocation/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation/behaviour.ex
@@ -1,0 +1,25 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.Geolocation.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+
+  @callback get(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(SensorPosition.t())} | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/device/geolocation/sensor_position.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation/sensor_position.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.Geolocation.SensorPosition do
+  @type t :: %__MODULE__{
+          sensor_id: String.t(),
+          latitude: float() | nil,
+          longitude: float() | nil,
+          altitude: float() | nil,
+          accuracy: float() | nil,
+          altitude_accuracy: float() | nil,
+          heading: float() | nil,
+          speed: float() | nil,
+          timestamp: DateTime.t()
+        }
+
+  @enforce_keys [
+    :sensor_id,
+    :latitude,
+    :longitude,
+    :altitude,
+    :accuracy,
+    :altitude_accuracy,
+    :heading,
+    :speed,
+    :timestamp
+  ]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -49,12 +49,16 @@ defmodule Edgehog.Config do
 
   @envdoc """
   A comma separated list of preferred geolocation providers.
-  Possible values are: freegeoip, google
+  Possible values are: device, google, freegeoip.
   """
   app_env :preferred_geolocation_providers, :edgehog, :preferred_geolocation_providers,
     os_env: "PREFERRED_GEOLOCATION_PROVIDERS",
     type: GeolocationProviders,
-    default: [Geolocation.Providers.GoogleGeolocation, Geolocation.Providers.FreeGeoIp]
+    default: [
+      Geolocation.Providers.DeviceGeolocation,
+      Geolocation.Providers.GoogleGeolocation,
+      Geolocation.Providers.FreeGeoIp
+    ]
 
   @envdoc """
   A comma separated list of preferred geocoding providers.

--- a/backend/lib/edgehog/config/geolocation_providers.ex
+++ b/backend/lib/edgehog/config/geolocation_providers.ex
@@ -20,6 +20,7 @@ defmodule Edgehog.Config.GeolocationProviders do
   use Skogsra.Type
 
   @providers %{
+    "device" => Edgehog.Geolocation.Providers.DeviceGeolocation,
     "freegeoip" => Edgehog.Geolocation.Providers.FreeGeoIp,
     "google" => Edgehog.Geolocation.Providers.GoogleGeolocation
   }

--- a/backend/lib/edgehog/geolocation/providers/device_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/device_geolocation.ex
@@ -1,0 +1,69 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Geolocation.Providers.DeviceGeolocation do
+  @behaviour Edgehog.Geolocation.GeolocationProvider
+
+  alias Edgehog.Astarte
+  alias Edgehog.Astarte.Device
+  alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+  alias Edgehog.Geolocation.Position
+
+  @impl Edgehog.Geolocation.GeolocationProvider
+  def geolocate(%Device{} = device) do
+    with {:ok, sensors_positions} <- Astarte.fetch_geolocation(device),
+         {:ok, sensors_positions} <- filter_latest_sensors_positions(sensors_positions),
+         {:ok, position} <- geolocate_sensors(sensors_positions) do
+      {:ok, position}
+    end
+  end
+
+  defp filter_latest_sensors_positions([_position | _] = sensors_positions) do
+    latest_position = Enum.max_by(sensors_positions, & &1.timestamp, DateTime)
+
+    latest_sensors_positions =
+      Enum.filter(
+        sensors_positions,
+        &(DateTime.diff(latest_position.timestamp, &1.timestamp, :second) < 1)
+      )
+
+    {:ok, latest_sensors_positions}
+  end
+
+  defp filter_latest_sensors_positions(_empty_list) do
+    {:error, :sensors_positions_not_found}
+  end
+
+  defp geolocate_sensors([%SensorPosition{} | _] = sensors_positions) do
+    # Take the position with the accuracy closest to 0. Also note that number < :nil
+    sensor_position = Enum.min_by(sensors_positions, & &1.accuracy)
+
+    position = %Position{
+      latitude: sensor_position.latitude,
+      longitude: sensor_position.longitude,
+      accuracy: sensor_position.accuracy,
+      timestamp: sensor_position.timestamp
+    }
+
+    {:ok, position}
+  end
+
+  defp geolocate_sensors(_empty_list) do
+    {:error, :position_not_found}
+  end
+end

--- a/backend/test/edgehog/astarte/device/geolocation_test.exs
+++ b/backend/test/edgehog/astarte/device/geolocation_test.exs
@@ -1,0 +1,107 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Astarte.Device.GeolocationTest do
+  use Edgehog.DataCase
+
+  alias Edgehog.Astarte.Device.Geolocation
+  alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+  alias Astarte.Client.AppEngine
+
+  describe "geolocation" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+
+      {:ok, appengine_client} =
+        AppEngine.new(cluster.base_api_url, realm.name, private_key: realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "get/2 correctly parses geolocation data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "gps1" => [
+            %{
+              "latitude" => 45.4095285,
+              "longitude" => 11.8788231,
+              "altitude" => nil,
+              "accuracy" => 0,
+              "altitudeAccuracy" => nil,
+              "heading" => nil,
+              "speed" => nil,
+              "timestamp" => "2021-11-30T10:45:00.575Z"
+            }
+          ],
+          "gps2" => [
+            %{
+              "latitude" => 45.4,
+              "longitude" => 11.9,
+              "altitude" => nil,
+              "accuracy" => 50,
+              "altitudeAccuracy" => nil,
+              "heading" => nil,
+              "speed" => nil,
+              "timestamp" => "2021-11-30T10:45:00.575Z"
+            }
+          ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, sensors_positions} = Geolocation.get(appengine_client, device.device_id)
+
+      assert sensors_positions == [
+               %SensorPosition{
+                 sensor_id: "gps1",
+                 latitude: 45.4095285,
+                 longitude: 11.8788231,
+                 altitude: nil,
+                 accuracy: 0,
+                 altitude_accuracy: nil,
+                 heading: nil,
+                 speed: nil,
+                 timestamp: ~U[2021-11-30 10:45:00.575Z]
+               },
+               %SensorPosition{
+                 sensor_id: "gps2",
+                 latitude: 45.4,
+                 longitude: 11.9,
+                 altitude: nil,
+                 accuracy: 50,
+                 altitude_accuracy: nil,
+                 heading: nil,
+                 speed: nil,
+                 timestamp: ~U[2021-11-30 10:45:00.575Z]
+               }
+             ]
+    end
+  end
+end

--- a/backend/test/edgehog/geolocation/providers/device_geolocation_test.exs
+++ b/backend/test/edgehog/geolocation/providers/device_geolocation_test.exs
@@ -1,0 +1,80 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Geolocation.Providers.DeviceGeolocationTest do
+  use Edgehog.DataCase
+  use Edgehog.AstarteMockCase
+
+  import Edgehog.AstarteFixtures
+  alias Edgehog.Geolocation.Position
+  alias Edgehog.Geolocation.Providers.DeviceGeolocation
+
+  describe "device_geolocation" do
+    alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = device_fixture(realm)
+
+      {:ok, cluster: cluster, realm: realm, device: device}
+    end
+
+    test "geolocate/1 returns error without input SensorPosition list", %{device: device} do
+      Edgehog.Astarte.Device.GeolocationMock
+      |> expect(:get, fn _appengine_client, _device_id -> {:ok, []} end)
+
+      assert DeviceGeolocation.geolocate(device) == {:error, :sensors_positions_not_found}
+    end
+
+    test "geolocate/1 returns position from SensorPosition list", %{device: device} do
+      sensors_positions = [
+        %SensorPosition{
+          sensor_id: "gps1",
+          latitude: 45.4095285,
+          longitude: 11.8788231,
+          altitude: nil,
+          accuracy: 0,
+          altitude_accuracy: nil,
+          heading: nil,
+          speed: nil,
+          timestamp: ~U[2021-11-30 10:45:00.575Z]
+        }
+      ]
+
+      Edgehog.Astarte.Device.GeolocationMock
+      |> expect(:get, fn _appengine_client, _device_id -> {:ok, sensors_positions} end)
+
+      assert {:ok, position} = DeviceGeolocation.geolocate(device)
+
+      assert %Position{
+               accuracy: 0,
+               latitude: 45.4095285,
+               longitude: 11.8788231,
+               timestamp: ~U[2021-11-30 10:45:00.575Z]
+             } == position
+    end
+
+    test "geolocate/1 returns error if fetching from the device fails", %{device: device} do
+      Edgehog.Astarte.Device.GeolocationMock
+      |> expect(:get, fn _appengine_client, _device_id -> {:error, :some_astarte_error} end)
+
+      assert {:error, :some_astarte_error} == DeviceGeolocation.geolocate(device)
+    end
+  end
+end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -77,6 +77,11 @@ defmodule Edgehog.AstarteMockCase do
     )
 
     Mox.stub_with(
+      Edgehog.Astarte.Device.GeolocationMock,
+      Edgehog.Mocks.Astarte.Device.Geolocation
+    )
+
+    Mox.stub_with(
       Edgehog.Astarte.Device.WiFiScanResultMock,
       Edgehog.Mocks.Astarte.Device.WiFiScanResult
     )

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -40,6 +40,10 @@ Mox.defmock(Edgehog.Astarte.Device.SystemStatusMock,
   for: Edgehog.Astarte.Device.SystemStatus.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.GeolocationMock,
+  for: Edgehog.Astarte.Device.Geolocation.Behaviour
+)
+
 Mox.defmock(Edgehog.Astarte.Device.WiFiScanResultMock,
   for: Edgehog.Astarte.Device.WiFiScanResult.Behaviour
 )

--- a/backend/test/support/mocks/astarte/device/geolocation.ex
+++ b/backend/test/support/mocks/astarte/device/geolocation.ex
@@ -1,0 +1,43 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.Geolocation do
+  @behaviour Edgehog.Astarte.Device.Geolocation.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.Geolocation.SensorPosition
+
+  @impl true
+  def get(%AppEngine{} = _client, _device_id) do
+    sensors_positions = [
+      %SensorPosition{
+        sensor_id: "gps1",
+        latitude: 45.4095285,
+        longitude: 11.8788231,
+        altitude: nil,
+        accuracy: 0,
+        altitude_accuracy: nil,
+        heading: nil,
+        speed: nil,
+        timestamp: ~U[2021-11-30 10:45:00.575Z]
+      }
+    ]
+
+    {:ok, sensors_positions}
+  end
+end

--- a/doc/pages/integrating/interacting_with_edgehog.md
+++ b/doc/pages/integrating/interacting_with_edgehog.md
@@ -55,12 +55,12 @@ A Device can expose this set of data via the
 To expose info about its current status or measured data, some additional Astarte Interfaces are
 already defined for Edgehog. Their adoption is optional but recommended.
 
-This section reports an overview on the current system status of the Device.
-
 - [io.edgehog.devicemanager.SystemStatus](astarte_interfaces.html): reports the current OS status.
 - [io.edgehog.devicemanager.StorageUsage](astarte_interfaces.html): reports the capacity and usage
   of the storage units.
 - [io.edgehog.devicemanager.BatteryStatus](astarte_interfaces.html): reports the current status of
   the battery slots.
+- [io.edgehog.devicemanager.Geolocation](astarte_interfaces.html): reports the current position
+  computed by the GPS sensors of the device.
 - [io.edgehog.devicemanager.WiFiScanResults](astarte_interfaces.html): reports the list of nearby
   Access Points that the Device found while scanning for WiFi signals.

--- a/doc/pages/user/devices.md
+++ b/doc/pages/user/devices.md
@@ -111,7 +111,10 @@ estimate a set of GPS coordinates.
 
 Depending on the data exposed by the Device, the coordinates can be estimated from:
 
-- nearby WiFi APs that the Device detected recently
+- the GPS position published via the Astarte interface
+  [io.edgehog.devicemanager.Geolocation](astarte_interfaces.html).
+- nearby WiFi APs that the Device detected recently, published via the Astarte interface
+  [io.edgehog.devicemanager.WiFiScanResults](astarte_interfaces.html)
 - the IP address used by the Device to connect to Astarte
 
 Based on the available data, Edgehog's geolocation modules try to find to best estimate by relying


### PR DESCRIPTION
- Add a module to fetch the device's data from the Astarte interface `io.edgehog.devicemanager.Geolocation`.
- Use the module to set up a preferred Geolocation Provider that computes the device's position from that data.

Closes #141 