### PR TITLE
[backend] Device network interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `MAX_UPLOAD_SIZE_BYTES` env variable to define the maximum dimension for uploads (particularly
   relevant for OTA updates). Defaults to 4 GB.
 - Allow creating and managing groups based on selectors.
+- Add support for device's `network_interfaces` ([#231](https://github.com/edgehog-device-manager/edgehog/pull/231))
 
 ### Changed
 - Handle Device part numbers for nonexistent system models

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -63,6 +63,7 @@ config :edgehog, :astarte_ota_request_module, Edgehog.Astarte.Device.OTARequestM
 config :edgehog, :astarte_runtime_info_module, Edgehog.Astarte.Device.RuntimeInfoMock
 config :edgehog, :astarte_led_behavior_module, Edgehog.Astarte.Device.LedBehaviorMock
 config :edgehog, :astarte_geolocation_module, Edgehog.Astarte.Device.GeolocationMock
+config :edgehog, :astarte_network_interface_module, Edgehog.Astarte.Device.NetworkInterfaceMock
 
 config :edgehog,
        :astarte_cellular_connection_module,

--- a/backend/lib/edgehog/astarte.ex
+++ b/backend/lib/edgehog/astarte.ex
@@ -38,6 +38,7 @@ defmodule Edgehog.Astarte do
     Geolocation,
     HardwareInfo,
     LedBehavior,
+    NetworkInterface,
     OSInfo,
     OTARequest,
     RuntimeInfo,
@@ -92,6 +93,11 @@ defmodule Edgehog.Astarte do
                          LedBehavior
                        )
   @geolocation_module Application.compile_env(:edgehog, :astarte_geolocation_module, Geolocation)
