### PR TITLE
[frontend] Add fragments for batteryStatus and storageUsage

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -122,6 +122,12 @@
   "components.BatteryTable.chargeLevelTitle": {
     "defaultMessage": "Charge Level"
   },
+  "components.BatteryTable.noBattery.message": {
+    "defaultMessage": "The device has not detected any battery yet."
+  },
+  "components.BatteryTable.noBattery.title": {
+    "defaultMessage": "No battery"
+  },
   "components.BatteryTable.slotTitle": {
     "defaultMessage": "Slot"
   },
@@ -412,6 +418,12 @@
   },
   "components.StorageTable.labelTitle": {
     "defaultMessage": "Storage Unit"
+  },
+  "components.StorageTable.noStorage.message": {
+    "defaultMessage": "The device has not detected any storage unit yet."
+  },
+  "components.StorageTable.noStorage.title": {
+    "defaultMessage": "No storage"
   },
   "components.StorageTable.totalSpaceTitle": {
     "defaultMessage": "Total Space"
@@ -884,12 +896,6 @@
   "pages.Device.BatteryStatusTab": {
     "defaultMessage": "Battery"
   },
-  "pages.Device.BatteryStatusTab.noBattery.message": {
-    "defaultMessage": "The device has not detected any battery yet."
-  },
-  "pages.Device.BatteryStatusTab.noBattery.title": {
-    "defaultMessage": "No battery"
-  },
   "pages.Device.CellularConnectionTab": {
     "defaultMessage": "Cellular Connection"
   },
@@ -946,12 +952,6 @@
   },
   "pages.Device.storageTab": {
     "defaultMessage": "Storage"
-  },
-  "pages.Device.storageTab.noResults.message": {
-    "defaultMessage": "The device has not detected any storage unit yet."
-  },
-  "pages.Device.storageTab.noStorage.title": {
-    "defaultMessage": "No storage"
   },
   "pages.Device.systemStatus.lastUpdateAt": {
     "defaultMessage": "Last updated at {date}"

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -136,11 +136,7 @@ const DEVICE_LOCATION_FRAGMENT = graphql`
 const DEVICE_STORAGE_USAGE_FRAGMENT = graphql`
   fragment Device_storageUsage on Device {
     capabilities
-    storageUsage {
-      label
-      totalBytes
-      freeBytes
-    }
+    ...StorageTable_storageUsage
   }
 `;
 
@@ -692,14 +688,10 @@ interface DeviceStorageUsageTabProps {
 
 const DeviceStorageUsageTab = ({ deviceRef }: DeviceStorageUsageTabProps) => {
   const intl = useIntl();
-  const { storageUsage, capabilities } = useFragment(
-    DEVICE_STORAGE_USAGE_FRAGMENT,
-    deviceRef
-  );
-  if (!storageUsage || !capabilities.includes("STORAGE")) {
+  const device = useFragment(DEVICE_STORAGE_USAGE_FRAGMENT, deviceRef);
+  if (!device.capabilities.includes("STORAGE")) {
     return null;
   }
-  const storageUnits = storageUsage.map((storageUnit) => ({ ...storageUnit }));
   return (
     <Tab
       eventKey="device-storage-usage-tab"
@@ -709,23 +701,7 @@ const DeviceStorageUsageTab = ({ deviceRef }: DeviceStorageUsageTabProps) => {
       })}
     >
       <div className="mt-3">
-        {storageUnits.length === 0 ? (
-          <Result.EmptyList
-            title={
-              <FormattedMessage
-                id="pages.Device.storageTab.noStorage.title"
-                defaultMessage="No storage"
-              />
-            }
-          >
-            <FormattedMessage
-              id="pages.Device.storageTab.noResults.message"
-              defaultMessage="The device has not detected any storage unit yet."
-            />
-          </Result.EmptyList>
-        ) : (
-          <StorageTable data={storageUnits} />
-        )}
+        <StorageTable deviceRef={device} />
       </div>
     </Tab>
   );

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -166,12 +166,7 @@ const DEVICE_WIFI_SCAN_RESULTS_FRAGMENT = graphql`
 const DEVICE_BATTERY_STATUS_FRAGMENT = graphql`
   fragment Device_batteryStatus on Device {
     capabilities
-    batteryStatus {
-      slot
-      status
-      levelPercentage
-      levelAbsoluteError
-    }
+    ...BatteryTable_batteryStatus
   }
 `;
 
@@ -932,17 +927,11 @@ interface DeviceBatteryTabProps {
 
 const DeviceBatteryTab = ({ deviceRef }: DeviceBatteryTabProps) => {
   const intl = useIntl();
-  const { batteryStatus, capabilities } = useFragment(
-    DEVICE_BATTERY_STATUS_FRAGMENT,
-    deviceRef
-  );
-  if (!batteryStatus || !capabilities.includes("BATTERY_STATUS")) {
+  const device = useFragment(DEVICE_BATTERY_STATUS_FRAGMENT, deviceRef);
+  if (!device.capabilities.includes("BATTERY_STATUS")) {
     return null;
   }
-  // TODO: handle readonly type without mapping to mutable type
-  const batterySlots = batteryStatus.map((batterySlot) => ({
-    ...batterySlot,
-  }));
+
   return (
     <Tab
       eventKey="device-battery-tab"
@@ -952,23 +941,7 @@ const DeviceBatteryTab = ({ deviceRef }: DeviceBatteryTabProps) => {
       })}
     >
       <div className="mt-3">
-        {batterySlots.length === 0 ? (
-          <Result.EmptyList
-            title={
-              <FormattedMessage
-                id="pages.Device.BatteryStatusTab.noBattery.title"
-                defaultMessage="No battery"
-              />
-            }
-          >
-            <FormattedMessage
-              id="pages.Device.BatteryStatusTab.noBattery.message"
-              defaultMessage="The device has not detected any battery yet."
-            />
-          </Result.EmptyList>
-        ) : (
-          <BatteryTable data={batterySlots} />
-        )}
+        <BatteryTable deviceRef={device} />
       </div>
     </Tab>
   );


### PR DESCRIPTION
Add GraphQL fragments for device's `batteryStatus` and `storageUsage` into respective components and use them on Device page.