### PR TITLE
[frontend] Add checks on mutation's result in updaters

### DIFF
--- a/frontend/src/pages/BaseImageCollection.tsx
+++ b/frontend/src/pages/BaseImageCollection.tsx
@@ -134,7 +134,11 @@ const BaseImageCollectionContent = ({
         );
         setShowDeleteModal(false);
       },
-      updater(store) {
+      updater(store, data) {
+        if (!data.deleteBaseImageCollection) {
+          return;
+        }
+
         const baseImageCollection = store
           .getRootField("deleteBaseImageCollection")
           .getLinkedRecord("baseImageCollection");

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -126,7 +126,11 @@ const BaseImageCollection = ({
             />
           );
         },
-        updater(store) {
+        updater(store, data) {
+          if (!data.createBaseImageCollection) {
+            return;
+          }
+
           const baseImageCollection = store
             .getRootField("createBaseImageCollection")
             .getLinkedRecord("baseImageCollection");

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -1221,7 +1221,11 @@ const DeviceContent = ({
                 />
               );
             },
-            updater(store) {
+            updater(store, data) {
+              if (!data.updateDevice) {
+                return;
+              }
+
               const root = store.getRoot();
               const deviceGroups = root.getLinkedRecords("deviceGroups");
               if (!deviceGroups) {

--- a/frontend/src/pages/DeviceGroup.tsx
+++ b/frontend/src/pages/DeviceGroup.tsx
@@ -140,7 +140,11 @@ const DeviceGroupContent = ({
         );
         setShowDeleteModal(false);
       },
-      updater(store) {
+      updater(store, data) {
+        if (!data.deleteDeviceGroup) {
+          return;
+        }
+
         const deviceGroup = store
           .getRootField("deleteDeviceGroup")
           .getLinkedRecord("deviceGroup");
@@ -211,7 +215,11 @@ const DeviceGroupContent = ({
             />
           );
         },
-        updater(store) {
+        updater(store, data) {
+          if (!data.updateDeviceGroup) {
+            return;
+          }
+
           const root = store.getRoot();
           const devices = root.getLinkedRecords("devices");
           if (!devices) {

--- a/frontend/src/pages/DeviceGroupCreate.tsx
+++ b/frontend/src/pages/DeviceGroupCreate.tsx
@@ -86,7 +86,11 @@ const DeviceGroupCreatePage = () => {
             />
           );
         },
-        updater(store) {
+        updater(store, data) {
+          if (!data.createDeviceGroup) {
+            return;
+          }
+
           const deviceGroup = store
             .getRootField("createDeviceGroup")
             .getLinkedRecord("deviceGroup");

--- a/frontend/src/pages/SystemModel.tsx
+++ b/frontend/src/pages/SystemModel.tsx
@@ -215,8 +215,8 @@ const SystemModelContent = ({
             },
           },
         },
-        updater(store) {
-          if (!input.partNumbers) {
+        updater(store, data) {
+          if (!data.updateSystemModel || !input.partNumbers) {
             return;
           }
           const systemModelId = store
@@ -276,7 +276,11 @@ const SystemModelContent = ({
           />
         );
       },
-      updater(store) {
+      updater(store, data) {
+        if (!data.deleteSystemModel) {
+          return;
+        }
+
         const systemModel = store
           .getRootField("deleteSystemModel")
           .getLinkedRecord("systemModel");

--- a/frontend/src/pages/SystemModelCreate.tsx
+++ b/frontend/src/pages/SystemModelCreate.tsx
@@ -147,7 +147,11 @@ const SystemModelContent = ({
             />
           );
         },
-        updater(store) {
+        updater(store, data) {
+          if (!data.createSystemModel) {
+            return;
+          }
+
           const systemModel = store
             .getRootField("createSystemModel")
             .getLinkedRecord("systemModel");


### PR DESCRIPTION
Backend may return null as mutation result and we need to check it before updating Relay store.