+  @network_interface_module Application.compile_env(
+                              :edgehog,
+                              :astarte_network_interface_module,
+                              NetworkInterface
+                            )
 
   @doc """
   Returns the list of clusters.
@@ -519,6 +525,10 @@ defmodule Edgehog.Astarte do
 
   def fetch_runtime_info(%AppEngine{} = client, device_id) do
     @runtime_info_module.get(client, device_id)
+  end
+
+  def fetch_network_interfaces(%AppEngine{} = client, device_id) do
+    @network_interface_module.get(client, device_id)
   end
 
   def send_led_behavior(%AppEngine{} = client, device_id, behavior) do

--- a/backend/lib/edgehog/astarte/device/network_interface.ex
+++ b/backend/lib/edgehog/astarte/device/network_interface.ex
@@ -1,0 +1,56 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.NetworkInterface do
+  @type t :: %__MODULE__{
+          name: String.t(),
+          mac_address: String.t() | nil,
+          technology: String.t() | nil
+        }
+
+  @enforce_keys [:name, :mac_address, :technology]
+  defstruct @enforce_keys
+
+  @behaviour Edgehog.Astarte.Device.NetworkInterface.Behaviour
+
+  alias Astarte.Client.AppEngine
+
+  @interface "io.edgehog.devicemanager.NetworkInterfaceProperties"
+
+  @impl true
+  def get(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_properties_data(client, device_id, @interface) do
+      interfaces = parse_data(data)
+
+      {:ok, interfaces}
+    end
+  end
+
+  def parse_data(data), do: Enum.map(data, &parse_interface_properties/1)
+
+  def parse_interface_properties({interface_name, properties_data}) do
+    %__MODULE__{
+      name: interface_name,
+      mac_address: properties_data["macAddress"],
+      technology: properties_data["technologyType"]
+    }
+  end
+end

--- a/backend/lib/edgehog/astarte/device/network_interface/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/network_interface/behaviour.ex
@@ -1,0 +1,27 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.NetworkInterface.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.NetworkInterface
+
+  @callback get(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(NetworkInterface.t())} | {:error, term()}
+end

--- a/backend/lib/edgehog_web/resolvers/astarte.ex
+++ b/backend/lib/edgehog_web/resolvers/astarte.ex
@@ -21,6 +21,7 @@
 defmodule EdgehogWeb.Resolvers.Astarte do
   alias Edgehog.Astarte
   alias Edgehog.Astarte.Device.BatteryStatus.BatterySlot
+  alias Edgehog.Astarte.Device.NetworkInterface
   alias Edgehog.Devices
   alias Edgehog.Devices.Device
 
@@ -95,6 +96,31 @@ defmodule EdgehogWeb.Resolvers.Astarte do
       _ -> {:ok, nil}
     end
   end
+
+  def fetch_network_interfaces(%Device{device_id: device_id} = device, _args, _context) do
+    with {:ok, client} <- Devices.appengine_client_from_device(device),
+         {:ok, network_interfaces} <- Astarte.fetch_network_interfaces(client, device_id) do
+      {:ok, network_interfaces}
+    else
+      _ -> {:ok, nil}
+    end
+  end
+
+  def resolve_network_interface_technology(%NetworkInterface{technology: nil}, _args, _res) do
+    {:ok, nil}
+  end
+
+  def resolve_network_interface_technology(%NetworkInterface{technology: technology}, _args, _res) do
+    network_interface_technology_to_enum(technology)
+  end
+
+  defp network_interface_technology_to_enum("Ethernet"), do: {:ok, :ethernet}
+  defp network_interface_technology_to_enum("Bluetooth"), do: {:ok, :bluetooth}
+  defp network_interface_technology_to_enum("Cellular"), do: {:ok, :cellular}
+  defp network_interface_technology_to_enum("WiFi"), do: {:ok, :wifi}
+
+  defp network_interface_technology_to_enum(_),
+    do: {:error, :invalid_network_interface_technology}
 
   def fetch_cellular_connection(%Device{device_id: device_id} = device, _args, _context) do
     with {:ok, client} <- Devices.appengine_client_from_device(device),

--- a/backend/lib/edgehog_web/resolvers/devices.ex
+++ b/backend/lib/edgehog_web/resolvers/devices.ex
@@ -37,7 +37,8 @@ defmodule EdgehogWeb.Resolvers.Devices do
     :base_image,
     :os_info,
     :cellular_connection,
-    :runtime_info
+    :runtime_info,
+    :network_interfaces
   ]
 
   def find_device(%{id: id}, %{context: context} = resolution) do

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -247,6 +247,33 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     end
   end
 
+  @desc """
+  The connection technology of the network interface.
+  """
+  enum :network_interface_technology do
+    @desc "Ethernet."
+    value :ethernet
+    @desc "Bluetooth."
+    value :bluetooth
+    @desc "Cellular."
+    value :cellular
+    @desc "WiFi."
+    value :wifi
+  end
+
+  @desc "Describes a network interface of a device."
+  object :network_interface do
+    @desc "The identifier of the network interface."
+    field :name, non_null(:string)
+    @desc "The normalized physical address."
+    field :mac_address, :string
+    @desc "Connection Technology"
+    field :technology, :network_interface_technology do
+      resolve &Resolvers.Astarte.resolve_network_interface_technology/3
+      middleware Middleware.ErrorHandler
+    end
+  end
+
   @desc "Describes an Edgehog runtime."
   object :runtime_info do
     @desc "The name of the Edgehog runtime."

--- a/backend/lib/edgehog_web/schema/devices_types.ex
+++ b/backend/lib/edgehog_web/schema/devices_types.ex
@@ -243,6 +243,12 @@ defmodule EdgehogWeb.Schema.DevicesTypes do
       resolve &Resolvers.Astarte.fetch_runtime_info/3
       middleware Middleware.ErrorHandler
     end
+
+    @desc "The list of Network Interfaces of the device."
+    field :network_interfaces, list_of(non_null(:network_interface)) do
+      resolve &Resolvers.Astarte.fetch_network_interfaces/3
+      middleware Middleware.ErrorHandler
+    end
   end
 
   @desc """

