### PR TITLE
schema: use the correct Device struct in node type resolution

### DIFF
--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -49,14 +49,14 @@ defmodule EdgehogWeb.Schema do
 
   node interface do
     resolve_type fn
-      %Edgehog.Astarte.Device{}, _ ->
-        :device
-
       %Edgehog.BaseImages.BaseImage{}, _ ->
         :base_image
 
       %Edgehog.BaseImages.BaseImageCollection{}, _ ->
         :base_image_collection
+
+      %Edgehog.Devices.Device{}, _ ->
+        :device
 
       %Edgehog.Devices.HardwareType{}, _ ->
         :hardware_type


### PR DESCRIPTION
This was not updated after the context refactoring in 42ef3603592093f79692020fbda48cb5e306366c, leading to Relay being unable to retrieve Devices using the node interface.
This fix also surfaced a problem with the conditional preload of Astarte fields for an `Edgehog.Device`, which was fixed contextually by always preloading the Astarte fields.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
