### PR TITLE
Fix queries and mutations for translated descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Start using logfmt as logging format.
 
+### Fixed
+- Use the tenant's default locale when managing translated descriptions if the user's locale is not
+available.
+
 ## [0.5.1] - 2022-06-01
 ### Added
 - Add `connected` field to wifi scan result and highlight the latest connected network

--- a/backend/lib/edgehog/devices.ex
+++ b/backend/lib/edgehog/devices.ex
@@ -246,19 +246,20 @@ defmodule Edgehog.Devices do
   end
 
   @doc """
-  Preloads only descriptions with a specific locale for an `SystemModel` (or a list of them).
+  Preloads only descriptions with specific locales for a `SystemModel` (or a list of them).
   """
-  def preload_localized_descriptions_for_system_model(model_or_models, locale) do
-    descriptions_preload = SystemModelDescription.localized(locale)
+  def preload_localized_descriptions_for_system_model(model_or_models, locales)
+      when is_list(locales) do
+    descriptions_preload = SystemModelDescription.localized(locales)
 
     Repo.preload(model_or_models, descriptions: descriptions_preload)
   end
 
   @doc """
-  Returns a query that selects only `SystemModelDescription` with a specific locale.
+  Returns a query that selects only `SystemModelDescription` with specific locales.
   """