--- a/backend/test/edgehog/astarte/device/network_interface_test.exs
+++ b/backend/test/edgehog/astarte/device/network_interface_test.exs
@@ -1,0 +1,53 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.NetworkInterfaceTest do
+  use ExUnit.Case
+
+  alias Edgehog.Astarte.Device.NetworkInterface
+
+  describe "parse_data/1" do
+    test "correctly parses NetworkInterface data" do
+      data = %{
+        "enp2s0" => %{
+          "macAddress" => "00:aa:bb:cc:dd:ee",
+          "technologyType" => "Ethernet"
+        },
+        "wlp3s0" => %{
+          "macAddress" => "00:aa:bb:cc:dd:ff",
+          "technologyType" => "WiFi"
+        }
+      }
+
+      assert [
+               %NetworkInterface{
+                 name: "enp2s0",
+                 mac_address: "00:aa:bb:cc:dd:ee",
+                 technology: "Ethernet"
+               },
+               %NetworkInterface{
+                 name: "wlp3s0",
+                 mac_address: "00:aa:bb:cc:dd:ff",
+                 technology: "WiFi"
+               }
+             ] == NetworkInterface.parse_data(data)
+    end
+  end
+end

--- a/backend/test/edgehog_web/resolvers/astarte_test.exs
+++ b/backend/test/edgehog_web/resolvers/astarte_test.exs
@@ -27,6 +27,7 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
 
   alias Edgehog.Astarte.Device.{
     BaseImage,
+    NetworkInterface,
     OSInfo,
     RuntimeInfo,
     SystemStatus,
@@ -184,6 +185,25 @@ defmodule EdgehogWeb.Resolvers.AstarteTest do
                environment: "esp-idf v4.3",
                url: "https://github.com/edgehog-device-manager/edgehog-esp32-device"
              } == runtime_info
+    end
+
+    test "fetch_network_interfaces/3 returns the network interfaces for a device", %{
+      device: device
+    } do
+      assert {:ok, network_interfaces} = Astarte.fetch_network_interfaces(device, %{}, %{})
+
+      assert [
+               %NetworkInterface{
+                 name: "enp2s0",
+                 mac_address: "00:aa:bb:cc:dd:ee",
+                 technology: "Ethernet"
+               },
+               %NetworkInterface{
+                 name: "wlp3s0",
+                 mac_address: "00:aa:bb:cc:dd:ff",
+                 technology: "WiFi"
+               }
+             ] == network_interfaces
     end
 
     test "set_led_behavior/2 validates requested behavior", %{device: device} do

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -104,6 +104,11 @@ defmodule Edgehog.AstarteMockCase do
     )
 
     Mox.stub_with(
+      Edgehog.Astarte.Device.NetworkInterfaceMock,
+      Edgehog.Mocks.Astarte.Device.NetworkInterface
+    )
+
+    Mox.stub_with(
       Edgehog.Astarte.Device.LedBehaviorMock,
       Edgehog.Mocks.Astarte.Device.LedBehavior
     )

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -62,6 +62,10 @@ Mox.defmock(Edgehog.Astarte.Device.RuntimeInfoMock,
   for: Edgehog.Astarte.Device.RuntimeInfo.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.NetworkInterfaceMock,
+  for: Edgehog.Astarte.Device.NetworkInterface.Behaviour
+)
+
 Mox.defmock(Edgehog.Astarte.Device.LedBehaviorMock,
   for: Edgehog.Astarte.Device.LedBehavior.Behaviour
 )

--- a/backend/test/support/mocks/astarte/device/network_interface.ex
+++ b/backend/test/support/mocks/astarte/device/network_interface.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.NetworkInterface do
+  @behaviour Edgehog.Astarte.Device.NetworkInterface.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.NetworkInterface
+
+  @impl true
+  def get(%AppEngine{} = _client, _device_id) do
+    network_interfaces = [
+      %NetworkInterface{
+        name: "enp2s0",
+        mac_address: "00:aa:bb:cc:dd:ee",
+        technology: "Ethernet"
+      },
+      %NetworkInterface{
+        name: "wlp3s0",
+        mac_address: "00:aa:bb:cc:dd:ff",
+        technology: "WiFi"
+      }
+    ]
+
+    {:ok, network_interfaces}
+  end
+end


### PR DESCRIPTION
Fetch NetworkInterfaceProperties data from AppEngine and expose it via GraphQL