### PR TITLE
CI: only run docs generation in the main repo

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -36,6 +36,7 @@ on:
 
 jobs:
   docs:
+    if: github.repository_owner == 'edgehog-device-manager'
     runs-on: ubuntu-20.04
     steps:
     # Checkout the source

--- a/.github/workflows/graphql-doc.yaml
+++ b/.github/workflows/graphql-doc.yaml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   docs:
+    if: github.repository_owner == 'edgehog-device-manager'
     runs-on: ubuntu-20.04
     steps:
     # Checkout the source


### PR DESCRIPTION
Avoid failed runs on forks due to missing secrets. Only the main repo should
build and push the docs.

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>