### PR TITLE
Add support for device tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for device tags ([#191](https://github.com/edgehog-device-manager/edgehog/pull/191))
 
 ## [0.5.1] - 2022-06-01
 ### Added

--- a/backend/lib/edgehog/astarte/device.ex
+++ b/backend/lib/edgehog/astarte/device.ex
@@ -41,6 +41,7 @@ defmodule Edgehog.Astarte.Device do
       type: :string
 
     has_one :system_model, through: [:system_model_part_number, :system_model]
+    many_to_many :tags, Devices.Tag, join_through: Devices.DeviceTag, on_replace: :delete
 
     timestamps()
   end

--- a/backend/lib/edgehog/devices.ex
+++ b/backend/lib/edgehog/devices.ex
@@ -32,6 +32,7 @@ defmodule Edgehog.Devices do
   alias Edgehog.Devices.SystemModelPartNumber
   alias Edgehog.Devices.HardwareType
   alias Edgehog.Devices.HardwareTypePartNumber
+  alias Edgehog.Devices.Tag
   alias Edgehog.Assets
 
   @doc """
@@ -419,5 +420,57 @@ defmodule Edgehog.Devices do
   """
   def change_system_model(%SystemModel{} = system_model, attrs \\ %{}) do
     SystemModel.changeset(system_model, attrs)
+  end
+
+  @doc """
+  Inserts the tags passed in attrs within a multi transaction, normalizing them.
+
+  Returns the updated `%Ecto.Multi{}`.
+  """
+  def ensure_tags_exist_multi(multi, %{tags: _tags} = attrs) do
+    multi
+    |> Multi.run(:cast_tags, fn _repo, _changes ->
+      data = %{}
+      types = %{tags: {:array, :string}}
+
+      changeset =
+        {data, types}
+        |> Ecto.Changeset.cast(attrs, Map.keys(types))
+
+      with {:ok, %{tags: tags}} <- Ecto.Changeset.apply_action(changeset, :insert) do
+        tenant_id = Repo.get_tenant_id()
+
+        now =
+          NaiveDateTime.utc_now()
+          |> NaiveDateTime.truncate(:second)
+
+        tag_maps =
+          for tag <- tags,
+              tag = normalize_tag(tag),
+              tag != "" do
+            %{name: tag, inserted_at: now, updated_at: now, tenant_id: tenant_id}
+          end
+
+        {:ok, tag_maps}
+      end
+    end)
+    |> Multi.insert_all(:insert_tags, Tag, & &1.cast_tags, on_conflict: :nothing)
+    |> Multi.run(:ensure_tags_exist, fn repo, %{cast_tags: tag_maps} ->
+      tag_names = for t <- tag_maps, do: t.name
+      {:ok, repo.all(from t in Tag, where: t.name in ^tag_names)}
+    end)
+  end
+
+  def ensure_tags_exist_multi(multi, _attrs) do
+    # No tags in the update, so we return nil for tags
+    Multi.run(multi, :ensure_tags_exist, fn _repo, _previous ->
+      {:ok, nil}
+    end)
+  end
+
+  defp normalize_tag(tag) do
+    tag
+    |> String.trim()
+    |> String.downcase()
   end
 end

--- a/backend/lib/edgehog/devices/device_tag.ex
+++ b/backend/lib/edgehog/devices/device_tag.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Devices.DeviceTag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "devices_tags" do
+    field :tenant_id, :id
+    field :tag_id, :id
+    field :device_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(device_tag, attrs) do
+    device_tag
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/backend/lib/edgehog/devices/device_tag.ex
+++ b/backend/lib/edgehog/devices/device_tag.ex
@@ -20,20 +20,11 @@
 
 defmodule Edgehog.Devices.DeviceTag do
   use Ecto.Schema
-  import Ecto.Changeset
 
+  @primary_key false
   schema "devices_tags" do
-    field :tenant_id, :id
-    field :tag_id, :id
-    field :device_id, :id
-
-    timestamps()
-  end
-
-  @doc false
-  def changeset(device_tag, attrs) do
-    device_tag
-    |> cast(attrs, [])
-    |> validate_required([])
+    field :tenant_id, :integer, autogenerate: {Edgehog.Repo, :get_tenant_id, []}
+    field :tag_id, :id, primary_key: true
+    field :device_id, :id, primary_key: true
   end
 end

--- a/backend/lib/edgehog/devices/tag.ex
+++ b/backend/lib/edgehog/devices/tag.ex
@@ -23,8 +23,8 @@ defmodule Edgehog.Devices.Tag do
   import Ecto.Changeset
 
   schema "tags" do
+    field :tenant_id, :integer, autogenerate: {Edgehog.Repo, :get_tenant_id, []}
     field :name, :string
-    field :tenant_id, :id
 
     timestamps()
   end

--- a/backend/lib/edgehog/devices/tag.ex
+++ b/backend/lib/edgehog/devices/tag.ex
@@ -34,6 +34,6 @@ defmodule Edgehog.Devices.Tag do
     tag
     |> cast(attrs, [:name])
     |> validate_required([:name])
-    |> unique_constraint(:name)
+    |> unique_constraint([:name, :tenant_id])
   end
 end

--- a/backend/lib/edgehog/devices/tag.ex
+++ b/backend/lib/edgehog/devices/tag.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Devices.Tag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tags" do
+    field :name, :string
+    field :tenant_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tag, attrs) do
+    tag
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
+  end
+end

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -19,6 +19,7 @@
 #
 
 defmodule EdgehogWeb.Resolvers.Devices do
+  alias Edgehog.Astarte
   alias Edgehog.Devices
   alias Edgehog.Devices.HardwareType
   alias Edgehog.Devices.SystemModel
@@ -167,5 +168,10 @@ defmodule EdgehogWeb.Resolvers.Devices do
       [description] -> {:ok, description}
       _ -> {:ok, nil}
     end
+  end
+
+  def extract_device_tags(%Astarte.Device{tags: tags}, _args, _context) do
+    tag_names = for t <- tags, do: t.name
+    {:ok, tag_names}
   end
 end

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -82,6 +82,13 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     the name of the device's hardware type.
     """
     field :hardware_type_name, :string
+
+    @desc """
+    A string to match against the tags of the device.
+    The match is case-insensitive and tests whether the string is included in \
+    one of the tags of the device.
+    """
+    field :tag, :string
   end
 
   @desc """
@@ -409,6 +416,11 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     @desc "The system model of the device."
     field :system_model, :system_model
 
+    @desc "The tags of the device"
+    field :tags, non_null(list_of(non_null(:string))) do
+      resolve &Resolvers.Devices.extract_device_tags/3
+    end
+
     @desc "List of capabilities supported by the device."
     field :capabilities, non_null(list_of(non_null(:device_capability))) do
       resolve &Resolvers.Astarte.list_device_capabilities/3
@@ -538,6 +550,9 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
 
         @desc "The display name of the device."
         field :name, :string
+
+        @desc "The tags of the device. These replace all the current tags."
+        field :tags, list_of(non_null(:string))
       end
 
       output do

--- a/backend/priv/repo/migrations/20220426061607_create_tags.exs
+++ b/backend/priv/repo/migrations/20220426061607_create_tags.exs
@@ -1,0 +1,35 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string
+      add :tenant_id, references(:tenants, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create unique_index(:tags, [:name])
+    create index(:tags, [:tenant_id])
+  end
+end

--- a/backend/priv/repo/migrations/20220426061607_create_tags.exs
+++ b/backend/priv/repo/migrations/20220426061607_create_tags.exs
@@ -23,13 +23,16 @@ defmodule Edgehog.Repo.Migrations.CreateTags do
 
   def change do
     create table(:tags) do
-      add :name, :string
-      add :tenant_id, references(:tenants, on_delete: :nothing)
+      add :tenant_id, references(:tenants, column: :tenant_id, on_delete: :delete_all),
+        null: false
+
+      add :name, :string, null: false
 
       timestamps()
     end
 
-    create unique_index(:tags, [:name])
     create index(:tags, [:tenant_id])
+    create unique_index(:tags, [:id, :tenant_id])
+    create unique_index(:tags, [:name, :tenant_id])
   end
 end

--- a/backend/priv/repo/migrations/20220517063737_create_devices_tags.exs
+++ b/backend/priv/repo/migrations/20220517063737_create_devices_tags.exs
@@ -22,16 +22,23 @@ defmodule Edgehog.Repo.Migrations.CreateDevicesTags do
   use Ecto.Migration
 
   def change do
-    create table(:devices_tags) do
-      add :tenant_id, references(:tenants, on_delete: :nothing)
-      add :tag_id, references(:tags, on_delete: :nothing)
-      add :device_id, references(:devices, on_delete: :nothing)
+    create table(:devices_tags, primary_key: false) do
+      add :tenant_id, references(:tenants, column: :tenant_id, on_delete: :delete_all),
+        null: false,
+        primary_key: true
 
-      timestamps()
+      add :tag_id,
+          references(:tags, with: [tenant_id: :tenant_id], match: :full, on_delete: :restrict),
+          null: false,
+          primary_key: true
+
+      add :device_id,
+          references(:devices, with: [tenant_id: :tenant_id], match: :full, on_delete: :delete_all),
+          null: false,
+          primary_key: true
     end
 
-    create index(:devices_tags, [:tenant_id])
-    create index(:devices_tags, [:tag_id])
-    create index(:devices_tags, [:device_id])
+    create index(:devices_tags, [:tag_id, :tenant_id])
+    create index(:devices_tags, [:device_id, :tenant_id])
   end
 end

--- a/backend/priv/repo/migrations/20220517063737_create_devices_tags.exs
+++ b/backend/priv/repo/migrations/20220517063737_create_devices_tags.exs
@@ -1,0 +1,37 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.CreateDevicesTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:devices_tags) do
+      add :tenant_id, references(:tenants, on_delete: :nothing)
+      add :tag_id, references(:tags, on_delete: :nothing)
+      add :device_id, references(:devices, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:devices_tags, [:tenant_id])
+    create index(:devices_tags, [:tag_id])
+    create index(:devices_tags, [:device_id])
+  end
+end

--- a/backend/test/edgehog/astarte_test.exs
+++ b/backend/test/edgehog/astarte_test.exs
@@ -416,6 +416,19 @@ defmodule Edgehog.AstarteTest do
       assert Astarte.list_devices(filters) == [device_1]
     end
 
+    test "list_devices/1 filters with tag", %{realm: realm} do
+      device_1 = device_fixture(realm, device_id: "7mcE8JeZQkSzjLyYuh5N9A")
+      update_attrs_1 = %{tags: ["custom", "customer"]}
+      assert {:ok, %Device{} = device_1} = Astarte.update_device(device_1, update_attrs_1)
+
+      device_2 = device_fixture(realm, device_id: "nWwr7SZiR8CgZN_uKHsAJg")
+      update_attrs_2 = %{tags: ["other"]}
+      assert {:ok, _device2} = Astarte.update_device(device_2, update_attrs_2)
+
+      filters = %{tag: "custom"}
+      assert Astarte.list_devices(filters) == [device_1]
+    end
+
     test "list_devices/1 combines filters with AND", %{realm: realm} do
       device_1 = device_fixture(realm, device_id: "7mcE8JeZQkSzjLyYuh5N9A", online: true)
       _device_2 = device_fixture(realm, device_id: "nWwr7SZiR8CgZN_uKHsAJg", online: false)

--- a/backend/test/edgehog_web/schema/query/devices_test.exs
+++ b/backend/test/edgehog_web/schema/query/devices_test.exs
@@ -25,6 +25,7 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
   import Edgehog.DevicesFixtures
   import Edgehog.AstarteFixtures
 
+  alias Edgehog.Astarte
   alias Edgehog.Astarte.Device
 
   describe "systemModels field" do
@@ -94,6 +95,37 @@ defmodule EdgehogWeb.Schema.Query.DevicesTest do
       _device_2 = device_fixture(realm, device_id: "1YmkqsFfSuWDZcYV3ceoBQ", online: false)
 
       variables = %{filter: %{online: true}}
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "devices" => [device]
+               }
+             } = json_response(conn, 200)
+
+      assert device["name"] == name
+      assert device["deviceId"] == device_id
+      assert device["online"] == online
+    end
+
+    test "filters devices with tag", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      {:ok,
+       %Device{
+         name: name,
+         device_id: device_id,
+         online: online
+       }} =
+        device_fixture(realm, device_id: "INyxlnmUT3CEJHPAwWMi0A")
+        |> Astarte.update_device(%{tags: ["foobar"]})
+
+      _device_2 = device_fixture(realm, device_id: "1YmkqsFfSuWDZcYV3ceoBQ")
+
+      variables = %{filter: %{tag: "foo"}}
 
       conn = post(conn, api_path, query: @query, variables: variables)
 


### PR DESCRIPTION
Allow tagging a device, showing its tags when querying it and filtering for a specific tag when requesting the device list.