### PR TITLE
REUSE 3.0 Compliancy

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: Build and Test Backend
 
 on:

--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: Docs generation for Github Pages
 
 on:

--- a/.github/workflows/frontend-codeql-analysis.yaml
+++ b/.github/workflows/frontend-codeql-analysis.yaml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: "CodeQL"
 
 on:

--- a/.github/workflows/frontend-test.yaml
+++ b/.github/workflows/frontend-test.yaml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: Build and Test Frontend
 
 on:

--- a/.github/workflows/graphql-doc.yaml
+++ b/.github/workflows/graphql-doc.yaml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: GraphQL Docs Generation
 
 on:

--- a/.github/workflows/reuse-lint.yaml
+++ b/.github/workflows/reuse-lint.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 # Ignore local emacs variables
 /.dir-locals.el

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 erlang 24.1.4
 elixir 1.12.3-otp-24
 nodejs 16.13.0

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,2 +1,8 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 Edgehog uses icons from Font Awesome in its frontend and documentation, see
 [license](https://fontawesome.com/license/free).

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,73 +1,202 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-1. Definitions.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+   1. Definitions.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-END OF TERMS AND CONDITIONS
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-APPENDIX: How to apply the Apache License to your work.
+   END OF TERMS AND CONDITIONS
 
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+   APPENDIX: How to apply the Apache License to your work.
 
-Copyright [yyyy] [name of copyright owner]
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Copyright [yyyy] [name of copyright owner]
 
-http://www.apache.org/licenses/LICENSE-2.0
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Edgehog is designed from the ground up to be run in containers, with
 deployment. Edgehog's images can be found at
 [Docker Hub](https://hub.docker.com/u/edgehogdevicemanager).
 
+## Contributing
+
+We are open to any contribution:
+[pull requests](https://github.com/edgehog-device-manager/edgehog/pulls),
+[bug reports and feature requests](https://github.com/edgehog-device-manager/edgehog/issues)
+are welcome.
+
 # License
 
 Edgehog source code is released under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Edgehog
 
 Edgehog is an Open Source software focused on the management of the whole life-cycle of IoT devices,

--- a/backend/.formatter.exs
+++ b/backend/.formatter.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 [
   import_deps: [:ecto, :phoenix, :absinthe, :skogsra],
   inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/backend/.spectaql-config.yaml
+++ b/backend/.spectaql-config.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
 # This config will not run "as-is" and will need to be modified. You can see a minimal working
 # config in /examples/config.yml
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 FROM elixir:1.12.3 as builder
 
 WORKDIR /app

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Edgehog
 
 To start your Phoenix server:

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Config module.
 #

--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 import Config
 
 # Configure your database

--- a/backend/config/prod.exs
+++ b/backend/config/prod.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 import Config
 
 # For production, don't forget to configure the url host

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 import Config
 
 # config/runtime.exs is executed for all environments, including

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 import Config
 
 # Configure your database

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
 
 ./bin/edgehog eval "Elixir.Edgehog.Release.migrate" || exit 1
 

--- a/backend/lib/edgehog.ex
+++ b/backend/lib/edgehog.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog do
   @moduledoc """

--- a/backend/lib/edgehog/application.ex
+++ b/backend/lib/edgehog/application.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Application do
   # See https://hexdocs.pm/elixir/Application.html

--- a/backend/lib/edgehog/assets.ex
+++ b/backend/lib/edgehog/assets.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Assets do
   alias Edgehog.Assets.SystemModelPicture

--- a/backend/lib/edgehog/assets/store/behaviour.ex
+++ b/backend/lib/edgehog/assets/store/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Assets.Store.Behaviour do
   @type upload :: %Plug.Upload{}

--- a/backend/lib/edgehog/assets/system_model_picture.ex
+++ b/backend/lib/edgehog/assets/system_model_picture.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Assets.SystemModelPicture do
   alias Edgehog.Devices.SystemModel

--- a/backend/lib/edgehog/assets/uploaders/system_model_picture.ex
+++ b/backend/lib/edgehog/assets/uploaders/system_model_picture.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Assets.Uploaders.SystemModelPicture do
   use Waffle.Definition

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte do
   @moduledoc """

--- a/backend/lib/edgehog/astarte/cluster.ex
+++ b/backend/lib/edgehog/astarte/cluster.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Cluster do
   use Ecto.Schema

--- a/backend/lib/edgehog/astarte/device.ex
+++ b/backend/lib/edgehog/astarte/device.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device do
   use Ecto.Schema

--- a/backend/lib/edgehog/astarte/device/base_image.ex
+++ b/backend/lib/edgehog/astarte/device/base_image.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BaseImage do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/base_image/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/base_image/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BaseImage.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/battery_status.ex
+++ b/backend/lib/edgehog/astarte/device/battery_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BatteryStatus do
   @behaviour Edgehog.Astarte.Device.BatteryStatus.Behaviour

--- a/backend/lib/edgehog/astarte/device/battery_status/battery_slot.ex
+++ b/backend/lib/edgehog/astarte/device/battery_status/battery_slot.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BatteryStatus.BatterySlot do
   defstruct [

--- a/backend/lib/edgehog/astarte/device/battery_status/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/battery_status/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BatteryStatus.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/cellular_connection.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.CellularConnection do
   @behaviour Edgehog.Astarte.Device.CellularConnection.Behaviour

--- a/backend/lib/edgehog/astarte/device/cellular_connection/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.CellularConnection.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/cellular_connection/modem_properties.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/modem_properties.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.CellularConnection.ModemProperties do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/cellular_connection/modem_status.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection/modem_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.CellularConnection.ModemStatus do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/device_status.ex
+++ b/backend/lib/edgehog/astarte/device/device_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.DeviceStatus do
   defstruct [

--- a/backend/lib/edgehog/astarte/device/device_status/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/device_status/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.DeviceStatus.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/geolocation.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.Geolocation do
   @behaviour Edgehog.Astarte.Device.Geolocation.Behaviour

--- a/backend/lib/edgehog/astarte/device/geolocation/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.Geolocation.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/geolocation/sensor_position.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation/sensor_position.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.Geolocation.SensorPosition do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/hardware_info.ex
+++ b/backend/lib/edgehog/astarte/device/hardware_info.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.HardwareInfo do
   defstruct [

--- a/backend/lib/edgehog/astarte/device/led_behavior.ex
+++ b/backend/lib/edgehog/astarte/device/led_behavior.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.LedBehavior do
   @behaviour Edgehog.Astarte.Device.LedBehavior.Behaviour

--- a/backend/lib/edgehog/astarte/device/led_behavior/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/led_behavior/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.LedBehavior.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/os_info.ex
+++ b/backend/lib/edgehog/astarte/device/os_info.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.OSInfo do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/os_info/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/os_info/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.OSInfo.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/ota_request.ex
+++ b/backend/lib/edgehog/astarte/device/ota_request.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.OTARequest do
   @behaviour Edgehog.Astarte.Device.OTARequest.Behaviour

--- a/backend/lib/edgehog/astarte/device/ota_request/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/ota_request/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.OTARequest.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/runtime_info.ex
+++ b/backend/lib/edgehog/astarte/device/runtime_info.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.RuntimeInfo do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/astarte/device/runtime_info/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/runtime_info/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.RuntimeInfo.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/storage_usage.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.StorageUsage do
   @behaviour Edgehog.Astarte.Device.StorageUsage.Behaviour

--- a/backend/lib/edgehog/astarte/device/storage_usage/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.StorageUsage.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/storage_usage/storage_unit.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage/storage_unit.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.StorageUsage.StorageUnit do
   @enforce_keys [:label]

--- a/backend/lib/edgehog/astarte/device/system_status.ex
+++ b/backend/lib/edgehog/astarte/device/system_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.SystemStatus do
   @enforce_keys [:timestamp]

--- a/backend/lib/edgehog/astarte/device/system_status/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/system_status/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.SystemStatus.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
+++ b/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Astarte.Device.WiFiScanResult do
   @enforce_keys [:timestamp]
   defstruct [

--- a/backend/lib/edgehog/astarte/device/wifi_scan_result/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/wifi_scan_result/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.WiFiScanResult.Behaviour do
   alias Astarte.Client.AppEngine

--- a/backend/lib/edgehog/astarte/interface_id.ex
+++ b/backend/lib/edgehog/astarte/interface_id.ex
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Astarte.InterfaceID do
   @enforce_keys [:name, :major, :minor]
   defstruct @enforce_keys

--- a/backend/lib/edgehog/astarte/realm.ex
+++ b/backend/lib/edgehog/astarte/realm.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Realm do
   use Ecto.Schema

--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Config do
   @moduledoc """

--- a/backend/lib/edgehog/config/geocoding_providers.ex
+++ b/backend/lib/edgehog/config/geocoding_providers.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Config.GeocodingProviders do
   use Skogsra.Type

--- a/backend/lib/edgehog/config/geolocation_providers.ex
+++ b/backend/lib/edgehog/config/geolocation_providers.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Config.GeolocationProviders do
   use Skogsra.Type

--- a/backend/lib/edgehog/devices.ex
+++ b/backend/lib/edgehog/devices.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices do
   @moduledoc """

--- a/backend/lib/edgehog/devices/hardware_type.ex
+++ b/backend/lib/edgehog/devices/hardware_type.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices.HardwareType do
   use Ecto.Schema

--- a/backend/lib/edgehog/devices/hardware_type_part_number.ex
+++ b/backend/lib/edgehog/devices/hardware_type_part_number.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices.HardwareTypePartNumber do
   use Ecto.Schema

--- a/backend/lib/edgehog/devices/system_model.ex
+++ b/backend/lib/edgehog/devices/system_model.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices.SystemModel do
   use Ecto.Schema

--- a/backend/lib/edgehog/devices/system_model_description.ex
+++ b/backend/lib/edgehog/devices/system_model_description.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices.SystemModelDescription do
   use Ecto.Schema

--- a/backend/lib/edgehog/devices/system_model_part_number.ex
+++ b/backend/lib/edgehog/devices/system_model_part_number.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Devices.SystemModelPartNumber do
   use Ecto.Schema

--- a/backend/lib/edgehog/error.ex
+++ b/backend/lib/edgehog/error.ex
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Error do
   @moduledoc """
   Module used to normalize all errors in Edghog, so that they can be shown by the API.

--- a/backend/lib/edgehog/geolocation.ex
+++ b/backend/lib/edgehog/geolocation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation do
   @moduledoc """

--- a/backend/lib/edgehog/geolocation/coordinates.ex
+++ b/backend/lib/edgehog/geolocation/coordinates.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Coordinates do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/geolocation/geocoding_provider.ex
+++ b/backend/lib/edgehog/geolocation/geocoding_provider.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.GeocodingProvider do
   alias Edgehog.Geolocation.Coordinates

--- a/backend/lib/edgehog/geolocation/geolocation_provider.ex
+++ b/backend/lib/edgehog/geolocation/geolocation_provider.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.GeolocationProvider do
   alias Edgehog.Astarte.Device

--- a/backend/lib/edgehog/geolocation/position.ex
+++ b/backend/lib/edgehog/geolocation/position.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Position do
   @type t :: %__MODULE__{

--- a/backend/lib/edgehog/geolocation/providers/device_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/device_geolocation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.DeviceGeolocation do
   @behaviour Edgehog.Geolocation.GeolocationProvider

--- a/backend/lib/edgehog/geolocation/providers/free_geo_ip.ex
+++ b/backend/lib/edgehog/geolocation/providers/free_geo_ip.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.FreeGeoIp do
   @behaviour Edgehog.Geolocation.GeolocationProvider

--- a/backend/lib/edgehog/geolocation/providers/google_geocoding.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geocoding.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.GoogleGeocoding do
   @behaviour Edgehog.Geolocation.GeocodingProvider

--- a/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.GoogleGeolocation do
   @behaviour Edgehog.Geolocation.GeolocationProvider

--- a/backend/lib/edgehog/mailer.ex
+++ b/backend/lib/edgehog/mailer.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mailer do
   use Swoosh.Mailer, otp_app: :edgehog

--- a/backend/lib/edgehog/os_management.ex
+++ b/backend/lib/edgehog/os_management.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagement do
   @moduledoc """

--- a/backend/lib/edgehog/os_management/ephemeral_image.ex
+++ b/backend/lib/edgehog/os_management/ephemeral_image.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagement.EphemeralImage do
   @behaviour Edgehog.OSManagement.EphemeralImage.Behaviour

--- a/backend/lib/edgehog/os_management/ephemeral_image/behaviour.ex
+++ b/backend/lib/edgehog/os_management/ephemeral_image/behaviour.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagement.EphemeralImage.Behaviour do
   @type upload :: %Plug.Upload{}

--- a/backend/lib/edgehog/os_management/ota_operation.ex
+++ b/backend/lib/edgehog/os_management/ota_operation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagement.OTAOperation do
   use Ecto.Schema

--- a/backend/lib/edgehog/os_management/uploaders/ephemeral_image.ex
+++ b/backend/lib/edgehog/os_management/uploaders/ephemeral_image.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagement.Uploaders.EphemeralImage do
   use Waffle.Definition

--- a/backend/lib/edgehog/repo.ex
+++ b/backend/lib/edgehog/repo.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Repo do
   use Ecto.Repo,

--- a/backend/lib/edgehog/tenants.ex
+++ b/backend/lib/edgehog/tenants.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Tenants do
   @moduledoc """

--- a/backend/lib/edgehog/tenants/tenant.ex
+++ b/backend/lib/edgehog/tenants/tenant.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Tenants.Tenant do
   use Ecto.Schema

--- a/backend/lib/edgehog_web.ex
+++ b/backend/lib/edgehog_web.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb do
   @moduledoc """

--- a/backend/lib/edgehog_web/auth.ex
+++ b/backend/lib/edgehog_web/auth.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Auth do
   alias Edgehog.Config

--- a/backend/lib/edgehog_web/auth/error_handler.ex
+++ b/backend/lib/edgehog_web/auth/error_handler.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Auth.ErrorHandler do
   @behaviour Guardian.Plug.ErrorHandler

--- a/backend/lib/edgehog_web/auth/pipeline.ex
+++ b/backend/lib/edgehog_web/auth/pipeline.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Auth.Pipeline do
   use Plug.Builder

--- a/backend/lib/edgehog_web/auth/token.ex
+++ b/backend/lib/edgehog_web/auth/token.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Auth.Token do
   use Guardian, otp_app: :edgehog

--- a/backend/lib/edgehog_web/auth/verify_header.ex
+++ b/backend/lib/edgehog_web/auth/verify_header.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Auth.VerifyHeader do
   @moduledoc """

--- a/backend/lib/edgehog_web/context.ex
+++ b/backend/lib/edgehog_web/context.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Context do
   @behaviour Plug

--- a/backend/lib/edgehog_web/controllers/trigger_controller.ex
+++ b/backend/lib/edgehog_web/controllers/trigger_controller.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.AstarteTriggerController do
   use EdgehogWeb, :controller

--- a/backend/lib/edgehog_web/endpoint.ex
+++ b/backend/lib/edgehog_web/endpoint.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :edgehog

--- a/backend/lib/edgehog_web/gettext.ex
+++ b/backend/lib/edgehog_web/gettext.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Gettext do
   @moduledoc """

--- a/backend/lib/edgehog_web/middleware/error_handler.ex
+++ b/backend/lib/edgehog_web/middleware/error_handler.ex
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule EdgehogWeb.Middleware.ErrorHandler do
   @behaviour Absinthe.Middleware
 

--- a/backend/lib/edgehog_web/populate_tenant.ex
+++ b/backend/lib/edgehog_web/populate_tenant.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.PopulateTenant do
   @behaviour Plug

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.Astarte do
   alias Edgehog.Devices

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.Devices do
   alias Edgehog.Devices

--- a/backend/lib/edgehog_web/resolvers/os_management.ex
+++ b/backend/lib/edgehog_web/resolvers/os_management.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.OSManagement do
   alias Edgehog.Astarte

--- a/backend/lib/edgehog_web/resolvers/tenants.ex
+++ b/backend/lib/edgehog_web/resolvers/tenants.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.Tenants do
   def get_current_tenant(_args, %{context: %{current_tenant: tenant}}) do

--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Router do
   use EdgehogWeb, :router

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema do
   use Absinthe.Schema

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.AstarteTypes do
   use Absinthe.Schema.Notation

--- a/backend/lib/edgehog_web/schema/devices_types.ex
+++ b/backend/lib/edgehog_web/schema/devices_types.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.DevicesTypes do
   use Absinthe.Schema.Notation

--- a/backend/lib/edgehog_web/schema/localization_types.ex
+++ b/backend/lib/edgehog_web/schema/localization_types.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.LocalizationTypes do
   use Absinthe.Schema.Notation

--- a/backend/lib/edgehog_web/schema/os_management_types.ex
+++ b/backend/lib/edgehog_web/schema/os_management_types.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.OSManagementTypes do
   use Absinthe.Schema.Notation

--- a/backend/lib/edgehog_web/schema/tenants_types.ex
+++ b/backend/lib/edgehog_web/schema/tenants_types.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.TenantsTypes do
   use Absinthe.Schema.Notation

--- a/backend/lib/edgehog_web/telemetry.ex
+++ b/backend/lib/edgehog_web/telemetry.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Telemetry do
   use Supervisor

--- a/backend/lib/edgehog_web/views/error_helpers.ex
+++ b/backend/lib/edgehog_web/views/error_helpers.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.ErrorHelpers do
   @moduledoc """

--- a/backend/lib/edgehog_web/views/error_view.ex
+++ b/backend/lib/edgehog_web/views/error_view.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.ErrorView do
   use EdgehogWeb, :view

--- a/backend/lib/release.ex
+++ b/backend/lib/release.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Release do
   @app :edgehog

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.MixProject do
   use Mix.Project

--- a/backend/mix.lock.license
+++ b/backend/mix.lock.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: CC0-1.0

--- a/backend/priv/gettext/en/LC_MESSAGES/errors.po.license
+++ b/backend/priv/gettext/en/LC_MESSAGES/errors.po.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/backend/priv/gettext/errors.pot.license
+++ b/backend/priv/gettext/errors.pot.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/backend/priv/repo/migrations/.formatter.exs
+++ b/backend/priv/repo/migrations/.formatter.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 [
   import_deps: [:ecto_sql],
   inputs: ["*.exs"]

--- a/backend/priv/repo/migrations/20211103114700_create_tenants.exs
+++ b/backend/priv/repo/migrations/20211103114700_create_tenants.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateTenants do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211103115956_create_clusters.exs
+++ b/backend/priv/repo/migrations/20211103115956_create_clusters.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateClusters do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211103121738_create_realms.exs
+++ b/backend/priv/repo/migrations/20211103121738_create_realms.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateRealms do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211103154857_create_devices.exs
+++ b/backend/priv/repo/migrations/20211103154857_create_devices.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateDevices do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211105171629_add_slug_to_tenants.exs
+++ b/backend/priv/repo/migrations/20211105171629_add_slug_to_tenants.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddSlugToTenants do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211105171735_add_uniqueness_constraints.exs
+++ b/backend/priv/repo/migrations/20211105171735_add_uniqueness_constraints.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddUniquenessConstraints do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211105185233_add_connection_info_to_devices.exs
+++ b/backend/priv/repo/migrations/20211105185233_add_connection_info_to_devices.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddConnectionInfoToDevices do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211108141736_create_hardware_types.exs
+++ b/backend/priv/repo/migrations/20211108141736_create_hardware_types.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateHardwareTypes do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
+++ b/backend/priv/repo/migrations/20211108144240_create_hardware_type_part_numbers.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateHardwareTypePartNumbers do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211110144031_create_appliance_models.exs
+++ b/backend/priv/repo/migrations/20211110144031_create_appliance_models.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateApplianceModels do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211110165401_create_appliance_model_part_numbers.exs
+++ b/backend/priv/repo/migrations/20211110165401_create_appliance_model_part_numbers.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateApplianceModelPartNumbers do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211112111450_add_serial_and_part_number_to_devices.exs
+++ b/backend/priv/repo/migrations/20211112111450_add_serial_and_part_number_to_devices.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddSerialAndPartNumberToDevices do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211124144043_add_default_locale_to_tenants.exs
+++ b/backend/priv/repo/migrations/20211124144043_add_default_locale_to_tenants.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddDefaultLocaleToTenants do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211124151021_create_appliance_model_descriptions.exs
+++ b/backend/priv/repo/migrations/20211124151021_create_appliance_model_descriptions.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateApplianceModelDescriptions do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211209103351_add_picture_to_appliance_models.exs
+++ b/backend/priv/repo/migrations/20211209103351_add_picture_to_appliance_models.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddPictureToApplianceModels do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20211223141031_create_ota_operations.exs
+++ b/backend/priv/repo/migrations/20211223141031_create_ota_operations.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.CreateOtaOperations do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20220131165249_rename_appliance_to_system.exs
+++ b/backend/priv/repo/migrations/20220131165249_rename_appliance_to_system.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.RenameApplianceToSystem do
   use Ecto.Migration
 

--- a/backend/priv/repo/migrations/20220202171522_add_public_key_to_tenants.exs
+++ b/backend/priv/repo/migrations/20220202171522_add_public_key_to_tenants.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Edgehog.Repo.Migrations.AddPublicKeyToTenants do
   use Ecto.Migration
 

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 alias Edgehog.{
   Devices,

--- a/backend/test/edgehog/astarte/device/base_image_test.exs
+++ b/backend/test/edgehog/astarte/device/base_image_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BaseImageTest do
   use ExUnit.Case

--- a/backend/test/edgehog/astarte/device/battery_status_test.exs
+++ b/backend/test/edgehog/astarte/device/battery_status_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.BatteryStatusTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/astarte/device/cellular_connection_test.exs
+++ b/backend/test/edgehog/astarte/device/cellular_connection_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.CellularConnectionTest do
   use ExUnit.Case

--- a/backend/test/edgehog/astarte/device/geolocation_test.exs
+++ b/backend/test/edgehog/astarte/device/geolocation_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.GeolocationTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/astarte/device/os_info_test.exs
+++ b/backend/test/edgehog/astarte/device/os_info_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.OSInfoTest do
   use ExUnit.Case

--- a/backend/test/edgehog/astarte/device/runtime_info_test.exs
+++ b/backend/test/edgehog/astarte/device/runtime_info_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.RuntimeInfoTest do
   use ExUnit.Case

--- a/backend/test/edgehog/astarte/device/storage_usage_test.exs
+++ b/backend/test/edgehog/astarte/device/storage_usage_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.StorageUsageTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/astarte/device/system_status_test.exs
+++ b/backend/test/edgehog/astarte/device/system_status_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.SystemStatusTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/astarte/device/wifi_scan_result_test.exs
+++ b/backend/test/edgehog/astarte/device/wifi_scan_result_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Astarte.Device.WiFiScanResultTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.AstarteTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/devices_test.exs
+++ b/backend/test/edgehog/devices_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.DevicesTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/geolocation/providers/device_geolocation_test.exs
+++ b/backend/test/edgehog/geolocation/providers/device_geolocation_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.DeviceGeolocationTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/geolocation/providers/free_geo_ip_test.exs
+++ b/backend/test/edgehog/geolocation/providers/free_geo_ip_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.FreeGeoIpTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/geolocation/providers/google_geocoding_test.exs
+++ b/backend/test/edgehog/geolocation/providers/google_geocoding_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.GoogleGeocodingTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/geolocation/providers/google_geolocation_test.exs
+++ b/backend/test/edgehog/geolocation/providers/google_geolocation_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Geolocation.Providers.GoogleGeolocationTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/geolocation_test.exs
+++ b/backend/test/edgehog/geolocation_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.GeolocationTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog/os_management_test.exs
+++ b/backend/test/edgehog/os_management_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagementTest do
   use Edgehog.AstarteMockCase

--- a/backend/test/edgehog/tenants_test.exs
+++ b/backend/test/edgehog/tenants_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.TenantsTest do
   use Edgehog.DataCase

--- a/backend/test/edgehog_web/auth_test.exs
+++ b/backend/test/edgehog_web/auth_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.AuthTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
+++ b/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/resolvers/astarte_test.exs
+++ b/backend/test/edgehog_web/resolvers/astarte_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.AstarteTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/resolvers/devices_test.exs
+++ b/backend/test/edgehog_web/resolvers/devices_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Resolvers.DevicesTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/set_led_behavior_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/set_led_behavior_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.SetLedBehaviorTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/update_device_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_device_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.UpdateDeviceTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.DeviceTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/devices_test.exs
+++ b/backend/test/edgehog_web/schema/query/devices_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.DevicesTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/query/hardware_type_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.HardwareTypeTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/hardware_types_test.exs
+++ b/backend/test/edgehog_web/schema/query/hardware_types_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.HardwareTypesTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/system_model_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_model_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.SystemModelTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/system_models_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_models_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/schema/query/tenant_info_test.exs
+++ b/backend/test/edgehog_web/schema/query/tenant_info_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.Schema.Query.TenantInfoTest do
   use EdgehogWeb.ConnCase

--- a/backend/test/edgehog_web/views/error_view_test.exs
+++ b/backend/test/edgehog_web/views/error_view_test.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.ErrorViewTest do
   use EdgehogWeb.ConnCase, async: true

--- a/backend/test/support/assets_store_mock_case.ex
+++ b/backend/test/support/assets_store_mock_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.AssetsStoreMockCase do
   @moduledoc """

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.AstarteMockCase do
   @moduledoc """

--- a/backend/test/support/channel_case.ex
+++ b/backend/test/support/channel_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.ChannelCase do
   @moduledoc """

--- a/backend/test/support/conn_case.ex
+++ b/backend/test/support/conn_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule EdgehogWeb.ConnCase do
   @moduledoc """

--- a/backend/test/support/data_case.ex
+++ b/backend/test/support/data_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.DataCase do
   @moduledoc """

--- a/backend/test/support/ephemeral_image_mock_case.ex
+++ b/backend/test/support/ephemeral_image_mock_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.EphemeralImageMockCase do
   @moduledoc """

--- a/backend/test/support/fixtures/astarte_fixtures.ex
+++ b/backend/test/support/fixtures/astarte_fixtures.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.AstarteFixtures do
   @moduledoc """

--- a/backend/test/support/fixtures/devices_fixtures.ex
+++ b/backend/test/support/fixtures/devices_fixtures.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.DevicesFixtures do
   @moduledoc """

--- a/backend/test/support/fixtures/os_management_fixtures.ex
+++ b/backend/test/support/fixtures/os_management_fixtures.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.OSManagementFixtures do
   @moduledoc """

--- a/backend/test/support/fixtures/tenants_fixtures.ex
+++ b/backend/test/support/fixtures/tenants_fixtures.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.TenantsFixtures do
   @moduledoc """

--- a/backend/test/support/geolocation_mock_case.ex
+++ b/backend/test/support/geolocation_mock_case.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.GeolocationMockCase do
   @moduledoc """

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 Mox.defmock(Edgehog.Astarte.Device.DeviceStatusMock,
   for: Edgehog.Astarte.Device.DeviceStatus.Behaviour

--- a/backend/test/support/mocks/assets/system_model_picture.ex
+++ b/backend/test/support/mocks/assets/system_model_picture.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Assets.SystemModelPicture do
   alias Edgehog.Devices.SystemModel

--- a/backend/test/support/mocks/astarte/device/base_image.ex
+++ b/backend/test/support/mocks/astarte/device/base_image.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.BaseImage do
   @behaviour Edgehog.Astarte.Device.BaseImage.Behaviour

--- a/backend/test/support/mocks/astarte/device/battery_status.ex
+++ b/backend/test/support/mocks/astarte/device/battery_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.BatteryStatus do
   @behaviour Edgehog.Astarte.Device.BatteryStatus.Behaviour

--- a/backend/test/support/mocks/astarte/device/cellular_connection.ex
+++ b/backend/test/support/mocks/astarte/device/cellular_connection.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.CellularConnection do
   @behaviour Edgehog.Astarte.Device.CellularConnection.Behaviour

--- a/backend/test/support/mocks/astarte/device/device_status.ex
+++ b/backend/test/support/mocks/astarte/device/device_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.DeviceStatus do
   @behaviour Edgehog.Astarte.Device.DeviceStatus.Behaviour

--- a/backend/test/support/mocks/astarte/device/geolocation.ex
+++ b/backend/test/support/mocks/astarte/device/geolocation.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.Geolocation do
   @behaviour Edgehog.Astarte.Device.Geolocation.Behaviour

--- a/backend/test/support/mocks/astarte/device/led_behavior.ex
+++ b/backend/test/support/mocks/astarte/device/led_behavior.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.LedBehavior do
   @behaviour Edgehog.Astarte.Device.LedBehavior.Behaviour

--- a/backend/test/support/mocks/astarte/device/os_info.ex
+++ b/backend/test/support/mocks/astarte/device/os_info.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.OSInfo do
   @behaviour Edgehog.Astarte.Device.OSInfo.Behaviour

--- a/backend/test/support/mocks/astarte/device/ota_request.ex
+++ b/backend/test/support/mocks/astarte/device/ota_request.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.OTARequest do
   @behaviour Edgehog.Astarte.Device.OTARequest.Behaviour

--- a/backend/test/support/mocks/astarte/device/runtime_info.ex
+++ b/backend/test/support/mocks/astarte/device/runtime_info.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.RuntimeInfo do
   @behaviour Edgehog.Astarte.Device.RuntimeInfo.Behaviour

--- a/backend/test/support/mocks/astarte/device/storage_usage.ex
+++ b/backend/test/support/mocks/astarte/device/storage_usage.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.StorageUsage do
   @behaviour Edgehog.Astarte.Device.StorageUsage.Behaviour

--- a/backend/test/support/mocks/astarte/device/system_status.ex
+++ b/backend/test/support/mocks/astarte/device/system_status.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.SystemStatus do
   @behaviour Edgehog.Astarte.Device.SystemStatus.Behaviour

--- a/backend/test/support/mocks/astarte/device/wifi_scan_result.ex
+++ b/backend/test/support/mocks/astarte/device/wifi_scan_result.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Astarte.Device.WiFiScanResult do
   @behaviour Edgehog.Astarte.Device.WiFiScanResult.Behaviour

--- a/backend/test/support/mocks/geolocation/geocoding_provider.ex
+++ b/backend/test/support/mocks/geolocation/geocoding_provider.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Geolocation.GeocodingProvider do
   @behaviour Edgehog.Geolocation.GeocodingProvider

--- a/backend/test/support/mocks/geolocation/geolocation_provider.ex
+++ b/backend/test/support/mocks/geolocation/geolocation_provider.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.Geolocation.GeolocationProvider do
   @behaviour Edgehog.Geolocation.GeolocationProvider

--- a/backend/test/support/mocks/os_management/ephemeral_image.ex
+++ b/backend/test/support/mocks/os_management/ephemeral_image.ex
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 defmodule Edgehog.Mocks.OSManagement.EphemeralImage do
   @behaviour Edgehog.OSManagement.EphemeralImage.Behaviour

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Edgehog.Repo, :manual)

--- a/doc/.formatter.exs
+++ b/doc/.formatter.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-License-Identifier: CC0-1.0
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Doc
 
 **TODO: Add description**

--- a/doc/image_sources/edgehog_architecture.drawio.license
+++ b/doc/image_sources/edgehog_architecture.drawio.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/create_hardware_type.png.license
+++ b/doc/images/create_hardware_type.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/create_system_model.png.license
+++ b/doc/images/create_system_model.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_base_image.png.license
+++ b/doc/images/device_base_image.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_battery.png.license
+++ b/doc/images/device_battery.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_cellular_connection.png.license
+++ b/doc/images/device_cellular_connection.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_geolocation.png.license
+++ b/doc/images/device_geolocation.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_hardware_info.png.license
+++ b/doc/images/device_hardware_info.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_operating_system.png.license
+++ b/doc/images/device_operating_system.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_runtime.png.license
+++ b/doc/images/device_runtime.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_storage.png.license
+++ b/doc/images/device_storage.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_system_status.png.license
+++ b/doc/images/device_system_status.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/device_wifi_aps.png.license
+++ b/doc/images/device_wifi_aps.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/devices.png.license
+++ b/doc/images/devices.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/edgehog_architecture.png.license
+++ b/doc/images/edgehog_architecture.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/hardware_types.png.license
+++ b/doc/images/hardware_types.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/logo-favicon.png.license
+++ b/doc/images/logo-favicon.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/system_model.png.license
+++ b/doc/images/system_model.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/images/system_models.png.license
+++ b/doc/images/system_models.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 defmodule Doc.MixProject do
   use Mix.Project
 

--- a/doc/mix.lock.license
+++ b/doc/mix.lock.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 SECO Mind Srl
+SPDX-License-Identifier: CC0-1.0

--- a/doc/pages/architecture/overview.md
+++ b/doc/pages/architecture/overview.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Architecture overview
 
 This is an overview of Edgehog's architecture.

--- a/doc/pages/integrating/interacting_with_edgehog.md
+++ b/doc/pages/integrating/interacting_with_edgehog.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Interacting with Edgehog
 
 Edgehog's interaction is logically divided amongst two main entities: devices and users.

--- a/doc/pages/user/core_concepts.md
+++ b/doc/pages/user/core_concepts.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Core concepts
 
 This page will illustrate some of the core concepts used in Edgehog.

--- a/doc/pages/user/device_sdks_runtime.md
+++ b/doc/pages/user/device_sdks_runtime.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # SDKs & Runtime
 
 ## Edgehog Device ESP32 SDK

--- a/doc/pages/user/devices.md
+++ b/doc/pages/user/devices.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Devices
 
 As mentioned in the [core concepts](core_concepts.html), a Device is an entity connected to Astarte.

--- a/doc/pages/user/hardware_types.md
+++ b/doc/pages/user/hardware_types.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hardware Types
 
 For each hardware type the following information can be displayed and edited.

--- a/doc/pages/user/intro_user.md
+++ b/doc/pages/user/intro_user.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Introduction
 
 Edgehog is an Open Source IoT platform focused on device fleet management. It conveniently handles

--- a/doc/pages/user/system_models.md
+++ b/doc/pages/user/system_models.md
@@ -1,3 +1,9 @@
+<!---
+  Copyright 2021,2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # System models
 
 As already mentioned in the [core concepts](core_concepts.html), System Models represent a group of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,23 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 version: "3.3"
 services:
   postgresql:

--- a/tools/gen-edgehog-jwt
+++ b/tools/gen-edgehog-jwt
@@ -1,4 +1,23 @@
 #!/usr/bin/env python3
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import argparse
 import datetime


### PR DESCRIPTION
Make edgehog main repo compliant with
[REUSE](https://reuse.software/) 3.0.

Starting from now each source file must comply with REUSE 3.0, in order to
fully comply adding SPDX license headers, copyright information or .license
file is mandatory.

A GitHub Workflow will check compliancy.

Closes #156  #157 