### PR TITLE
[backend] Get device introspection using device_status_module

### DIFF
--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -27,6 +27,7 @@ defmodule Edgehog.Astarte do
   alias Astarte.Client.AppEngine
   alias Edgehog.Astarte.Cluster
   alias Edgehog.Astarte.InterfaceID
+  alias Edgehog.Astarte.InterfaceVersion
 
   alias Edgehog.Astarte.Device.{
     BaseImage,
@@ -736,8 +737,8 @@ defmodule Edgehog.Astarte do
   #      and following functions can use preloaded data
   def fetch_device_introspection(%Device{} = device) do
     with {:ok, client} <- appengine_client_from_device(device),
-         {:ok, %{"data" => %{"introspection" => introspection}}} <-
-           Astarte.Client.AppEngine.Devices.get_device_status(client, device.device_id) do
+         {:ok, %DeviceStatus{introspection: introspection}} <-
+           @device_status_module.get(client, device.device_id) do
       {:ok, introspection}
     end
   end
@@ -774,7 +775,7 @@ defmodule Edgehog.Astarte do
 
   defp interface_supported?(introspection, %InterfaceID{} = interface) do
     case Map.fetch(introspection, interface.name) do
-      {:ok, %{"major" => major, "minor" => minor}} ->
+      {:ok, %InterfaceVersion{major: major, minor: minor}} ->
         major == interface.major && minor >= interface.minor
 
       _ ->

--- a/backend/lib/edgehog/astarte/device/device_status.ex
+++ b/backend/lib/edgehog/astarte/device/device_status.ex
@@ -18,30 +18,54 @@
 
 defmodule Edgehog.Astarte.Device.DeviceStatus do
   defstruct [
+    :attributes,
+    :groups,
+    :introspection,
     :last_connection,
     :last_disconnection,
+    :last_seen_ip,
     :online,
-    :last_seen_ip
+    :previous_interfaces
   ]
 
   @behaviour Edgehog.Astarte.Device.DeviceStatus.Behaviour
 
   alias Astarte.Client.AppEngine
   alias Edgehog.Astarte.Device.DeviceStatus
+  alias Edgehog.Astarte.InterfaceVersion
 
   @impl true
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
            AppEngine.Devices.get_device_status(client, device_id) do
       device_status = %DeviceStatus{
+        attributes: data["attributes"],
+        groups: data["groups"],
+        introspection: build_introspection(data["introspection"]),
         last_connection: parse_datetime(data["last_connection"]),
         last_disconnection: parse_datetime(data["last_disconnection"]),
+        last_seen_ip: data["last_seen_ip"],
         online: data["connected"] || false,
-        last_seen_ip: data["last_seen_ip"]
+        previous_interfaces: data["previous_interfaces"]
       }
 
       {:ok, device_status}
     end
+  end
+
+  defp build_introspection(nil) do
+    %{}
+  end
+
+  defp build_introspection(interfaces_map) do
+    Enum.map(interfaces_map, fn {name, info} ->
+      {name,
+       %InterfaceVersion{
+         major: info["major"],
+         minor: info["minor"]
+       }}
+    end)
+    |> Map.new()
   end
 
   defp parse_datetime(nil) do

--- a/backend/lib/edgehog/astarte/interface_version.ex
+++ b/backend/lib/edgehog/astarte/interface_version.ex
@@ -1,0 +1,24 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.InterfaceVersion do
+  @enforce_keys [:major, :minor]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -74,9 +74,11 @@ defmodule EdgehogWeb.Resolvers.Astarte do
   end
 
   def list_device_capabilities(%Device{} = device, _args, _context) do
-    case Astarte.fetch_device_introspection(device) do
-      {:ok, introspection} -> Astarte.get_device_capabilities(introspection)
-      _ -> []
+    with {:ok, introspection} <- Astarte.fetch_device_introspection(device),
+         capabilities = Astarte.get_device_capabilities(introspection) do
+      {:ok, capabilities}
+    else
+      _ -> {:ok, []}
     end
   end
 

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -140,6 +140,7 @@ defmodule Edgehog.AstarteTest do
 
   describe "devices" do
     alias Edgehog.Astarte.Device
+    alias Edgehog.Astarte.InterfaceVersion
 
     import Edgehog.AstarteFixtures
     import Edgehog.DevicesFixtures
@@ -603,26 +604,34 @@ defmodule Edgehog.AstarteTest do
       assert device.system_model.id == system_model.id
     end
 
-    test "get_device_capabilities/1 returns all capabilities if interfaces are implemented by the device",
-         _ do
+    test "get_device_capabilities/1 returns all capabilities if interfaces are implemented by the device" do
       device_introspection = %{
-        "io.edgehog.devicemanager.BaseImage" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.Commands" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.HardwareInfo" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.LedBehavior" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.NetworkInterfaceProperties" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.OSInfo" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.RuntimeInfo" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.OTARequest" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.OTAResponse" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.StorageUsage" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.SystemInfo" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.SystemStatus" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.config.Telemetry" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.WiFiScanResults" => %{"major" => 0, "minor" => 1}
+        "io.edgehog.devicemanager.BaseImage" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.BatteryStatus" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.Commands" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.HardwareInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.LedBehavior" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.NetworkInterfaceProperties" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.OSInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.RuntimeInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.OTAResponse" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.StorageUsage" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.SystemInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.SystemStatus" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.config.Telemetry" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.WiFiScanResults" => %InterfaceVersion{major: 0, minor: 1}
       }
 
       expected_capabilities = [
@@ -648,31 +657,34 @@ defmodule Edgehog.AstarteTest do
                Enum.sort(Astarte.get_device_capabilities(device_introspection))
     end
 
-    test "get_device_capabilities/1 returns a capability only if all its interfaces are supported by the device",
-         _ do
+    test "get_device_capabilities/1 returns a capability only if all its interfaces are supported by the device" do
       partial_introspection_1 = %{
-        "io.edgehog.devicemanager.OTARequest" => %{"major" => 0, "minor" => 1}
+        "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 0, minor: 1}
       }
 
       partial_introspection_2 = %{
-        "io.edgehog.devicemanager.OTAResponse" => %{"major" => 0, "minor" => 1}
+        "io.edgehog.devicemanager.OTAResponse" => %InterfaceVersion{major: 0, minor: 1}
       }
 
       assert :software_updates not in Astarte.get_device_capabilities(partial_introspection_1)
       assert :software_updates not in Astarte.get_device_capabilities(partial_introspection_2)
     end
 
-    test "get_device_capabilities/1 returns only geolocation if no interface is supported by the device",
-         _ do
+    test "get_device_capabilities/1 returns only geolocation if no interface is supported by the device" do
       assert [:geolocation] = Astarte.get_device_capabilities(%{})
     end
 
-    test "get_device_capabilities/1 should not fail when devices uses a minor greater than the one required",
-         _ do
+    test "get_device_capabilities/1 should not fail when devices uses a minor greater than the one required" do
       device_introspection = %{
-        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 0, "minor" => 2},
-        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 0, "minor" => 1},
-        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 3}
+        "io.edgehog.devicemanager.BatteryStatus" => %InterfaceVersion{major: 0, minor: 2},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %InterfaceVersion{
+          major: 0,
+          minor: 3
+        }
       }
 
       expected_capabilities = [
@@ -685,12 +697,17 @@ defmodule Edgehog.AstarteTest do
                Enum.sort(Astarte.get_device_capabilities(device_introspection))
     end
 
-    test "get_device_capabilities/1 should not return a capability if major version mismatches",
-         _ do
+    test "get_device_capabilities/1 should not return a capability if major version mismatches" do
       device_introspection = %{
-        "io.edgehog.devicemanager.BatteryStatus" => %{"major" => 1, "minor" => 0},
-        "io.edgehog.devicemanager.CellularConnectionProperties" => %{"major" => 1, "minor" => 1},
-        "io.edgehog.devicemanager.CellularConnectionStatus" => %{"major" => 0, "minor" => 1}
+        "io.edgehog.devicemanager.BatteryStatus" => %InterfaceVersion{major: 1, minor: 0},
+        "io.edgehog.devicemanager.CellularConnectionProperties" => %InterfaceVersion{
+          major: 1,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.CellularConnectionStatus" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        }
       }
 
       assert [:geolocation] = Astarte.get_device_capabilities(device_introspection)

--- a/backend/test/edgehog_web/resolvers/astarte_test.exs
+++ b/backend/test/edgehog_web/resolvers/astarte_test.exs
@@ -21,9 +21,19 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
   use Edgehog.AstarteMockCase
   use Edgehog.GeolocationMockCase
 
+  alias Astarte.Client.APIError
   alias Edgehog.Astarte.Device.BatteryStatus.BatterySlot
   alias Edgehog.Astarte.Device.StorageUsage.StorageUnit
-  alias Edgehog.Astarte.Device.{BaseImage, OSInfo, RuntimeInfo, SystemStatus, WiFiScanResult}
+
+  alias Edgehog.Astarte.Device.{
+    BaseImage,
+    DeviceStatus,
+    OSInfo,
+    RuntimeInfo,
+    SystemStatus,
+    WiFiScanResult
+  }
+
   alias Edgehog.Geolocation
   alias EdgehogWeb.Resolvers.Astarte
 
@@ -184,6 +194,36 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
                environment: "esp-idf v4.3",
                url: "https://github.com/edgehog-device-manager/edgehog-esp32-device"
              } == runtime_info
+    end
+
+    test "list_device_capabilities/3 returns the device capabilities info for a device", %{
+      device: device
+    } do
+      Edgehog.Astarte.Device.DeviceStatusMock
+      |> expect(:get, fn _appengine_client, _device_id ->
+        {:ok,
+         %DeviceStatus{
+           introspection: %{}
+         }}
+      end)
+
+      assert {:ok, capabilities} = Astarte.list_device_capabilities(device, %{}, %{})
+      assert is_list(capabilities)
+    end
+
+    test "list_device_capabilities/3 without DeviceStatus returns empty list", %{
+      device: device
+    } do
+      Edgehog.Astarte.Device.DeviceStatusMock
+      |> expect(:get, fn _appengine_client, _device_id ->
+        {:error,
+         %APIError{
+           status: 404,
+           response: %{"errors" => %{"detail" => "Device not found"}}
+         }}
+      end)
+
+      assert {:ok, []} = Astarte.list_device_capabilities(device, %{}, %{})
     end
   end
 end

--- a/backend/test/support/mocks/astarte/device/device_status.ex
+++ b/backend/test/support/mocks/astarte/device/device_status.ex
@@ -21,14 +21,20 @@ defmodule Edgehog.Mocks.Astarte.Device.DeviceStatus do
 
   alias Astarte.Client.AppEngine
   alias Edgehog.Astarte.Device.DeviceStatus
+  alias Edgehog.Astarte.InterfaceVersion
 
   @impl true
   def get(%AppEngine{} = _client, _device_id) do
     device_status = %DeviceStatus{
+      attributes: %{"attribute_key" => "attribute_value"},
+      groups: ["test-devices"],
+      introspection: %{
+        "com.example.ExampleInterface" => %InterfaceVersion{major: 1, minor: 0}
+      },
       last_connection: ~U[2021-11-15 10:44:57.432516Z],
       last_disconnection: ~U[2021-11-15 10:45:57.432516Z],
-      online: false,
-      last_seen_ip: "198.51.100.25"
+      last_seen_ip: "198.51.100.25",
+      online: false
     }
 
     {:ok, device_status}


### PR DESCRIPTION
* Update `DeviceStatus` struct
* Use `device_status_module` to fetch device introspection
* Fix device capabilities resolution in GraphQL

Signed-off-by: Sergey Zakhlypa <sergey.zakhlypa@secomind.com>