-  def localized_system_model_description_query(locale) do
-    SystemModelDescription.localized(locale)
+  def localized_system_model_description_query(locales) when is_list(locales) do
+    SystemModelDescription.localized(locales)
   end
 
   @doc """

--- a/backend/lib/edgehog/devices/system_model_description.ex
+++ b/backend/lib/edgehog/devices/system_model_description.ex
@@ -44,8 +44,8 @@ defmodule Edgehog.Devices.SystemModelDescription do
     |> unique_constraint([:locale, :system_model_id, :tenant_id])
   end
 
-  def localized(locale) do
+  def localized(locales) when is_list(locales) do
     from d in SystemModelDescription,
-      where: d.locale == ^locale
+      where: d.locale in ^locales
   end
 end

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -60,7 +60,7 @@ defmodule EdgehogWeb.Resolvers.Astarte do
 
   defp preload_system_model_for_device(target, %{locale: locale}) do
     # Explicit locale, use that one
-    descriptions_query = Devices.localized_system_model_description_query(locale)
+    descriptions_query = Devices.localized_system_model_description_query([locale])
     preload = [descriptions: descriptions_query, hardware_type: [], part_numbers: []]
 
     Astarte.preload_system_model_for_device(target, preload: preload)
@@ -69,7 +69,7 @@ defmodule EdgehogWeb.Resolvers.Astarte do
   defp preload_system_model_for_device(target, %{current_tenant: tenant}) do
     # Fallback
     %{default_locale: default_locale} = tenant
-    descriptions_query = Devices.localized_system_model_description_query(default_locale)
+    descriptions_query = Devices.localized_system_model_description_query([default_locale])
     preload = [descriptions: descriptions_query, hardware_type: [], part_numbers: []]
 
     Astarte.preload_system_model_for_device(target, preload: preload)

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -58,18 +58,12 @@ defmodule EdgehogWeb.Resolvers.Astarte do
     end
   end
 
-  defp preload_system_model_for_device(target, %{locale: locale}) do
-    # Explicit locale, use that one
-    descriptions_query = Devices.localized_system_model_description_query([locale])
-    preload = [descriptions: descriptions_query, hardware_type: [], part_numbers: []]
+  defp preload_system_model_for_device(target, context) do
+    descriptions_query =
+      context
+      |> Map.fetch!(:preferred_locales)
+      |> Devices.localized_system_model_description_query()
 
-    Astarte.preload_system_model_for_device(target, preload: preload)
-  end
-
-  defp preload_system_model_for_device(target, %{current_tenant: tenant}) do
-    # Fallback
-    %{default_locale: default_locale} = tenant
-    descriptions_query = Devices.localized_system_model_description_query([default_locale])
     preload = [descriptions: descriptions_query, hardware_type: [], part_numbers: []]
 
     Astarte.preload_system_model_for_device(target, preload: preload)

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -140,9 +140,11 @@ defmodule EdgehogWeb.Resolvers.Devices do
 
   # If it's there, wraps description to descriptions, as {create,update}_system_model expects a list
   defp wrap_description(%{description: description} = attrs) do
+    descriptions = Enum.reject([description], &(is_nil(&1) || String.trim(&1.text) == ""))
+
     attrs
     |> Map.delete(:description)
-    |> Map.put(:descriptions, [description])
+    |> Map.put(:descriptions, descriptions)
   end
 
   defp wrap_description(attrs), do: attrs

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -79,14 +79,14 @@ defmodule EdgehogWeb.Resolvers.Devices do
 
   defp localize_system_model_description(target, %{locale: locale}) do
     # Explicit locale, use that one
-    Devices.preload_localized_descriptions_for_system_model(target, locale)
+    Devices.preload_localized_descriptions_for_system_model(target, [locale])
   end
 
   defp localize_system_model_description(target, %{current_tenant: tenant}) do
     # Fallback
     %{default_locale: default_locale} = tenant
 
-    Devices.preload_localized_descriptions_for_system_model(target, default_locale)
+    Devices.preload_localized_descriptions_for_system_model(target, [default_locale])
   end
 
   def extract_system_model_part_numbers(
@@ -111,7 +111,7 @@ defmodule EdgehogWeb.Resolvers.Devices do
            Devices.create_system_model(hardware_type, attrs) do
       system_model =
         system_model
-        |> Devices.preload_localized_descriptions_for_system_model(default_locale)
+        |> Devices.preload_localized_descriptions_for_system_model([default_locale])
 
       {:ok, %{system_model: system_model}}
     end
@@ -127,12 +127,12 @@ defmodule EdgehogWeb.Resolvers.Devices do
          attrs = wrap_description(attrs),
          system_model =
            system_model
-           |> Devices.preload_localized_descriptions_for_system_model(default_locale),
+           |> Devices.preload_localized_descriptions_for_system_model([default_locale]),
          {:ok, %SystemModel{} = system_model} <-
            Devices.update_system_model(system_model, attrs) do
       system_model =
         system_model
-        |> Devices.preload_localized_descriptions_for_system_model(default_locale)
+        |> Devices.preload_localized_descriptions_for_system_model([default_locale])
 
       {:ok, %{system_model: system_model}}
     end

--- a/backend/test/edgehog/devices_test.exs
+++ b/backend/test/edgehog/devices_test.exs
@@ -328,9 +328,12 @@ defmodule Edgehog.DevicesTest do
       assert {:ok, system_model} = Devices.fetch_system_model(system_model.id)
 
       system_model =
-        Devices.preload_localized_descriptions_for_system_model(system_model, ["it-IT"])
+        Devices.preload_localized_descriptions_for_system_model(system_model, ["it-IT", "en-US"])
 
-      assert Enum.map(system_model.descriptions, & &1.locale) == ["it-IT"]
+      assert [
+               %{locale: "en-US", text: "A system model"},
+               %{locale: "it-IT", text: "Un modello di sistema"}
+             ] = system_model.descriptions
     end
   end
 end

--- a/backend/test/edgehog/devices_test.exs
+++ b/backend/test/edgehog/devices_test.exs
@@ -308,7 +308,7 @@ defmodule Edgehog.DevicesTest do
 
       assert [system_model_1, system_model_2] =
                Devices.list_system_models()
-               |> Devices.preload_localized_descriptions_for_system_model("it-IT")
+               |> Devices.preload_localized_descriptions_for_system_model(["it-IT"])
 
       assert [%{locale: "it-IT"}] = system_model_1.descriptions
       assert [] = system_model_2.descriptions
@@ -328,7 +328,7 @@ defmodule Edgehog.DevicesTest do
       assert {:ok, system_model} = Devices.fetch_system_model(system_model.id)
 
       system_model =
-        Devices.preload_localized_descriptions_for_system_model(system_model, "it-IT")
+        Devices.preload_localized_descriptions_for_system_model(system_model, ["it-IT"])
 
       assert Enum.map(system_model.descriptions, & &1.locale) == ["it-IT"]
     end

--- a/backend/test/edgehog_web/context_test.exs
+++ b/backend/test/edgehog_web/context_test.exs
@@ -1,0 +1,57 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.ContextTest do
+  use EdgehogWeb.ConnCase
+
+  alias EdgehogWeb.Context
+
+  test "build_context/1 fetches preferred locales from accept-language header", %{
+    conn: conn,
+    tenant: tenant
+  } do
+    default_locale = tenant.default_locale
+    conn = Plug.Conn.assign(conn, :current_tenant, tenant)
+
+    language_headers = [
+      {"accept-language", "it-IT,it;q=0.8,en-UK;q=0.6,en;q=0.4"},
+      {"accept-language", "#{default_locale}"},
+      {"accept-language", "fr-FR,fr;q=0.8,en-UK;q=0.6,en;q=0.4"}
+    ]
+
+    conn = %{conn | req_headers: conn.req_headers ++ language_headers}
+
+    %{preferred_locales: preferred_locales} = Context.build_context(conn)
+
+    assert ["it-IT", "en-UK", ^default_locale, "fr-FR"] = preferred_locales
+  end
+
+  test "build_context/1 uses the tenant's default locale without accept-language headers", %{
+    conn: conn,
+    tenant: tenant
+  } do
+    default_locale = tenant.default_locale
+    conn = Plug.Conn.assign(conn, :current_tenant, tenant)
+
+    %{preferred_locales: preferred_locales} = Context.build_context(conn)
+
+    assert [^default_locale] = preferred_locales
+  end
+end

--- a/backend/test/edgehog_web/resolvers/devices_test.exs
+++ b/backend/test/edgehog_web/resolvers/devices_test.exs
@@ -28,7 +28,7 @@ defmodule EdgehogWeb.Resolvers.DevicesTest do
 
   describe "hardware_types" do
     setup %{tenant: tenant} do
-      context = %{current_tenant: tenant}
+      context = %{current_tenant: tenant, preferred_locales: [tenant.default_locale]}
 
       {:ok, context: context}
     end
@@ -63,7 +63,7 @@ defmodule EdgehogWeb.Resolvers.DevicesTest do
 
   describe "system_models" do
     setup %{tenant: tenant} do
-      context = %{current_tenant: tenant}
+      context = %{current_tenant: tenant, preferred_locales: [tenant.default_locale]}
 
       {:ok, context: context}
     end

--- a/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
@@ -209,13 +209,13 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
       assert %SystemModel{descriptions: [%{locale: "en-US", text: "Another system model"}]} =
                Devices.preload_localized_descriptions_for_system_model(
                  system_model,
-                 default_locale
+                 [default_locale]
                )
 
       assert %SystemModel{descriptions: [%{locale: "it-IT", text: "Un modello di sistema"}]} =
                Devices.preload_localized_descriptions_for_system_model(
                  system_model,
-                 "it-IT"
+                 ["it-IT"]
                )
     end
 

--- a/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
@@ -206,16 +206,15 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
 
       assert {:ok, system_model} = Devices.fetch_system_model(system_model.id)
 
-      assert %SystemModel{descriptions: [%{locale: "en-US", text: "Another system model"}]} =
+      assert %SystemModel{
+               descriptions: [
+                 %{locale: "it-IT", text: "Un modello di sistema"},
+                 %{locale: "en-US", text: "Another system model"}
+               ]
+             } =
                Devices.preload_localized_descriptions_for_system_model(
                  system_model,
-                 [default_locale]
-               )
-
-      assert %SystemModel{descriptions: [%{locale: "it-IT", text: "Un modello di sistema"}]} =
-               Devices.preload_localized_descriptions_for_system_model(
-                 system_model,
-                 ["it-IT"]
+                 ["it-IT", default_locale]
                )
     end
 

--- a/backend/test/edgehog_web/schema/query/system_models_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_models_test.exs
@@ -137,7 +137,7 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
       assert system_model["description"]["text"] == "Un modello di sistema"
     end
 
-    test "returns empty description for non existing locale", %{
+    test "returns description in the tenant's default locale for non existing locale", %{
       conn: conn,
       api_path: api_path,
       tenant: tenant
@@ -164,7 +164,36 @@ defmodule EdgehogWeb.Schema.Query.SystemModelsTest do
                }
              } = json_response(conn, 200)
 
-      assert system_model["description"] == nil
+      assert %{"locale" => ^default_locale, "text" => "A system model"} =
+               system_model["description"]
+    end
+
+    test "returns no description when both user and tenant's locale are missing", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      hardware_type = hardware_type_fixture()
+
+      descriptions = [
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      _system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "fr-FR")
+        |> get(api_path, query: @query)
+
+      assert %{
+               "data" => %{
+                 "systemModels" => [
+                   %{
+                     "description" => nil
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
     end
   end
 end

--- a/frontend/src/forms/UpdateSystemModel.tsx
+++ b/frontend/src/forms/UpdateSystemModel.tsx
@@ -68,10 +68,10 @@ type SystemModelData = {
 type SystemModelChanges = {
   name: string;
   handle: string;
-  description?: {
+  description: {
     locale: string;
     text: string;
-  };
+  } | null;
   hardwareType: {
     name: string;
   };
@@ -137,19 +137,18 @@ const transformOutputData = (
       name: data.hardwareType,
     },
     partNumbers: data.partNumbers.map((pn) => pn.value),
+    description: data.description
+      ? {
+          locale,
+          text: data.description,
+        }
+      : null,
   };
 
   if (data.pictureFile) {
     systemModel.pictureFile = data.pictureFile[0];
   } else if (data.pictureFile === null) {
     systemModel.pictureUrl = null;
-  }
-
-  if (data.description) {
-    systemModel.description = {
-      locale,
-      text: data.description,
-    };
   }
 
   return systemModel;


### PR DESCRIPTION
Currently, saving translated descriptions for System Models doesn't work when the browser displaying the Edgehog's frontend has a preferred locale that differs from the default one configured for the tenant. Indeed, browsers can query descriptions for a custom locale, but they can only save descriptions in the tenant's default locale.

Sample steps to reproduce the issue:
1. The browser queries a System Model asking for its translated description with, an `it-IT` locale.
2. The backend returns the System Model without a description because there is none.
3. The browser tries to update the System Model with a description in the tenant's default locale: `en-US`.
4. The subsequent query to get the updated System Model still asks for a description in `it-IT`, the preferred locale for the browser, so the backend still returns no description. Although it is persisted, the previously inserted description seems to have disappeared from the user's point of view.

The change proposed here fixes the odd behavior in the backend by:
- Preloading both the default locale of the tenant and the locale specified by the user, if any.
- Extracting the best match of translated descriptions according to locale preferences when rendering System Models in the GraphQL layer.
This way, the user is always presented with a translated description for one of the locales, if it exists at least for the tenant's default locale.

Then another fix is added to support removing previously entered descriptions:
1. Allow the frontend to pass blank descriptions.
2. Make sure the backend discards and remove empty descriptions.

With these changes in place, users can now correctly see and manage descriptions at least in the tenant's locale until a full i18n support is implemented.