### PR TITLE
mix.exs: remove gettext compiler

### DIFF
--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -27,7 +27,7 @@ defmodule Edgehog.MixProject do
       version: "0.6.0-dev",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:gettext] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
This is not needed anymore, avoid compiler warning

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
