### PR TITLE
Allow different interfaces sets to support a capability

### DIFF
--- a/backend/test/edgehog/capabilities_test.exs
+++ b/backend/test/edgehog/capabilities_test.exs
@@ -133,5 +133,35 @@ defmodule Edgehog.CapabilitiesTest do
 
       assert [:geolocation] = Capabilities.from_introspection(device_introspection)
     end
+
+    test "returns software_updates capability with the older set of interfaces" do
+      device_introspection = %{
+        "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.OTAResponse" => %InterfaceVersion{major: 0, minor: 1}
+      }
+
+      expected_capabilities = [
+        :software_updates,
+        :geolocation
+      ]
+
+      assert Enum.sort(expected_capabilities) ==
+               Enum.sort(Capabilities.from_introspection(device_introspection))
+    end
+
+    test "returns software_updates capability with the newer set of interfaces" do
+      device_introspection = %{
+        "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 1, minor: 0},
+        "io.edgehog.devicemanager.OTAEvent" => %InterfaceVersion{major: 0, minor: 1}
+      }
+
+      expected_capabilities = [
+        :software_updates,
+        :geolocation
+      ]
+
+      assert Enum.sort(expected_capabilities) ==
+               Enum.sort(Capabilities.from_introspection(device_introspection))
+    end
   end
 end


### PR DESCRIPTION
Previously, we were using a map to map a capability to the set of all interfaces required to support it. This meant that a capability could be supported only with a single interface set.
This commit changes that, allowing for a capability to be supported using different interface sets. The first use case for this is OTA, since we already support two different interface pairs for that, but this unlocks more general developments where we change how we provide a specific capability while maintaining backwards compatibility.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
