### PR TITLE
[docs] Fix k8s secret name for ipbase

### DIFF
--- a/doc/pages/admin/deploying_with_kubernetes.md
+++ b/doc/pages/admin/deploying_with_kubernetes.md
@@ -1,5 +1,5 @@
 <!---
-  Copyright 2021,2022 SECO Mind Srl
+  Copyright 2021-2023 SECO Mind Srl
 
   SPDX-License-Identifier: Apache-2.0
 -->
@@ -288,7 +288,7 @@ spec:
         #  valueFrom:
         #    secretKeyRef:
         #      key: api-key
-        #      name: edgehog-ipbase-credential
+        #      name: edgehog-ipbase-credentials
 
         # Uncomment this env if you have installed an optional Google Geolocation API Key in the
         # secrets


### PR DESCRIPTION
Optional secret for ipbase.com API Key has `edgehog-ipbase-credentials` name (ends with **s**), but `secretKeyRef` in `backend-deployment.yaml` looks for `edgehog-ipbase-credential` secret name (without **s**).
There are other secrets with `**-credentials` names (like `edgehog-google-geolocation-credentials`, `edgehog-s3-credentials`, etc), so I've updated `secretKeyRef` in `backend-deployment.yaml` .