### PR TITLE
Use the repository URL as project homepage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,6 @@
 {
   "name": "edgehog-device-manager-frontend",
   "version": "0.1.0",
-  "homepage": "https://github.com/edgehog-device-manager/edgehog",
   "bugs": {
     "url": "https://github.com/edgehog-device-manager/edgehog/issues"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,7 @@ import HardwareTypes from "pages/HardwareTypes";
 import Login from "pages/Login";
 import Logout from "pages/Logout";
 
-import { version, homepage, repository, bugs } from "../package.json";
+import { version, repository, bugs } from "../package.json";
 
 type RouterRule = {
   path: string;
@@ -85,7 +85,7 @@ function App() {
         <Footer
           appName={"Edgehog Device Manager"}
           appVersion={version}
-          homepageUrl={homepage}
+          homepageUrl={repository.url}
           repoUrl={repository.url}
           issueTrackerUrl={bugs.url}
         />


### PR DESCRIPTION
package.json homepage filed refers to the project's homepage
(see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#homepage)
but CRA uses it as the app public URL. This leads to broken URL injected
in the generated index.html file
(https://create-react-app.dev/docs/deployment/#building-for-relative-paths)

Signed-off-by: Mattia <mattia.pavinati@secomind.com>