### PR TITLE
Add validation for `base_api_url` in Astarte.Cluster changeset

### DIFF
--- a/backend/lib/edgehog/astarte/cluster.ex
+++ b/backend/lib/edgehog/astarte/cluster.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,5 +38,23 @@ defmodule Edgehog.Astarte.Cluster do
     |> cast(attrs, [:name, :base_api_url])
     |> validate_required([:name, :base_api_url])
     |> unique_constraint(:name)
+    |> validate_change(:base_api_url, &validate_url/2)
+  end
+
+  defp validate_url(field, url) do
+    %URI{scheme: scheme, host: maybe_host} = URI.parse(url)
+
+    host = to_string(maybe_host)
+    empty_host? = host == ""
+    space_in_host? = host =~ " "
+
+    valid_host? = not empty_host? and not space_in_host?
+    valid_scheme? = scheme in ["http", "https"]
+
+    if valid_host? and valid_scheme? do
+      []
+    else
+      [{field, "is not a valid URL"}]
+    end
   end
 end


### PR DESCRIPTION
Validate that the given `base_api_url` is a valid URL by cheking that
- The scheme is either `"http"` or `"https"`
- The host is **not** `nil` or `""`, or contains spaces

Closes #250 