### PR TITLE
[Backend] Add workaround to ensure Astarte datastreams are always parsed correctly

### DIFF
--- a/backend/lib/edgehog/astarte/device/battery_status.ex
+++ b/backend/lib/edgehog/astarte/device/battery_status.ex
@@ -31,22 +31,23 @@ defmodule Edgehog.Astarte.Device.BatteryStatus do
            AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
       battery_slots =
         data
-        |> Enum.map(fn {battery_slot, [battery_slot_info]} ->
-          %{
-            "levelPercentage" => level_percentage,
-            "levelAbsoluteError" => level_absolute_error,
-            "status" => status
-          } = battery_slot_info
-
-          %BatterySlot{
-            slot: battery_slot,
-            level_percentage: level_percentage,
-            level_absolute_error: level_absolute_error,
-            status: status
-          }
+        |> Enum.map(fn
+          {label, [battery_slot]} -> parse_battery_slot(label, battery_slot)
+          # TODO: handle value as single object too, as a workaround for the issue:
+          # https://github.com/astarte-platform/astarte/issues/707
+          {label, battery_slot} -> parse_battery_slot(label, battery_slot)
         end)
 
       {:ok, battery_slots}
     end
+  end
+
+  defp parse_battery_slot(slot_label, battery_slot) when is_binary(slot_label) do
+    %BatterySlot{
+      slot: slot_label,
+      level_percentage: battery_slot["levelPercentage"],
+      level_absolute_error: battery_slot["levelAbsoluteError"],
+      status: battery_slot["status"]
+    }
   end
 end

--- a/backend/lib/edgehog/astarte/device/geolocation.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation.ex
@@ -37,21 +37,28 @@ defmodule Edgehog.Astarte.Device.Geolocation do
   def parse_data(data) do
     sensors_positions =
       data
-      |> Enum.map(fn {sensor_id, [sensor_data]} ->
-        %SensorPosition{
-          sensor_id: sensor_id,
-          latitude: sensor_data["latitude"],
-          longitude: sensor_data["longitude"],
-          altitude: sensor_data["altitude"],
-          accuracy: sensor_data["accuracy"],
-          altitude_accuracy: sensor_data["altitudeAccuracy"],
-          heading: sensor_data["heading"],
-          speed: sensor_data["speed"],
-          timestamp: parse_datetime(sensor_data["timestamp"])
-        }
+      |> Enum.map(fn
+        {sensor_id, [sensor_data]} -> parse_sensor_data(sensor_id, sensor_data)
+        # TODO: handle value as single object too, as a workaround for the issue:
+        # https://github.com/astarte-platform/astarte/issues/707
+        {sensor_id, sensor_data} -> parse_sensor_data(sensor_id, sensor_data)
       end)
 
     {:ok, sensors_positions}
+  end
+
+  def parse_sensor_data(sensor_id, sensor_data) when is_binary(sensor_id) do
+    %SensorPosition{
+      sensor_id: sensor_id,
+      latitude: sensor_data["latitude"],
+      longitude: sensor_data["longitude"],
+      altitude: sensor_data["altitude"],
+      accuracy: sensor_data["accuracy"],
+      altitude_accuracy: sensor_data["altitudeAccuracy"],
+      heading: sensor_data["heading"],
+      speed: sensor_data["speed"],
+      timestamp: parse_datetime(sensor_data["timestamp"])
+    }
   end
 
   defp parse_datetime(nil) do

--- a/backend/test/edgehog/astarte/device/geolocation_test.exs
+++ b/backend/test/edgehog/astarte/device/geolocation_test.exs
@@ -40,7 +40,7 @@ defmodule Edgehog.Astarte.Device.GeolocationTest do
       {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
     end
 
-    test "get/2 correctly parses geolocation data", %{
+    test "get/2 correctly parses geolocation data with a single path", %{
       device: device,
       appengine_client: appengine_client
     } do
@@ -57,19 +57,58 @@ defmodule Edgehog.Astarte.Device.GeolocationTest do
               "speed" => nil,
               "timestamp" => "2021-11-30T10:45:00.575Z"
             }
-          ],
-          "gps2" => [
-            %{
-              "latitude" => 45.4,
-              "longitude" => 11.9,
-              "altitude" => nil,
-              "accuracy" => 50,
-              "altitudeAccuracy" => nil,
-              "heading" => nil,
-              "speed" => nil,
-              "timestamp" => "2021-11-30T10:45:00.575Z"
-            }
           ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, sensors_positions} = Geolocation.get(appengine_client, device.device_id)
+
+      assert sensors_positions == [
+               %SensorPosition{
+                 sensor_id: "gps1",
+                 latitude: 45.4095285,
+                 longitude: 11.8788231,
+                 altitude: nil,
+                 accuracy: 0,
+                 altitude_accuracy: nil,
+                 heading: nil,
+                 speed: nil,
+                 timestamp: ~U[2021-11-30 10:45:00.575Z]
+               }
+             ]
+    end
+
+    test "get/2 correctly parses geolocation data with multiple paths", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "gps1" => %{
+            "latitude" => 45.4095285,
+            "longitude" => 11.8788231,
+            "altitude" => nil,
+            "accuracy" => 0,
+            "altitudeAccuracy" => nil,
+            "heading" => nil,
+            "speed" => nil,
+            "timestamp" => "2021-11-30T10:45:00.575Z"
+          },
+          "gps2" => %{
+            "latitude" => 45.4,
+            "longitude" => 11.9,
+            "altitude" => nil,
+            "accuracy" => 50,
+            "altitudeAccuracy" => nil,
+            "heading" => nil,
+            "speed" => nil,
+            "timestamp" => "2021-11-30T10:45:00.575Z"
+          }
         }
       }
 

--- a/backend/test/edgehog/astarte/device/storage_usage_test.exs
+++ b/backend/test/edgehog/astarte/device/storage_usage_test.exs
@@ -40,7 +40,7 @@ defmodule Edgehog.Astarte.Device.StorageUsageTest do
       {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
     end
 
-    test "get/2 correctly parses storage usage data", %{
+    test "get/2 correctly parses storage usage data with a single path", %{
       device: device,
       appengine_client: appengine_client
     } do
@@ -52,14 +52,38 @@ defmodule Edgehog.Astarte.Device.StorageUsageTest do
               "timestamp" => "2021-11-30T10:45:00.575Z",
               "totalBytes" => "16128"
             }
-          ],
-          "nvs2" => [
-            %{
-              "freeBytes" => "5000",
-              "timestamp" => "2021-11-30T10:41:48.575Z",
-              "totalBytes" => "8064"
-            }
           ]
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, storage_units} = StorageUsage.get(appengine_client, device.device_id)
+
+      assert storage_units == [
+               %StorageUnit{free_bytes: 7000, label: "nvs1", total_bytes: 16128}
+             ]
+    end
+
+    test "get/2 correctly parses storage usage data with multiple paths", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "nvs1" => %{
+            "freeBytes" => "7000",
+            "timestamp" => "2021-11-30T10:45:00.575Z",
+            "totalBytes" => "16128"
+          },
+          "nvs2" => %{
+            "freeBytes" => "5000",
+            "timestamp" => "2021-11-30T10:41:48.575Z",
+            "totalBytes" => "8064"
+          }
         }
       }
 


### PR DESCRIPTION
The workaround ensures that Edgehog is able to parse datastream data in the case that the values for its parametric paths are not returned as lists of values but as the last value directly. Indeed, when querying a Datastream interface on Astarte specifying `limit=1` then the resulting data have a different structure depending on how many parametric paths have published data.

See the following issue for more details:
https://github.com/astarte-platform/astarte/issues/707
