### PR TITLE
Handle device missing interfaces with device capabilities query

### DIFF
--- a/backend/lib/edgehog/astarte/interface_id.ex
+++ b/backend/lib/edgehog/astarte/interface_id.ex
@@ -1,0 +1,4 @@
+defmodule Edgehog.Astarte.InterfaceID do
+  @enforce_keys [:name, :major, :minor]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -73,6 +73,13 @@ defmodule EdgehogWeb.Resolvers.Astarte do
     Astarte.preload_system_model_for_device(target, preload: preload)
   end
 
+  def list_device_capabilities(%Device{} = device, _args, _context) do
+    case Astarte.fetch_device_introspection(device) do
+      {:ok, introspection} -> Astarte.get_device_capabilities(introspection)
+      _ -> []
+    end
+  end
+
   def get_hardware_info(%Device{} = device, _args, _context) do
     Astarte.get_hardware_info(device)
   end

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -340,6 +340,44 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
   end
 
   @desc """
+  The capabilities that devices can support
+  """
+  enum :device_capability do
+    @desc "The device provides information about its base image."
+    value :base_image
+    @desc "The device provides information about its battery status."
+    value :battery_status
+    @desc "The device provides information about its cellular connection."
+    value :cellular_connection
+    @desc "The device supports commands, for example the rebooting command."
+    value :commands
+    @desc "The device can be geolocated."
+    value :geolocation
+    @desc "The device provides information about its hardware."
+    value :hardware_info
+    @desc "The device can be asked to blink its LED in a specific pattern."
+    value :led_behaviors
+    @desc "The device can provide information about its network interfaces."
+    value :network_interface_info
+    @desc "The device provides information about its operating system."
+    value :operating_system
+    @desc "The device provides information about its runtime."
+    value :runtime_info
+    @desc "The device can be updated remotely."
+    value :software_updates
+    @desc "The device provides information about its storage units."
+    value :storage
+    @desc "The device provides information about its system."
+    value :system_info
+    @desc "The device provides information about its system status."
+    value :system_status
+    @desc "The device telemetry can be configured."
+    value :telemetry_config
+    @desc "The device provides information about surrounding WiFi APs."
+    value :wifi
+  end
+
+  @desc """
   Denotes a device instance that connects and exchanges data.
 
   Each Device is associated to a specific SystemModel, which in turn is \
@@ -365,6 +403,12 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
 
     @desc "The system model of the device."
     field :system_model, :system_model
+
+    @desc "List of capabilities supported by the device."
+    field :capabilities, non_null(list_of(non_null(:device_capability))) do
+      resolve &Resolvers.Astarte.list_device_capabilities/3
+      middleware Middleware.ErrorHandler
+    end
 
     @desc "Info read from the device's hardware."
     field :hardware_info, :hardware_info do

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -602,5 +602,98 @@ defmodule Edgehog.AstarteTest do
       assert device.part_number == part_number
       assert device.system_model.id == system_model.id
     end
+
+    test "get_device_capabilities/1 returns all capabilities if interfaces are implemented by the device",
+         _ do
+      device_introspection = %{
+        "io.edgehog.devicemanager.BaseImage" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.Commands" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.HardwareInfo" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.LedBehavior" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.NetworkInterfaceProperties" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.OSInfo" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.RuntimeInfo" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.OTARequest" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.OTAResponse" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.StorageUsage" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.SystemInfo" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.SystemStatus" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.config.Telemetry" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.WiFiScanResults" => %{"major" => 0, "minor" => 1}
+      }
+
+      expected_capabilities = [
+        :base_image,
+        :battery_status,
+        :cellular_connection,
+        :commands,
+        :geolocation,
+        :hardware_info,
+        :led_behaviors,
+        :network_interface_info,
+        :operating_system,
+        :runtime_info,
+        :software_updates,
+        :storage,
+        :system_info,
+        :system_status,
+        :telemetry_config,
+        :wifi
+      ]
+
+      assert Enum.sort(expected_capabilities) ==
+               Enum.sort(Astarte.get_device_capabilities(device_introspection))
+    end
+
+    test "get_device_capabilities/1 returns a capability only if all its interfaces are supported by the device",
+         _ do
+      partial_introspection_1 = %{
+        "io.edgehog.devicemanager.OTARequest" => %{"major" => 0, "minor" => 1}
+      }
+
+      partial_introspection_2 = %{
+        "io.edgehog.devicemanager.OTAResponse" => %{"major" => 0, "minor" => 1}
+      }
+
+      assert :software_updates not in Astarte.get_device_capabilities(partial_introspection_1)
+      assert :software_updates not in Astarte.get_device_capabilities(partial_introspection_2)
+    end
+
+    test "get_device_capabilities/1 returns only geolocation if no interface is supported by the device",
+         _ do
+      assert [:geolocation] = Astarte.get_device_capabilities(%{})
+    end
+
+    test "get_device_capabilities/1 should not fail when devices uses a minor greater than the one required",
+         _ do
+      device_introspection = %{
+        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 0, "minor" => 2},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 0, "minor" => 1},
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 3}
+      }
+
+      expected_capabilities = [
+        :battery_status,
+        :cellular_connection,
+        :geolocation
+      ]
+
+      assert Enum.sort(expected_capabilities) ==
+               Enum.sort(Astarte.get_device_capabilities(device_introspection))
+    end
+
+    test "get_device_capabilities/1 should not return a capability if major version mismatches",
+         _ do
+      device_introspection = %{
+        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 1, "minor" => 0},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 1, "minor" => 1},
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 1}
+      }
+
+      assert [:geolocation] = Astarte.get_device_capabilities(device_introspection)
+    end
   end
 end

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -214,6 +214,57 @@ type DeviceLocation {
   timestamp: DateTime!
 }
 
+"The capabilities that devices can support"
+enum DeviceCapability {
+  "The device provides information about its base image."
+  BASE_IMAGE
+
+  "The device provides information about its battery status."
+  BATTERY_STATUS
+
+  "The device provides information about its cellular connection."
+  CELLULAR_CONNECTION
+
+  "The device supports commands, for example the rebooting command."
+  COMMANDS
+
+  "The device can be geolocated."
+  GEOLOCATION
+
+  "The device provides information about its hardware."
+  HARDWARE_INFO
+
+  "The device can be asked to blink its LED in a specific pattern."
+  LED_BEHAVIORS
+
+  "The device can provide information about its network interfaces."
+  NETWORK_INTERFACE_INFO
+
+  "The device provides information about its operating system."
+  OPERATING_SYSTEM
+
+  "The device provides information about its runtime."
+  RUNTIME_INFO
+
+  "The device can be updated remotely."
+  SOFTWARE_UPDATES
+
+  "The device provides information about its storage units."
+  STORAGE
+
+  "The device provides information about its system."
+  SYSTEM_INFO
+
+  "The device provides information about its system status."
+  SYSTEM_STATUS
+
+  "The device telemetry can be configured."
+  TELEMETRY_CONFIG
+
+  "The device provides information about surrounding WiFi APs."
+  WIFI
+}
+
 interface Node {
   "The ID of the object."
   id: ID!
@@ -461,6 +512,9 @@ type Device implements Node {
 
   "The system model of the device."
   systemModel: SystemModel
+
+  "List of capabilities supported by the device."
+  capabilities: [DeviceCapability!]!
 
   "Info read from the device's hardware."
   hardwareInfo: HardwareInfo

--- a/frontend/src/components/CellularConnectionTabs.tsx
+++ b/frontend/src/components/CellularConnectionTabs.tsx
@@ -28,6 +28,7 @@ import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
 
 import Form from "components/Form";
+import Result from "components/Result";
 import Stack from "components/Stack";
 
 import type {
@@ -337,7 +338,21 @@ const CellularConnectionTabs = ({ deviceRef }: Props) => {
   );
 
   if (!cellularConnection || cellularConnection.length === 0) {
-    return null;
+    return (
+      <Result.EmptyList
+        title={
+          <FormattedMessage
+            id="pages.Device.DeviceCellularConnectionTab.noModems.title"
+            defaultMessage="No modem"
+          />
+        }
+      >
+        <FormattedMessage
+          id="pages.Device.DeviceCellularConnectionTab.noModems.message"
+          defaultMessage="The device has not detected any modems yet."
+        />
+      </Result.EmptyList>
+    );
   }
 
   return (


### PR DESCRIPTION
Allow the frontend or other GrahQL clients to query the device capabilities. This is a useful information if you want to know what the device actually supports and act accordingly.

Closes #112

Signed-off-by: Mattia Pavinati <mattia.pavinati@secomind.com>