### PR TITLE
[backend] Add Base Image Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relevant for OTA updates). Defaults to 4 GB.
 - Allow creating and managing groups based on selectors.
 - Add support for device's `network_interfaces` ([#231](https://github.com/edgehog-device-manager/edgehog/pull/231))
+- Add support for base image collections ([#229](https://github.com/edgehog-device-manager/edgehog/pull/229)).
 
 ### Changed
 - Handle Device part numbers for nonexistent system models

--- a/backend/lib/edgehog/base_images.ex
+++ b/backend/lib/edgehog/base_images.ex
@@ -1,0 +1,124 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.BaseImages do
+  @moduledoc """
+  The BaseImages context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Edgehog.Repo
+
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  @doc """
+  Returns the list of base_image_collections.
+
+  ## Examples
+
+      iex> list_base_image_collections()
+      [%BaseImageCollection{}, ...]
+
+  """
+  def list_base_image_collections do
+    Repo.all(BaseImageCollection)
+  end
+
+  @doc """
+  Gets a single base_image_collection.
+
+  Raises `Ecto.NoResultsError` if the Base image collection does not exist.
+
+  ## Examples
+
+      iex> get_base_image_collection!(123)
+      %BaseImageCollection{}
+
+      iex> get_base_image_collection!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_base_image_collection!(id), do: Repo.get!(BaseImageCollection, id)
+
+  @doc """
+  Creates a base_image_collection.
+
+  ## Examples
+
+      iex> create_base_image_collection(%{field: value})
+      {:ok, %BaseImageCollection{}}
+
+      iex> create_base_image_collection(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_base_image_collection(attrs \\ %{}) do
+    %BaseImageCollection{}
+    |> BaseImageCollection.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a base_image_collection.
+
+  ## Examples
+
+      iex> update_base_image_collection(base_image_collection, %{field: new_value})
+      {:ok, %BaseImageCollection{}}
+
+      iex> update_base_image_collection(base_image_collection, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_base_image_collection(%BaseImageCollection{} = base_image_collection, attrs) do
+    base_image_collection
+    |> BaseImageCollection.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a base_image_collection.
+
+  ## Examples
+
+      iex> delete_base_image_collection(base_image_collection)
+      {:ok, %BaseImageCollection{}}
+
+      iex> delete_base_image_collection(base_image_collection)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_base_image_collection(%BaseImageCollection{} = base_image_collection) do
+    Repo.delete(base_image_collection)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking base_image_collection changes.
+
+  ## Examples
+
+      iex> change_base_image_collection(base_image_collection)
+      %Ecto.Changeset{data: %BaseImageCollection{}}
+
+  """
+  def change_base_image_collection(%BaseImageCollection{} = base_image_collection, attrs \\ %{}) do
+    BaseImageCollection.changeset(base_image_collection, attrs)
+  end
+end

--- a/backend/lib/edgehog/base_images.ex
+++ b/backend/lib/edgehog/base_images.ex
@@ -43,20 +43,28 @@ defmodule Edgehog.BaseImages do
   end
 
   @doc """
-  Gets a single base_image_collection.
+  Fetches a single base_image_collection.
 
-  Raises `Ecto.NoResultsError` if the Base image collection does not exist.
+  Returns `{:ok, base_image_collection}` or `{:error, :not_found}` if the Base image collection does not exist.
 
   ## Examples
 
-      iex> get_base_image_collection!(123)
-      %BaseImageCollection{}
+      iex> fetch_base_image_collection(123)
+      {:ok, %BaseImageCollection{}}
 
-      iex> get_base_image_collection!(456)
-      ** (Ecto.NoResultsError)
+      iex> fetch_base_image_collection(456)
+      {:error, :not_found}
 
   """
-  def get_base_image_collection!(id), do: Repo.get!(BaseImageCollection, id)
+  def fetch_base_image_collection(id) do
+    case Repo.get(BaseImageCollection, id) do
+      %BaseImageCollection{} = base_image_collection ->
+        {:ok, base_image_collection}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
 
   @doc """
   Creates a base_image_collection.

--- a/backend/lib/edgehog/base_images.ex
+++ b/backend/lib/edgehog/base_images.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.BaseImages do
   import Ecto.Query, warn: false
   alias Edgehog.Repo
 
+  alias Edgehog.Devices
   alias Edgehog.BaseImages.BaseImageCollection
 
   @doc """
@@ -62,15 +63,15 @@ defmodule Edgehog.BaseImages do
 
   ## Examples
 
-      iex> create_base_image_collection(%{field: value})
+      iex> create_base_image_collection(%Devices.SystemModel{}, %{field: value})
       {:ok, %BaseImageCollection{}}
 
-      iex> create_base_image_collection(%{field: bad_value})
+      iex> create_base_image_collection(%Devices.SystemModel{}, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_base_image_collection(attrs \\ %{}) do
-    %BaseImageCollection{}
+  def create_base_image_collection(%Devices.SystemModel{} = system_model, attrs \\ %{}) do
+    %BaseImageCollection{system_model_id: system_model.id}
     |> BaseImageCollection.changeset(attrs)
     |> Repo.insert()
   end

--- a/backend/lib/edgehog/base_images/base_image_collection.ex
+++ b/backend/lib/edgehog/base_images/base_image_collection.ex
@@ -22,10 +22,13 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Edgehog.Devices
+
   schema "base_image_collections" do
+    field :tenant_id, :integer, autogenerate: {Edgehog.Repo, :get_tenant_id, []}
     field :handle, :string
     field :name, :string
-    field :system_model_id, :id
+    belongs_to :system_model, Devices.SystemModel
 
     timestamps()
   end
@@ -35,8 +38,12 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
     base_image_collection
     |> cast(attrs, [:name, :handle])
     |> validate_required([:name, :handle])
-    |> unique_constraint(:system_model_id)
-    |> unique_constraint(:handle)
-    |> unique_constraint(:name)
+    |> unique_constraint([:system_model_id, :tenant_id])
+    |> unique_constraint([:name, :tenant_id])
+    |> unique_constraint([:handle, :tenant_id])
+    |> validate_format(:handle, ~r/^[a-z][a-z\d\-]*$/,
+      message:
+        "should start with a lower case ASCII letter and only contain lower case ASCII letters, digits and -"
+    )
   end
 end

--- a/backend/lib/edgehog/base_images/base_image_collection.ex
+++ b/backend/lib/edgehog/base_images/base_image_collection.ex
@@ -1,0 +1,42 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.BaseImages.BaseImageCollection do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "base_image_collections" do
+    field :handle, :string
+    field :name, :string
+    field :system_model_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(base_image_collection, attrs) do
+    base_image_collection
+    |> cast(attrs, [:name, :handle])
+    |> validate_required([:name, :handle])
+    |> unique_constraint(:system_model_id)
+    |> unique_constraint(:handle)
+    |> unique_constraint(:name)
+  end
+end

--- a/backend/lib/edgehog/devices.ex
+++ b/backend/lib/edgehog/devices.ex
@@ -164,18 +164,18 @@ defmodule Edgehog.Devices do
   end
 
   @doc """
-  Preloads a system model for a device (or a list of devices)
+  Preloads a system model for a resource (or a list of resources) associated with it.
 
   Supported options:
   - `:force` a boolean indicating if the preload has to be read from the database also if it's
   already populated. Defaults to `false`.
   - `:preload` the option passed to the preload, can be a query or a list of atoms. Defaults to `[]`.
   """
-  def preload_system_model_for_device(device_or_devices, opts \\ []) do
+  def preload_system_model(target_resource, opts \\ []) do
     force = Keyword.get(opts, :force, false)
     preload = Keyword.get(opts, :preload, [])
 
-    Repo.preload(device_or_devices, [system_model: preload], force: force)
+    Repo.preload(target_resource, [system_model: preload], force: force)
   end
 
   @doc """

--- a/backend/lib/edgehog_web/resolvers/base_images.ex
+++ b/backend/lib/edgehog_web/resolvers/base_images.ex
@@ -1,0 +1,92 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Resolvers.BaseImages do
+  alias Edgehog.BaseImages
+  alias Edgehog.BaseImages.BaseImageCollection
+  alias Edgehog.Devices
+  alias Edgehog.Devices.SystemModel
+  alias EdgehogWeb.Resolvers
+
+  def find_base_image_collection(args, resolution) do
+    with {:ok, base_image_collection} <- BaseImages.fetch_base_image_collection(args.id) do
+      base_image_collection =
+        Resolvers.Devices.preload_localized_system_model(
+          base_image_collection,
+          resolution.context
+        )
+
+      {:ok, base_image_collection}
+    end
+  end
+
+  def list_base_image_collections(_args, resolution) do
+    base_image_collections =
+      BaseImages.list_base_image_collections()
+      |> Resolvers.Devices.preload_localized_system_model(resolution.context)
+
+    {:ok, base_image_collections}
+  end
+
+  def create_base_image_collection(attrs, resolution) do
+    with {:ok, %SystemModel{} = system_model} <-
+           Devices.fetch_system_model(attrs.system_model_id),
+         {:ok, base_image_collection} <-
+           BaseImages.create_base_image_collection(system_model, attrs) do
+      base_image_collection =
+        Resolvers.Devices.preload_localized_system_model(
+          base_image_collection,
+          resolution.context
+        )
+
+      {:ok, %{base_image_collection: base_image_collection}}
+    end
+  end
+
+  def update_base_image_collection(attrs, resolution) do
+    with {:ok, %BaseImageCollection{} = base_image_collection} <-
+           BaseImages.fetch_base_image_collection(attrs.base_image_collection_id),
+         {:ok, %BaseImageCollection{} = base_image_collection} <-
+           BaseImages.update_base_image_collection(base_image_collection, attrs) do
+      base_image_collection =
+        Resolvers.Devices.preload_localized_system_model(
+          base_image_collection,
+          resolution.context
+        )
+
+      {:ok, %{base_image_collection: base_image_collection}}
+    end
+  end
+
+  def delete_base_image_collection(args, resolution) do
+    with {:ok, %BaseImageCollection{} = base_image_collection} <-
+           BaseImages.fetch_base_image_collection(args.base_image_collection_id),
+         {:ok, %BaseImageCollection{} = base_image_collection} <-
+           BaseImages.delete_base_image_collection(base_image_collection) do
+      base_image_collection =
+        Resolvers.Devices.preload_localized_system_model(
+          base_image_collection,
+          resolution.context
+        )
+
+      {:ok, %{base_image_collection: base_image_collection}}
+    end
+  end
+end

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -44,7 +44,7 @@ defmodule EdgehogWeb.Resolvers.Devices do
   def find_device(%{id: id}, %{context: context} = resolution) do
     device =
       Devices.get_device!(id)
-      |> preload_system_model_for_device(context)
+      |> preload_localized_system_model(context)
       |> maybe_preload_astarte_resources_for_device(resolution)
 
     {:ok, device}
@@ -71,7 +71,7 @@ defmodule EdgehogWeb.Resolvers.Devices do
   def list_devices(_parent, %{filter: filter}, %{context: context} = resolution) do
     devices =
       Devices.list_devices(filter)
-      |> preload_system_model_for_device(context)
+      |> preload_localized_system_model(context)
       |> maybe_preload_astarte_resources_for_device(resolution)
 
     {:ok, devices}
@@ -80,7 +80,7 @@ defmodule EdgehogWeb.Resolvers.Devices do
   def list_devices(_parent, _args, %{context: context} = resolution) do
     devices =
       Devices.list_devices()
-      |> preload_system_model_for_device(context)
+      |> preload_localized_system_model(context)
       |> maybe_preload_astarte_resources_for_device(resolution)
 
     {:ok, devices}
@@ -93,14 +93,14 @@ defmodule EdgehogWeb.Resolvers.Devices do
     with {:ok, device} <- Devices.update_device(device, attrs) do
       device =
         device
-        |> preload_system_model_for_device(context)
+        |> preload_localized_system_model(context)
         |> maybe_preload_astarte_resources_for_device(resolution)
 
       {:ok, %{device: device}}
     end
   end
 
-  def preload_system_model_for_device(target, context) do
+  def preload_localized_system_model(target, context) do
     descriptions_query =
       context
       |> Map.fetch!(:preferred_locales)
@@ -108,7 +108,7 @@ defmodule EdgehogWeb.Resolvers.Devices do
 
     preload = [descriptions: descriptions_query, hardware_type: [], part_numbers: []]
 
-    Devices.preload_system_model_for_device(target, preload: preload)
+    Devices.preload_system_model(target, preload: preload)
   end
 
   defp maybe_preload_astarte_resources_for_device(device, resolution) do

--- a/backend/lib/edgehog_web/resolvers/groups.ex
+++ b/backend/lib/edgehog_web/resolvers/groups.ex
@@ -44,7 +44,7 @@ defmodule EdgehogWeb.Resolvers.Groups do
   def devices_for_group(%DeviceGroup{} = device_group, _args, %{context: context} = _resolution) do
     devices =
       Groups.list_devices_in_group(device_group)
-      |> Resolvers.Devices.preload_system_model_for_device(context)
+      |> Resolvers.Devices.preload_localized_system_model(context)
 
     {:ok, devices}
   end

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -22,6 +22,7 @@ defmodule EdgehogWeb.Schema do
   use Absinthe.Schema
   use Absinthe.Relay.Schema, :modern
   import_types EdgehogWeb.Schema.AstarteTypes
+  import_types EdgehogWeb.Schema.BaseImagesTypes
   import_types EdgehogWeb.Schema.CapabilitiesTypes
   import_types EdgehogWeb.Schema.DevicesTypes
   import_types EdgehogWeb.Schema.GeolocationTypes
@@ -51,6 +52,9 @@ defmodule EdgehogWeb.Schema do
       %Edgehog.Astarte.Device{}, _ ->
         :device
 
+      %Edgehog.BaseImages.BaseImageCollection{}, _ ->
+        :base_image_collection
+
       %Edgehog.Devices.HardwareType{}, _ ->
         :hardware_type
 
@@ -71,6 +75,9 @@ defmodule EdgehogWeb.Schema do
   query do
     node field do
       resolve fn
+        %{type: :base_image_collection, id: id}, context ->
+          Resolvers.BaseImages.find_base_image_collection(%{id: id}, context)
+
         %{type: :device, id: id}, context ->
           Resolvers.Devices.find_device(%{id: id}, context)
 
@@ -88,6 +95,7 @@ defmodule EdgehogWeb.Schema do
       end
     end
 
+    import_fields :base_images_queries
     import_fields :devices_queries
     import_fields :groups_queries
     import_fields :labeling_queries
@@ -96,6 +104,7 @@ defmodule EdgehogWeb.Schema do
 
   mutation do
     import_fields :astarte_mutations
+    import_fields :base_images_mutations
     import_fields :devices_mutations
     import_fields :groups_mutations
     import_fields :os_management_mutations

--- a/backend/lib/edgehog_web/schema/base_images_types.ex
+++ b/backend/lib/edgehog_web/schema/base_images_types.ex
@@ -1,0 +1,135 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.BaseImagesTypes do
+  use Absinthe.Schema.Notation
+  use Absinthe.Relay.Schema.Notation, :modern
+
+  alias EdgehogWeb.Resolvers
+
+  @desc """
+  Represents a collection of Base Images.
+
+  A base image collection represents the collection of all Base Images that \
+  can run on a specific System Model.
+  """
+  node object(:base_image_collection) do
+    @desc "The display name of the base image collection."
+    field :name, non_null(:string)
+
+    @desc "The identifier of the base image collection."
+    field :handle, non_null(:string)
+
+    @desc "The System Model associated with the Base Image Collection"
+    field :system_model, :system_model
+  end
+
+  object :base_images_queries do
+    @desc "Fetches the list of all base image collections."
+    field :base_image_collections, non_null(list_of(non_null(:base_image_collection))) do
+      resolve &Resolvers.BaseImages.list_base_image_collections/2
+    end
+
+    @desc "Fetches a single base image collection."
+    field :base_image_collection, :base_image_collection do
+      @desc "The ID of the base image collection."
+      arg :id, non_null(:id)
+
+      middleware Absinthe.Relay.Node.ParseIDs, id: :base_image_collection
+      resolve &Resolvers.BaseImages.find_base_image_collection/2
+    end
+  end
+
+  object :base_images_mutations do
+    @desc "Creates a new base image collection."
+    payload field :create_base_image_collection do
+      input do
+        @desc "The display name of the base image collection."
+        field :name, non_null(:string)
+
+        @desc """
+        The identifier of the base image collection.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
+        field :handle, non_null(:string)
+
+        @desc """
+        The ID of the system model that is targeted by this base image collection
+        """
+        field :system_model_id, non_null(:id)
+      end
+
+      output do
+        @desc "The created base image collection."
+        field :base_image_collection, non_null(:base_image_collection)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, system_model_id: :system_model
+
+      resolve &Resolvers.BaseImages.create_base_image_collection/2
+    end
+
+    @desc "Updates a base image collection."
+    payload field :update_base_image_collection do
+      input do
+        @desc "The ID of the base image collection to be updated."
+        field :base_image_collection_id, non_null(:id)
+
+        @desc "The display name of the base image collection."
+        field :name, :string
+
+        @desc """
+        The identifier of the base image collection.
+
+        It should start with a lower case ASCII letter and only contain \
+        lower case ASCII letters, digits and the hyphen - symbol.
+        """
+        field :handle, :string
+      end
+
+      output do
+        @desc "The updated base image collection."
+        field :base_image_collection, non_null(:base_image_collection)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, base_image_collection_id: :base_image_collection
+
+      resolve &Resolvers.BaseImages.update_base_image_collection/2
+    end
+
+    @desc "Deletes a base image collection."
+    payload field :delete_base_image_collection do
+      input do
+        @desc "The ID of the base image collection to be deleted."
+        field :base_image_collection_id, non_null(:id)
+      end
+
+      output do
+        @desc "The deleted base image collection."
+        field :base_image_collection, non_null(:base_image_collection)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, base_image_collection_id: :base_image_collection
+      resolve &Resolvers.BaseImages.delete_base_image_collection/2
+    end
+  end
+end

--- a/backend/priv/repo/migrations/20221219105630_create_base_image_collections.exs
+++ b/backend/priv/repo/migrations/20221219105630_create_base_image_collections.exs
@@ -23,15 +23,25 @@ defmodule Edgehog.Repo.Migrations.CreateBaseImageCollections do
 
   def change do
     create table(:base_image_collections) do
-      add :name, :string
-      add :handle, :string
-      add :system_model_id, references(:system_models, on_delete: :nothing)
+      add :tenant_id, references(:tenants, column: :tenant_id, on_delete: :delete_all),
+        null: false
+
+      add :name, :string, null: false
+      add :handle, :string, null: false
+
+      add :system_model_id,
+          references(:system_models,
+            with: [tenant_id: :tenant_id],
+            match: :full,
+            on_delete: :nothing
+          ),
+          null: false
 
       timestamps()
     end
 
-    create unique_index(:base_image_collections, [:system_model_id])
-    create unique_index(:base_image_collections, [:handle])
-    create unique_index(:base_image_collections, [:name])
+    create unique_index(:base_image_collections, [:system_model_id, :tenant_id])
+    create unique_index(:base_image_collections, [:handle, :tenant_id])
+    create unique_index(:base_image_collections, [:name, :tenant_id])
   end
 end

--- a/backend/priv/repo/migrations/20221219105630_create_base_image_collections.exs
+++ b/backend/priv/repo/migrations/20221219105630_create_base_image_collections.exs
@@ -1,0 +1,37 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.CreateBaseImageCollections do
+  use Ecto.Migration
+
+  def change do
+    create table(:base_image_collections) do
+      add :name, :string
+      add :handle, :string
+      add :system_model_id, references(:system_models, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create unique_index(:base_image_collections, [:system_model_id])
+    create unique_index(:base_image_collections, [:handle])
+    create unique_index(:base_image_collections, [:name])
+  end
+end

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -19,8 +19,9 @@
 #
 
 alias Edgehog.{
-  Devices,
   Astarte,
+  BaseImages,
+  Devices,
   Tenants
 }
 
@@ -69,4 +70,10 @@ _ = Edgehog.Repo.put_tenant_id(tenant.tenant_id)
     name: "Thingie",
     device_id: "DqL4H107S42WBEHmDrvPLQ",
     part_number: "AM-1234"
+  })
+
+{:ok, _base_image_collection} =
+  BaseImages.create_base_image_collection(system_model, %{
+    handle: "ultra-firmware",
+    name: "Ultra Firmware"
   })

--- a/backend/test/edgehog/base_images_test.exs
+++ b/backend/test/edgehog/base_images_test.exs
@@ -1,0 +1,96 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.BaseImagesTest do
+  use Edgehog.DataCase
+
+  alias Edgehog.BaseImages
+
+  describe "base_image_collections" do
+    alias Edgehog.BaseImages.BaseImageCollection
+
+    import Edgehog.BaseImagesFixtures
+
+    @invalid_attrs %{handle: nil, name: nil}
+
+    test "list_base_image_collections/0 returns all base_image_collections" do
+      base_image_collection = base_image_collection_fixture()
+      assert BaseImages.list_base_image_collections() == [base_image_collection]
+    end
+
+    test "get_base_image_collection!/1 returns the base_image_collection with given id" do
+      base_image_collection = base_image_collection_fixture()
+
+      assert BaseImages.get_base_image_collection!(base_image_collection.id) ==
+               base_image_collection
+    end
+
+    test "create_base_image_collection/1 with valid data creates a base_image_collection" do
+      valid_attrs = %{handle: "some handle", name: "some name"}
+
+      assert {:ok, %BaseImageCollection{} = base_image_collection} =
+               BaseImages.create_base_image_collection(valid_attrs)
+
+      assert base_image_collection.handle == "some handle"
+      assert base_image_collection.name == "some name"
+    end
+
+    test "create_base_image_collection/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = BaseImages.create_base_image_collection(@invalid_attrs)
+    end
+
+    test "update_base_image_collection/2 with valid data updates the base_image_collection" do
+      base_image_collection = base_image_collection_fixture()
+      update_attrs = %{handle: "some updated handle", name: "some updated name"}
+
+      assert {:ok, %BaseImageCollection{} = base_image_collection} =
+               BaseImages.update_base_image_collection(base_image_collection, update_attrs)
+
+      assert base_image_collection.handle == "some updated handle"
+      assert base_image_collection.name == "some updated name"
+    end
+
+    test "update_base_image_collection/2 with invalid data returns error changeset" do
+      base_image_collection = base_image_collection_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               BaseImages.update_base_image_collection(base_image_collection, @invalid_attrs)
+
+      assert base_image_collection ==
+               BaseImages.get_base_image_collection!(base_image_collection.id)
+    end
+
+    test "delete_base_image_collection/1 deletes the base_image_collection" do
+      base_image_collection = base_image_collection_fixture()
+
+      assert {:ok, %BaseImageCollection{}} =
+               BaseImages.delete_base_image_collection(base_image_collection)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        BaseImages.get_base_image_collection!(base_image_collection.id)
+      end
+    end
+
+    test "change_base_image_collection/1 returns a base_image_collection changeset" do
+      base_image_collection = base_image_collection_fixture()
+      assert %Ecto.Changeset{} = BaseImages.change_base_image_collection(base_image_collection)
+    end
+  end
+end

--- a/backend/test/edgehog/base_images_test.exs
+++ b/backend/test/edgehog/base_images_test.exs
@@ -44,13 +44,13 @@ defmodule Edgehog.BaseImagesTest do
       assert BaseImages.list_base_image_collections() == [base_image_collection]
     end
 
-    test "get_base_image_collection!/1 returns the base_image_collection with given id", %{
+    test "fetch_base_image_collection/1 returns the base_image_collection with given id", %{
       system_model: system_model
     } do
       base_image_collection = base_image_collection_fixture(system_model)
 
-      assert BaseImages.get_base_image_collection!(base_image_collection.id) ==
-               base_image_collection
+      assert BaseImages.fetch_base_image_collection(base_image_collection.id) ==
+               {:ok, base_image_collection}
     end
 
     test "create_base_image_collection/2 with valid data creates a base_image_collection", %{
@@ -93,8 +93,8 @@ defmodule Edgehog.BaseImagesTest do
       assert {:error, %Ecto.Changeset{}} =
                BaseImages.update_base_image_collection(base_image_collection, @invalid_attrs)
 
-      assert base_image_collection ==
-               BaseImages.get_base_image_collection!(base_image_collection.id)
+      assert {:ok, base_image_collection} ==
+               BaseImages.fetch_base_image_collection(base_image_collection.id)
     end
 
     test "delete_base_image_collection/1 deletes the base_image_collection", %{
@@ -105,9 +105,8 @@ defmodule Edgehog.BaseImagesTest do
       assert {:ok, %BaseImageCollection{}} =
                BaseImages.delete_base_image_collection(base_image_collection)
 
-      assert_raise Ecto.NoResultsError, fn ->
-        BaseImages.get_base_image_collection!(base_image_collection.id)
-      end
+      assert {:error, :not_found} ==
+               BaseImages.fetch_base_image_collection(base_image_collection.id)
     end
 
     test "change_base_image_collection/1 returns a base_image_collection changeset", %{

--- a/backend/test/edgehog/base_images_test.exs
+++ b/backend/test/edgehog/base_images_test.exs
@@ -27,48 +27,68 @@ defmodule Edgehog.BaseImagesTest do
     alias Edgehog.BaseImages.BaseImageCollection
 
     import Edgehog.BaseImagesFixtures
+    import Edgehog.DevicesFixtures
 
-    @invalid_attrs %{handle: nil, name: nil}
+    setup do
+      hardware_type = hardware_type_fixture()
 
-    test "list_base_image_collections/0 returns all base_image_collections" do
-      base_image_collection = base_image_collection_fixture()
+      {:ok, system_model: system_model_fixture(hardware_type)}
+    end
+
+    @invalid_attrs %{handle: "3 invalid handle", name: ""}
+
+    test "list_base_image_collections/0 returns all base_image_collections", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
       assert BaseImages.list_base_image_collections() == [base_image_collection]
     end
 
-    test "get_base_image_collection!/1 returns the base_image_collection with given id" do
-      base_image_collection = base_image_collection_fixture()
+    test "get_base_image_collection!/1 returns the base_image_collection with given id", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
 
       assert BaseImages.get_base_image_collection!(base_image_collection.id) ==
                base_image_collection
     end
 
-    test "create_base_image_collection/1 with valid data creates a base_image_collection" do
-      valid_attrs = %{handle: "some handle", name: "some name"}
+    test "create_base_image_collection/2 with valid data creates a base_image_collection", %{
+      system_model: system_model
+    } do
+      valid_attrs = %{handle: "some-handle", name: "some name"}
 
       assert {:ok, %BaseImageCollection{} = base_image_collection} =
-               BaseImages.create_base_image_collection(valid_attrs)
+               BaseImages.create_base_image_collection(system_model, valid_attrs)
 
-      assert base_image_collection.handle == "some handle"
+      assert base_image_collection.handle == "some-handle"
       assert base_image_collection.name == "some name"
     end
 
-    test "create_base_image_collection/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = BaseImages.create_base_image_collection(@invalid_attrs)
+    test "create_base_image_collection/2 with invalid data returns error changeset", %{
+      system_model: system_model
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               BaseImages.create_base_image_collection(system_model, @invalid_attrs)
     end
 
-    test "update_base_image_collection/2 with valid data updates the base_image_collection" do
-      base_image_collection = base_image_collection_fixture()
-      update_attrs = %{handle: "some updated handle", name: "some updated name"}
+    test "update_base_image_collection/2 with valid data updates the base_image_collection", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
+      update_attrs = %{handle: "some-updated-handle", name: "some updated name"}
 
       assert {:ok, %BaseImageCollection{} = base_image_collection} =
                BaseImages.update_base_image_collection(base_image_collection, update_attrs)
 
-      assert base_image_collection.handle == "some updated handle"
+      assert base_image_collection.handle == "some-updated-handle"
       assert base_image_collection.name == "some updated name"
     end
 
-    test "update_base_image_collection/2 with invalid data returns error changeset" do
-      base_image_collection = base_image_collection_fixture()
+    test "update_base_image_collection/2 with invalid data returns error changeset", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
 
       assert {:error, %Ecto.Changeset{}} =
                BaseImages.update_base_image_collection(base_image_collection, @invalid_attrs)
@@ -77,8 +97,10 @@ defmodule Edgehog.BaseImagesTest do
                BaseImages.get_base_image_collection!(base_image_collection.id)
     end
 
-    test "delete_base_image_collection/1 deletes the base_image_collection" do
-      base_image_collection = base_image_collection_fixture()
+    test "delete_base_image_collection/1 deletes the base_image_collection", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
 
       assert {:ok, %BaseImageCollection{}} =
                BaseImages.delete_base_image_collection(base_image_collection)
@@ -88,8 +110,10 @@ defmodule Edgehog.BaseImagesTest do
       end
     end
 
-    test "change_base_image_collection/1 returns a base_image_collection changeset" do
-      base_image_collection = base_image_collection_fixture()
+    test "change_base_image_collection/1 returns a base_image_collection changeset", %{
+      system_model: system_model
+    } do
+      base_image_collection = base_image_collection_fixture(system_model)
       assert %Ecto.Changeset{} = BaseImages.change_base_image_collection(base_image_collection)
     end
   end

--- a/backend/test/edgehog/devices_test.exs
+++ b/backend/test/edgehog/devices_test.exs
@@ -698,15 +698,15 @@ defmodule Edgehog.DevicesTest do
 
       device_1 =
         device_fixture(realm, part_number: part_number_1)
-        |> Devices.preload_system_model_for_device()
+        |> Devices.preload_system_model()
 
       device_2 =
         device_fixture(realm, part_number: part_number_2)
-        |> Devices.preload_system_model_for_device()
+        |> Devices.preload_system_model()
 
       device_3 =
         device_fixture(realm, part_number: "4321-rev1")
-        |> Devices.preload_system_model_for_device()
+        |> Devices.preload_system_model()
 
       assert device_1.system_model == nil
       assert device_2.system_model == nil
@@ -722,9 +722,9 @@ defmodule Edgehog.DevicesTest do
                Devices.create_system_model(hardware_type, attrs)
 
       preload = [hardware_type: [], part_numbers: []]
-      device_1 = Devices.preload_system_model_for_device(device_1, force: true, preload: preload)
-      device_2 = Devices.preload_system_model_for_device(device_2, force: true, preload: preload)
-      device_3 = Devices.preload_system_model_for_device(device_3, force: true, preload: preload)
+      device_1 = Devices.preload_system_model(device_1, force: true, preload: preload)
+      device_2 = Devices.preload_system_model(device_2, force: true, preload: preload)
+      device_3 = Devices.preload_system_model(device_3, force: true, preload: preload)
 
       assert device_1.system_model == system_model
       assert device_2.system_model == system_model
@@ -844,7 +844,7 @@ defmodule Edgehog.DevicesTest do
       device =
         realm
         |> device_fixture(part_number: part_number)
-        |> Devices.preload_system_model_for_device(
+        |> Devices.preload_system_model(
           force: true,
           preload: [hardware_type: [], part_numbers: []]
         )
@@ -854,7 +854,7 @@ defmodule Edgehog.DevicesTest do
       assert {:ok, %SystemModel{}} = Devices.delete_system_model(system_model)
       assert Devices.fetch_system_model(system_model.id) == {:error, :not_found}
 
-      device = Devices.preload_system_model_for_device(device, force: true)
+      device = Devices.preload_system_model(device, force: true)
       assert device.system_model == nil
       assert device.part_number == part_number
     end

--- a/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
+++ b/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
@@ -189,7 +189,7 @@ defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
       assert response(conn, 200)
 
       assert device = Devices.get_device!(id)
-      device = Devices.preload_system_model_for_device(device)
+      device = Devices.preload_system_model(device)
       assert device.system_model.id == system_model.id
       assert device.system_model.name == system_model.name
       assert device.system_model.handle == system_model.handle
@@ -226,7 +226,7 @@ defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
       device =
         id
         |> Devices.get_device!()
-        |> Devices.preload_system_model_for_device()
+        |> Devices.preload_system_model()
 
       assert device.part_number == part_number
       assert device.system_model_part_number == nil

--- a/backend/test/edgehog_web/schema/mutation/create_base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_base_image_collection_test.exs
@@ -1,0 +1,139 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.CreateBaseImageCollectionTest do
+  use EdgehogWeb.ConnCase
+
+  alias Edgehog.BaseImages
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  import Edgehog.DevicesFixtures
+
+  describe "createBaseImageCollection field" do
+    setup do
+      hardware_type = hardware_type_fixture()
+
+      {:ok, system_model: system_model_fixture(hardware_type)}
+    end
+
+    @query """
+    mutation CreateBaseImageCollection($input: CreateBaseImageCollectionInput!) {
+      createBaseImageCollection(input: $input) {
+        baseImageCollection {
+          id
+          name
+          handle
+          systemModel {
+            id
+            name
+            handle
+          }
+        }
+      }
+    }
+    """
+    test "creates base image collection with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      system_model: system_model
+    } do
+      name = "Foobar"
+      handle = "foobar"
+
+      system_model_id =
+        Absinthe.Relay.Node.to_global_id(:system_model, system_model.id, EdgehogWeb.Schema)
+
+      system_model_name = system_model.name
+      system_model_handle = system_model.handle
+
+      variables = %{
+        input: %{
+          name: name,
+          handle: handle,
+          system_model_id: system_model_id
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "createBaseImageCollection" => %{
+                   "baseImageCollection" => %{
+                     "id" => id,
+                     "name" => ^name,
+                     "handle" => ^handle,
+                     "systemModel" => %{
+                       "id" => ^system_model_id,
+                       "name" => ^system_model_name,
+                       "handle" => ^system_model_handle
+                     }
+                   }
+                 }
+               }
+             } = assert(json_response(conn, 200))
+
+      {:ok, %{type: :base_image_collection, id: db_id}} =
+        Absinthe.Relay.Node.from_global_id(id, EdgehogWeb.Schema)
+
+      assert {:ok, %BaseImageCollection{name: ^name, handle: ^handle}} =
+               BaseImages.fetch_base_image_collection(db_id)
+    end
+
+    test "fails with invalid data", %{conn: conn, api_path: api_path} do
+      variables = %{
+        input: %{
+          base_image_collection: %{
+            name: nil,
+            handle: nil
+          }
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{"errors" => _} = assert(json_response(conn, 200))
+    end
+
+    test "fails when trying to use a non-existing system model", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      name = "Foobar"
+      handle = "foobar"
+
+      system_model_id =
+        Absinthe.Relay.Node.to_global_id(:system_model, "12345678", EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          name: name,
+          handle: handle,
+          system_model_id: system_model_id
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{"errors" => [%{"status_code" => 404, "code" => "not_found"}]} =
+               assert(json_response(conn, 200))
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/mutation/delete_base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/delete_base_image_collection_test.exs
@@ -1,0 +1,180 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.DeleteBaseImageCollectionTest do
+  use EdgehogWeb.ConnCase
+
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  describe "deleteBaseImageCollection field" do
+    import Edgehog.DevicesFixtures
+    import Edgehog.BaseImagesFixtures
+
+    setup do
+      hardware_type = hardware_type_fixture()
+      {:ok, hardware_type: hardware_type}
+    end
+
+    @query """
+    mutation DeleteBaseImageCollection($input: DeleteBaseImageCollectionInput!) {
+      deleteBaseImageCollection(input: $input) {
+        baseImageCollection {
+          id
+          name
+          handle
+          systemModel {
+            description {
+              locale
+              text
+            }
+          }
+        }
+      }
+    }
+    """
+
+    test "deletes the base image collection", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_description_locale = tenant.default_locale
+      default_description_text = "A system model"
+
+      descriptions = [
+        %{locale: default_description_locale, text: default_description_text},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      name = "Ultimate Firmware"
+      handle = "ultimate-firmware"
+
+      %BaseImageCollection{id: id} =
+        base_image_collection_fixture(system_model,
+          name: name,
+          handle: handle,
+          system_model: system_model
+        )
+
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, id, EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "deleteBaseImageCollection" => %{
+                   "baseImageCollection" => %{
+                     "id" => ^id,
+                     "name" => ^name,
+                     "handle" => ^handle,
+                     "systemModel" => %{
+                       "description" => %{
+                         "locale" => ^default_description_locale,
+                         "text" => ^default_description_text
+                       }
+                     }
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns the explicit locale description of the system model", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A system model"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      name = "Ultimate Firmware"
+      handle = "ultimate-firmware"
+
+      %BaseImageCollection{id: id} =
+        base_image_collection_fixture(system_model,
+          name: name,
+          handle: handle,
+          system_model: system_model
+        )
+
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, id, EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id
+        }
+      }
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "it-IT")
+        |> post(api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "deleteBaseImageCollection" => %{
+                   "baseImageCollection" => %{
+                     "id" => ^id,
+                     "name" => ^name,
+                     "handle" => ^handle,
+                     "systemModel" => %{
+                       "description" => %{
+                         "locale" => "it-IT",
+                         "text" => "Un modello di sistema"
+                       }
+                     }
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "fails with non-existing id", %{conn: conn, api_path: api_path} do
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, 10_000_000, EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{"errors" => [%{"code" => "not_found", "status_code" => 404}]} =
+               json_response(conn, 200)
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/mutation/update_base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_base_image_collection_test.exs
@@ -1,0 +1,172 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.UpdateBaseImageCollectionTest do
+  use EdgehogWeb.ConnCase
+
+  alias Edgehog.BaseImages
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  describe "updateBaseImageCollection field" do
+    import Edgehog.BaseImagesFixtures
+    import Edgehog.DevicesFixtures
+
+    setup do
+      hardware_type = hardware_type_fixture()
+      system_model = system_model_fixture(hardware_type)
+
+      {:ok, base_image_collection: base_image_collection_fixture(system_model)}
+    end
+
+    @query """
+    mutation UpdateBaseImageCollection($input: UpdateBaseImageCollectionInput!) {
+      updateBaseImageCollection(input: $input) {
+        baseImageCollection {
+          id
+          name
+          handle
+        }
+      }
+    }
+    """
+    test "updates base image collection with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      base_image_collection: base_image_collection
+    } do
+      name = "Foobaz"
+      handle = "foobaz"
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id,
+          name: name,
+          handle: handle
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "updateBaseImageCollection" => %{
+                   "baseImageCollection" => %{
+                     "id" => ^id,
+                     "name" => ^name,
+                     "handle" => ^handle
+                   }
+                 }
+               }
+             } = assert(json_response(conn, 200))
+
+      assert {:ok, %BaseImageCollection{name: ^name, handle: ^handle}} =
+               BaseImages.fetch_base_image_collection(base_image_collection.id)
+    end
+
+    test "fails with invalid data", %{
+      conn: conn,
+      api_path: api_path,
+      base_image_collection: base_image_collection
+    } do
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id,
+          name: nil,
+          handle: nil
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{"errors" => _} = assert(json_response(conn, 200))
+    end
+
+    test "updates base image collection with partial data", %{
+      conn: conn,
+      api_path: api_path,
+      base_image_collection: base_image_collection
+    } do
+      name = "Foobarbaz"
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id,
+          name: name
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "updateBaseImageCollection" => %{
+                   "baseImageCollection" => %{
+                     "name" => ^name
+                   }
+                 }
+               }
+             } = assert(json_response(conn, 200))
+
+      assert {:ok, %BaseImageCollection{name: ^name}} =
+               BaseImages.fetch_base_image_collection(base_image_collection.id)
+    end
+
+    test "fails with non-existing id", %{conn: conn, api_path: api_path} do
+      name = "Foobaz"
+      handle = "foobaz"
+
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, 10_000_000, EdgehogWeb.Schema)
+
+      variables = %{
+        input: %{
+          base_image_collection_id: id,
+          name: name,
+          handle: handle
+        }
+      }
+
+      conn = post(conn, api_path, query: @query, variables: variables)
+
+      assert %{"errors" => [%{"code" => "not_found", "status_code" => 404}]} =
+               assert(json_response(conn, 200))
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/query/base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/query/base_image_collection_test.exs
@@ -1,0 +1,269 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.BaseImageCollectionTest do
+  use EdgehogWeb.ConnCase
+
+  import Edgehog.DevicesFixtures
+  import Edgehog.BaseImagesFixtures
+
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  describe "baseImageCollection field" do
+    setup do
+      hardware_type = hardware_type_fixture(name: "Fixture", handle: "fixture")
+      system_model = system_model_fixture(hardware_type, name: "Fixture", handle: "fixture")
+      base_image_collection = base_image_collection_fixture(system_model)
+
+      {:ok,
+       hardware_type: hardware_type,
+       system_model: system_model,
+       base_image_collection: base_image_collection}
+    end
+
+    @query """
+    query ($id: ID!) {
+      baseImageCollection(id: $id) {
+        name
+        handle
+        systemModel {
+          description {
+            locale
+            text
+          }
+        }
+      }
+    }
+    """
+    test "returns base image collection if present", %{
+      conn: conn,
+      api_path: api_path,
+      base_image_collection: base_image_collection
+    } do
+      %BaseImageCollection{
+        id: id,
+        name: name,
+        handle: handle
+      } = base_image_collection
+
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, id, EdgehogWeb.Schema)
+
+      variables = %{id: id}
+
+      conn = get(conn, api_path, query: @query, variables: variables)
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "baseImageCollection" => %{
+                   "name" => name,
+                   "handle" => handle,
+                   "systemModel" => %{
+                     "description" => nil
+                   }
+                 }
+               }
+             }
+    end
+
+    test "returns not found if non existing", %{conn: conn, api_path: api_path} do
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, 1_234_567, EdgehogWeb.Schema)
+
+      variables = %{id: id}
+
+      conn = get(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{"baseImageCollection" => nil},
+               "errors" => [%{"code" => "not_found", "status_code" => 404}]
+             } = json_response(conn, 200)
+    end
+
+    test "returns the default locale description for system model", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      base_image_collection = base_image_collection_fixture(system_model)
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{id: id}
+
+      conn = get(conn, api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollection" => %{
+                   "systemModel" => %{
+                     "description" => %{
+                       "locale" => ^default_locale,
+                       "text" => "A base image collection"
+                     }
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns the explicit locale system model description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      base_image_collection = base_image_collection_fixture(system_model)
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{id: id}
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "it-IT")
+        |> get(api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollection" => %{
+                   "systemModel" => %{
+                     "description" => %{
+                       "locale" => "it-IT",
+                       "text" => "Un modello di sistema"
+                     }
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns description in the tenant's default locale for non existing locale", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      base_image_collection = base_image_collection_fixture(system_model)
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{id: id}
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "fr-FR")
+        |> get(api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollection" => %{
+                   "systemModel" => %{
+                     "description" => %{
+                       "locale" => ^default_locale,
+                       "text" => "A base image collection"
+                     }
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns no system model description when both user and tenant's locale are missing",
+         %{
+           conn: conn,
+           api_path: api_path,
+           hardware_type: hardware_type
+         } do
+      descriptions = [
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      base_image_collection = base_image_collection_fixture(system_model)
+
+      id =
+        Absinthe.Relay.Node.to_global_id(
+          :base_image_collection,
+          base_image_collection.id,
+          EdgehogWeb.Schema
+        )
+
+      variables = %{id: id}
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "fr-FR")
+        |> get(api_path, query: @query, variables: variables)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollection" => %{
+                   "systemModel" => %{
+                     "description" => nil
+                   }
+                 }
+               }
+             } = json_response(conn, 200)
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/query/base_image_collections_test.exs
+++ b/backend/test/edgehog_web/schema/query/base_image_collections_test.exs
@@ -1,0 +1,236 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.BaseImageCollectionsTest do
+  use EdgehogWeb.ConnCase
+
+  import Edgehog.DevicesFixtures
+  import Edgehog.BaseImagesFixtures
+
+  alias Edgehog.BaseImages.BaseImageCollection
+
+  describe "baseImageCollections field" do
+    setup do
+      hardware_type = hardware_type_fixture(name: "Fixture", handle: "fixture")
+      system_model = system_model_fixture(hardware_type, name: "Fixture", handle: "fixture")
+
+      {:ok, hardware_type: hardware_type, system_model: system_model}
+    end
+
+    @query """
+    query {
+      baseImageCollections {
+        name
+        handle
+        systemModel {
+          description {
+            locale
+            text
+          }
+        }
+      }
+    }
+    """
+    test "returns empty base image collections", %{conn: conn, api_path: api_path} do
+      conn = get(conn, api_path, query: @query)
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "baseImageCollections" => []
+               }
+             }
+    end
+
+    test "returns base image collections if they're present", %{
+      conn: conn,
+      api_path: api_path,
+      system_model: system_model
+    } do
+      %BaseImageCollection{
+        id: id,
+        name: name,
+        handle: handle
+      } = base_image_collection_fixture(system_model)
+
+      id = Absinthe.Relay.Node.to_global_id(:base_image_collection, id, EdgehogWeb.Schema)
+
+      variables = %{id: id}
+
+      conn = get(conn, api_path, query: @query, variables: variables)
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "baseImageCollections" => [
+                   %{
+                     "name" => name,
+                     "handle" => handle,
+                     "systemModel" => %{
+                       "description" => nil
+                     }
+                   }
+                 ]
+               }
+             }
+    end
+
+    test "returns the default locale description for system model", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      _base_image_collection = base_image_collection_fixture(system_model)
+
+      conn = get(conn, api_path, query: @query)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollections" => [
+                   %{
+                     "systemModel" => %{
+                       "description" => %{
+                         "locale" => ^default_locale,
+                         "text" => "A base image collection"
+                       }
+                     }
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns the explicit locale system model description", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      _base_image_collection = base_image_collection_fixture(system_model)
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "it-IT")
+        |> get(api_path, query: @query)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollections" => [
+                   %{
+                     "systemModel" => %{
+                       "description" => %{
+                         "locale" => "it-IT",
+                         "text" => "Un modello di sistema"
+                       }
+                     }
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns description in the tenant's default locale for non existing locale", %{
+      conn: conn,
+      api_path: api_path,
+      tenant: tenant,
+      hardware_type: hardware_type
+    } do
+      default_locale = tenant.default_locale
+
+      descriptions = [
+        %{locale: default_locale, text: "A base image collection"},
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      _base_image_collection = base_image_collection_fixture(system_model)
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "fr-FR")
+        |> get(api_path, query: @query)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollections" => [
+                   %{
+                     "systemModel" => %{
+                       "description" => %{
+                         "locale" => ^default_locale,
+                         "text" => "A base image collection"
+                       }
+                     }
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+    end
+
+    test "returns no system model description when both user and tenant's locale are missing",
+         %{
+           conn: conn,
+           api_path: api_path,
+           hardware_type: hardware_type
+         } do
+      descriptions = [
+        %{locale: "it-IT", text: "Un modello di sistema"}
+      ]
+
+      system_model = system_model_fixture(hardware_type, descriptions: descriptions)
+
+      _base_image_collection = base_image_collection_fixture(system_model)
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "fr-FR")
+        |> get(api_path, query: @query)
+
+      assert %{
+               "data" => %{
+                 "baseImageCollections" => [
+                   %{
+                     "systemModel" => %{
+                       "description" => nil
+                     }
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+    end
+  end
+end

--- a/backend/test/support/fixtures/base_images_fixtures.ex
+++ b/backend/test/support/fixtures/base_images_fixtures.ex
@@ -1,0 +1,51 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.BaseImagesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Edgehog.BaseImages` context.
+  """
+
+  @doc """
+  Generate a unique base_image_collection handle.
+  """
+  def unique_base_image_collection_handle, do: "some handle#{System.unique_integer([:positive])}"
+
+  @doc """
+  Generate a unique base_image_collection name.
+  """
+  def unique_base_image_collection_name, do: "some name#{System.unique_integer([:positive])}"
+
+  @doc """
+  Generate a base_image_collection.
+  """
+  def base_image_collection_fixture(attrs \\ %{}) do
+    {:ok, base_image_collection} =
+      attrs
+      |> Enum.into(%{
+        handle: unique_base_image_collection_handle(),
+        name: unique_base_image_collection_name()
+      })
+      |> Edgehog.BaseImages.create_base_image_collection()
+
+    base_image_collection
+  end
+end

--- a/backend/test/support/fixtures/base_images_fixtures.ex
+++ b/backend/test/support/fixtures/base_images_fixtures.ex
@@ -27,7 +27,7 @@ defmodule Edgehog.BaseImagesFixtures do
   @doc """
   Generate a unique base_image_collection handle.
   """
-  def unique_base_image_collection_handle, do: "some handle#{System.unique_integer([:positive])}"
+  def unique_base_image_collection_handle, do: "some-handle#{System.unique_integer([:positive])}"
 
   @doc """
   Generate a unique base_image_collection name.
@@ -37,14 +37,16 @@ defmodule Edgehog.BaseImagesFixtures do
   @doc """
   Generate a base_image_collection.
   """
-  def base_image_collection_fixture(attrs \\ %{}) do
-    {:ok, base_image_collection} =
+  def base_image_collection_fixture(system_model, attrs \\ %{}) do
+    attrs =
       attrs
       |> Enum.into(%{
         handle: unique_base_image_collection_handle(),
         name: unique_base_image_collection_name()
       })
-      |> Edgehog.BaseImages.create_base_image_collection()
+
+    {:ok, base_image_collection} =
+      Edgehog.BaseImages.create_base_image_collection(system_model, attrs)
 
     base_image_collection
   end


### PR DESCRIPTION
This PR adds a CRUD for Base Image Collections, which is the starting point to support Base Images and OTA Campaigns.