### PR TITLE
[frontend] Fix react-error-overlay version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2021 SECO Mind Srl
+# SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
 
 erlang 25.1.1
 elixir 1.14.0-otp-25
-nodejs 16.13.0
+nodejs 16.20.0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+# SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
 # SPDX-License-Identifier: Apache-2.0
-FROM node:16 as builder
+FROM node:16.20 as builder
 
 WORKDIR /app
 ADD package*.json ./

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17853,6 +17853,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
       "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
     },
+    "node_modules/react-dev-utils/node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
     "node_modules/react-dev-utils/node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -17891,11 +17896,6 @@
       "peerDependencies": {
         "react": ">=16.13.1"
       }
-    },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
     "node_modules/react-hook-form": {
       "version": "7.27.1",
@@ -37583,7 +37583,7 @@
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.9",
+        "react-error-overlay": "6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -37642,6 +37642,11 @@
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
           "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
         },
+        "react-error-overlay": {
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+          "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -37669,11 +37674,6 @@
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
-    },
-    "react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
     "react-hook-form": {
       "version": "7.27.1",

--- a/frontend/package-lock.json.license
+++ b/frontend/package-lock.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,5 +120,8 @@
     "schema": "./src/api/schema.graphql",
     "src": "./src"
   },
-  "proxy": "http://localhost:4000/"
+  "proxy": "http://localhost:4000/",
+  "overrides": {
+    "react-error-overlay": "6.0.9"
+  }
 }

--- a/frontend/package.json.license
+++ b/frontend/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Running frontend in development mode you may encounter `Uncaught ReferenceError: process is not defined.` error due to a bug with react-error-overlay. This PR fixes version of react-error-overlay to 6.0.9.
See more: https://github.com/facebook/create-react-app/issues/11773
