### PR TITLE
[frontend] More strict typings for Relay's enums

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2021-2022 SECO Mind Srl
+# SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
 .git
 node_modules
+src/api/__generated__

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,19 +109,6 @@
       "last 1 safari version"
     ]
   },
-  "relay": {
-    "artifactDirectory": "./src/api/__generated__",
-    "customScalars": {
-      "DateTime": "string",
-      "Upload": "File"
-    },
-    "featureFlags": {
-      "enable_relay_resolver_transform": true
-    },
-    "language": "typescript",
-    "schema": "./src/api/schema.graphql",
-    "src": "./src"
-  },
   "proxy": "http://localhost:4000/",
   "overrides": {
     "react-error-overlay": "6.0.9"

--- a/frontend/relay.config.json
+++ b/frontend/relay.config.json
@@ -1,0 +1,13 @@
+{
+  "artifactDirectory": "./src/api/__generated__",
+  "customScalars": {
+    "DateTime": "string",
+    "Upload": "File"
+  },
+  "featureFlags": {
+    "enable_relay_resolver_transform": true
+  },
+  "language": "typescript",
+  "schema": "./src/api/schema.graphql",
+  "src": "./src"
+}

--- a/frontend/relay.config.json
+++ b/frontend/relay.config.json
@@ -8,6 +8,7 @@
     "enable_relay_resolver_transform": true
   },
   "language": "typescript",
+  "noFutureProofEnums": true,
   "schema": "./src/api/schema.graphql",
   "src": "./src"
 }

--- a/frontend/relay.config.json.license
+++ b/frontend/relay.config.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: Apache-2.0

--- a/frontend/src/components/BatteryTable.tsx
+++ b/frontend/src/components/BatteryTable.tsx
@@ -18,10 +18,12 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { FormattedMessage, FormattedNumber } from "react-intl";
+import type { ReactElement } from "react";
+import { defineMessages, FormattedMessage, FormattedNumber } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
+  BatteryStatus,
   BatteryTable_batteryStatus$data,
   BatteryTable_batteryStatus$key,
 } from "api/__generated__/BatteryTable_batteryStatus.graphql";
@@ -43,71 +45,42 @@ const BATTERY_TABLE_FRAGMENT = graphql`
   }
 `;
 
+const statusMessages = defineMessages<BatteryStatus>({
+  CHARGING: {
+    id: "components.BatteryTable.status.Charging",
+    defaultMessage: "Charging",
+  },
+  DISCHARGING: {
+    id: "components.BatteryTable.status.Discharging",
+    defaultMessage: "Discharging",
+  },
+  EITHER_IDLE_OR_CHARGING: {
+    id: "components.BatteryTable.status.Either_idle_or_charging",
+    defaultMessage: "Idle/Charging",
+  },
+  FAILURE: {
+    id: "components.BatteryTable.status.Failure",
+    defaultMessage: "Failure",
+  },
+  IDLE: {
+    id: "components.BatteryTable.status.Idle",
+    defaultMessage: "Idle",
+  },
+  REMOVED: {
+    id: "components.BatteryTable.status.Removed",
+    defaultMessage: "Removed",
+  },
+  UNKNOWN: {
+    id: "components.BatteryTable.status.Unknown",
+    defaultMessage: "Unknown",
+  },
+});
+
 type BatterySlot = NonNullable<
   BatteryTable_batteryStatus$data["batteryStatus"]
 >[number];
 
-const renderBatteryStatus = (status: BatterySlot["status"]) => {
-  switch (status) {
-    case "CHARGING":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Charging"
-          defaultMessage="Charging"
-        />
-      );
-    case "DISCHARGING":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Discharging"
-          defaultMessage="Discharging"
-        />
-      );
-    case "IDLE":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Idle"
-          defaultMessage="Idle"
-        />
-      );
-    case "EITHER_IDLE_OR_CHARGING":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Either_idle_or_charging"
-          defaultMessage="Idle/Charging"
-        />
-      );
-    case "REMOVED":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Removed"
-          defaultMessage="Removed"
-        />
-      );
-    case "FAILURE":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Failure"
-          defaultMessage="Failure"
-        />
-      );
-    case "UNKNOWN":
-      return (
-        <FormattedMessage
-          id="components.BatteryTable.status.Unknown"
-          defaultMessage="Unknown"
-        />
-      );
-
-    case null:
-      return null;
-
-    default:
-      return null;
-  }
-};
-
-const renderChargeLevel = (slot: BatterySlot) => {
+const renderChargeLevel = (slot: BatterySlot): ReactElement | null => {
   switch (slot.status) {
     case "CHARGING":
     case "DISCHARGING":
@@ -130,7 +103,10 @@ const renderChargeLevel = (slot: BatterySlot) => {
         />
       );
 
-    default:
+    case null:
+    case "FAILURE":
+    case "REMOVED":
+    case "UNKNOWN":
       return null;
   }
 };
@@ -153,7 +129,8 @@ const columns: Column<BatterySlot>[] = [
         defaultMessage="Status"
       />
     ),
-    Cell: ({ value }) => renderBatteryStatus(value),
+    Cell: ({ value }) =>
+      value && <FormattedMessage id={statusMessages[value].id} />,
   },
   {
     accessor: "levelPercentage",

--- a/frontend/src/components/CellularConnectionTabs.tsx
+++ b/frontend/src/components/CellularConnectionTabs.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022 SECO Mind Srl
+  Copyright 2022-2023 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@
 */
 
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
-import type { MessageDescriptor } from "react-intl";
-import { graphql, useFragment } from "react-relay";
+import { graphql, useFragment } from "react-relay/hooks";
 
 import Col from "react-bootstrap/Col";
 import Nav from "react-bootstrap/Nav";
@@ -34,37 +33,38 @@ import Stack from "components/Stack";
 import type {
   CellularConnectionTabs_cellularConnection$data,
   CellularConnectionTabs_cellularConnection$key,
+  ModemRegistrationStatus,
+  ModemTechnology,
 } from "api/__generated__/CellularConnectionTabs_cellularConnection.graphql";
 
-const registrationStatusMessages: Record<string, MessageDescriptor> =
-  defineMessages({
-    NOT_REGISTERED: {
-      id: "modem.RegistrationStatus.NotRegistered",
-      defaultMessage: "Not Registered",
-    },
-    REGISTERED: {
-      id: "modem.RegistrationStatus.Registered",
-      defaultMessage: "Registered",
-    },
-    REGISTRATION_DENIED: {
-      id: "modem.RegistrationStatus.RegistrationDenied",
-      defaultMessage: "Registration denied",
-    },
-    REGISTERED_ROAMING: {
-      id: "modem.RegistrationStatus.RegisteredRoaming",
-      defaultMessage: "Registered, roaming",
-    },
-    SEARCHING_OPERATOR: {
-      id: "modem.RegistrationStatus.SearchingOperator",
-      defaultMessage: "Searching an operator to register to",
-    },
-    UNKNOWN: {
-      id: "modem.RegistrationStatus.Unknown",
-      defaultMessage: "Unknown",
-    },
-  });
+const registrationStatusMessages = defineMessages<ModemRegistrationStatus>({
+  NOT_REGISTERED: {
+    id: "modem.RegistrationStatus.NotRegistered",
+    defaultMessage: "Not Registered",
+  },
+  REGISTERED: {
+    id: "modem.RegistrationStatus.Registered",
+    defaultMessage: "Registered",
+  },
+  REGISTRATION_DENIED: {
+    id: "modem.RegistrationStatus.RegistrationDenied",
+    defaultMessage: "Registration denied",
+  },
+  REGISTERED_ROAMING: {
+    id: "modem.RegistrationStatus.RegisteredRoaming",
+    defaultMessage: "Registered, roaming",
+  },
+  SEARCHING_OPERATOR: {
+    id: "modem.RegistrationStatus.SearchingOperator",
+    defaultMessage: "Searching an operator to register to",
+  },
+  UNKNOWN: {
+    id: "modem.RegistrationStatus.Unknown",
+    defaultMessage: "Unknown",
+  },
+});
 
-const technologyMessages: Record<string, MessageDescriptor> = defineMessages({
+const technologyMessages = defineMessages<ModemTechnology>({
   EUTRAN: {
     id: "modem.technology.EUTRAN",
     defaultMessage: "E-UTRAN",
@@ -96,10 +96,6 @@ const technologyMessages: Record<string, MessageDescriptor> = defineMessages({
   UTRAN_HSUPA: {
     id: "modem.technology.UTRAN_HSUPA",
     defaultMessage: "UTRAN with HSUPA",
-  },
-  UNKNOWN: {
-    id: "modem.technology.Unknown",
-    defaultMessage: "Unknown",
   },
 });
 
@@ -222,8 +218,7 @@ const ModemTab = ({ modem }: { modem: Modem }) => {
             <Form.Control
               type="text"
               value={intl.formatMessage(
-                registrationStatusMessages[modem.registrationStatus] ||
-                  registrationStatusMessages.UNKNOWN
+                registrationStatusMessages[modem.registrationStatus]
               )}
               readOnly
             />
@@ -241,10 +236,7 @@ const ModemTab = ({ modem }: { modem: Modem }) => {
           >
             <Form.Control
               type="text"
-              value={intl.formatMessage(
-                technologyMessages[modem.technology] ||
-                  technologyMessages.UNKNOWN
-              )}
+              value={intl.formatMessage(technologyMessages[modem.technology])}
               readOnly
             />
           </FormRow>

--- a/frontend/src/components/NetworkInterfacesTable.tsx
+++ b/frontend/src/components/NetworkInterfacesTable.tsx
@@ -18,10 +18,11 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay";
+import { defineMessages, FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
+  NetworkInterfaceTechnology,
   NetworkInterfacesTable_networkInterfaces$data,
   NetworkInterfacesTable_networkInterfaces$key,
 } from "api/__generated__/NetworkInterfacesTable_networkInterfaces.graphql";
@@ -42,47 +43,28 @@ const NETWORK_INTERFACES_TABLE_FRAGMENT = graphql`
   }
 `;
 
+const technologyMessages = defineMessages<NetworkInterfaceTechnology>({
+  ETHERNET: {
+    id: "components.NetworkInterfacesTable.technology.Ethernet",
+    defaultMessage: "Ethernet",
+  },
+  WIFI: {
+    id: "components.NetworkInterfacesTable.technology.WiFi",
+    defaultMessage: "WiFi",
+  },
+  CELLULAR: {
+    id: "components.NetworkInterfacesTable.technology.Cellular",
+    defaultMessage: "Cellular",
+  },
+  BLUETOOTH: {
+    id: "components.NetworkInterfacesTable.technology.Bluetooth",
+    defaultMessage: "Bluetooth",
+  },
+});
+
 type TableRecord = NonNullable<
   NetworkInterfacesTable_networkInterfaces$data["networkInterfaces"]
 >[number];
-
-const renderTechnology = (technology: TableRecord["technology"]) => {
-  switch (technology) {
-    case "ETHERNET":
-      return (
-        <FormattedMessage
-          id="components.NetworkInterfacesTable.technology.Ethernet"
-          defaultMessage="Ethernet"
-        />
-      );
-    case "WIFI":
-      return (
-        <FormattedMessage
-          id="components.NetworkInterfacesTable.technology.WiFi"
-          defaultMessage="WiFi"
-        />
-      );
-    case "CELLULAR":
-      return (
-        <FormattedMessage
-          id="components.NetworkInterfacesTable.technology.Cellular"
-          defaultMessage="Cellular"
-        />
-      );
-    case "BLUETOOTH":
-      return (
-        <FormattedMessage
-          id="components.NetworkInterfacesTable.technology.Bluetooth"
-          defaultMessage="Bluetooth"
-        />
-      );
-    case null:
-      return null;
-
-    default:
-      return null;
-  }
-};
 
 const columns: Column<TableRecord>[] = [
   {
@@ -102,7 +84,8 @@ const columns: Column<TableRecord>[] = [
         defaultMessage="Technology"
       />
     ),
-    Cell: ({ value }) => renderTechnology(value),
+    Cell: ({ value }) =>
+      value && <FormattedMessage id={technologyMessages[value].id} />,
   },
   {
     accessor: "macAddress",
@@ -121,9 +104,12 @@ interface Props {
 }
 
 const NetworkInterfacesTable = ({ className, deviceRef }: Props) => {
-  const data = useFragment(NETWORK_INTERFACES_TABLE_FRAGMENT, deviceRef);
+  const { networkInterfaces } = useFragment(
+    NETWORK_INTERFACES_TABLE_FRAGMENT,
+    deviceRef
+  );
 
-  if (!data.networkInterfaces || !data.networkInterfaces.length) {
+  if (!networkInterfaces || !networkInterfaces.length) {
     return (
       <Result.EmptyList
         title={
@@ -140,11 +126,6 @@ const NetworkInterfacesTable = ({ className, deviceRef }: Props) => {
       </Result.EmptyList>
     );
   }
-
-  // TODO: handle readonly type without mapping to mutable type
-  const networkInterfaces = data.networkInterfaces.map((networkInterface) => ({
-    ...networkInterface,
-  }));
 
   return (
     <Table className={className} columns={columns} data={networkInterfaces} />

--- a/frontend/src/components/OperationTable.tsx
+++ b/frontend/src/components/OperationTable.tsx
@@ -19,7 +19,6 @@
 */
 
 import { defineMessages, FormattedDate, FormattedMessage } from "react-intl";
-import type { MessageDescriptor } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
@@ -63,39 +62,30 @@ const isOtaOperationWithFinalStatus = (
 ): operation is OtaOperationWithFinalStatus =>
   isOtaOperationFinalStatus(operation.status);
 
-const getStatusColor = (status: OtaOperationFinalStatus): string => {
-  switch (status) {
-    case "SUCCESS":
-      return "text-success";
-
-    case "FAILURE":
-      return "text-danger";
-  }
+const statusColors: Record<OtaOperationFinalStatus, string> = {
+  SUCCESS: "text-success",
+  FAILURE: "text-danger",
 };
 
-const messages: Record<OtaOperationFinalStatus, MessageDescriptor> =
-  defineMessages({
-    SUCCESS: {
-      id: "device.otaOperationStatus.Success",
-      defaultMessage: "Success",
-    },
-    FAILURE: {
-      id: "device.otaOperationStatus.Failure",
-      defaultMessage: "Failure",
-    },
-  });
+const statusMessages = defineMessages<OtaOperationFinalStatus>({
+  SUCCESS: {
+    id: "device.otaOperationStatus.Success",
+    defaultMessage: "Success",
+  },
+  FAILURE: {
+    id: "device.otaOperationStatus.Failure",
+    defaultMessage: "Failure",
+  },
+});
 
-const OperationStatus = ({ status }: { status: OtaOperationFinalStatus }) => {
-  const color = getStatusColor(status);
-  return (
-    <div className="d-flex align-items-center">
-      <Icon icon="circle" className={`me-2 ${color}`} />
-      <span>
-        <FormattedMessage id={messages[status].id} />
-      </span>
-    </div>
-  );
-};
+const OperationStatus = ({ status }: { status: OtaOperationFinalStatus }) => (
+  <div className="d-flex align-items-center">
+    <Icon icon="circle" className={`me-2 ${statusColors[status]}`} />
+    <span>
+      <FormattedMessage id={statusMessages[status].id} />
+    </span>
+  </div>
+);
 
 const columns: Column<OtaOperationWithFinalStatus>[] = [
   {

--- a/frontend/src/components/UpdateCampaignOutcome.tsx
+++ b/frontend/src/components/UpdateCampaignOutcome.tsx
@@ -19,7 +19,6 @@
 */
 
 import { defineMessages, FormattedMessage } from "react-intl";
-import type { MessageDescriptor } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
@@ -35,20 +34,12 @@ const UPDATE_CAMPAIGN_OUTCOME_FRAGMENT = graphql`
   }
 `;
 
-const getColor = (outcome: UpdateCampaignOutcomeEnum) => {
-  switch (outcome) {
-    case "SUCCESS":
-      return "text-success";
-
-    case "FAILURE":
-      return "text-danger";
-
-    default:
-      return "text-muted";
-  }
+const colors: Record<UpdateCampaignOutcomeEnum, string> = {
+  SUCCESS: "text-success",
+  FAILURE: "text-danger",
 };
 
-const messages: Record<string, MessageDescriptor> = defineMessages({
+const messages = defineMessages<UpdateCampaignOutcomeEnum>({
   SUCCESS: {
     id: "components.UpdateCampaignOutcome.Success",
     defaultMessage: "Success",
@@ -56,10 +47,6 @@ const messages: Record<string, MessageDescriptor> = defineMessages({
   FAILURE: {
     id: "components.UpdateCampaignOutcome.Failure",
     defaultMessage: "Failure",
-  },
-  UnknownOutcome: {
-    id: "components.UpdateCampaignOutcome.Unknown",
-    defaultMessage: "Unknown",
   },
 });
 
@@ -73,20 +60,15 @@ const UpdateCampaignOutcome = ({ updateCampaignRef }: Props) => {
     updateCampaignRef
   );
 
-  if (outcome === null) {
-    return null;
-  }
-
-  const color = getColor(outcome);
   return (
-    <div className="d-flex align-items-center">
-      <Icon icon="circle" className={`me-2 ${color}`} />
-      <span>
-        <FormattedMessage
-          id={messages[outcome]?.id || messages.UnknownOutcome.id}
-        />
-      </span>
-    </div>
+    outcome && (
+      <div className="d-flex align-items-center">
+        <Icon icon="circle" className={`me-2 ${colors[outcome]}`} />
+        <span>
+          <FormattedMessage id={messages[outcome].id} />
+        </span>
+      </div>
+    )
   );
 };
 

--- a/frontend/src/components/UpdateCampaignStatus.tsx
+++ b/frontend/src/components/UpdateCampaignStatus.tsx
@@ -19,7 +19,6 @@
 */
 
 import { defineMessages, FormattedMessage } from "react-intl";
-import type { MessageDescriptor } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
@@ -35,20 +34,12 @@ const UPDATE_CAMPAIGN_STATUS_FRAGMENT = graphql`
   }
 `;
 
-const getColor = (status: UpdateCampaignStatusEnum) => {
-  switch (status) {
-    case "IN_PROGRESS":
-      return "text-warning";
-
-    case "FINISHED":
-      return "text-success";
-
-    default:
-      return "text-muted";
-  }
+const colors: Record<UpdateCampaignStatusEnum, string> = {
+  IN_PROGRESS: "text-warning",
+  FINISHED: "text-success",
 };
 
-const messages: Record<string, MessageDescriptor> = defineMessages({
+const messages = defineMessages<UpdateCampaignStatusEnum>({
   IN_PROGRESS: {
     id: "components.UpdateCampaignStatus.InProgress",
     defaultMessage: "In progress",
@@ -56,10 +47,6 @@ const messages: Record<string, MessageDescriptor> = defineMessages({
   FINISHED: {
     id: "components.UpdateCampaignStatus.Finished",
     defaultMessage: "Finished",
-  },
-  UnknownStatus: {
-    id: "components.UpdateCampaignStatus.Unknown",
-    defaultMessage: "Unknown",
   },
 });
 
@@ -73,14 +60,11 @@ const UpdateCampaignStatus = ({ updateCampaignRef }: Props) => {
     updateCampaignRef
   );
 
-  const color = getColor(status);
   return (
     <div className="d-flex align-items-center">
-      <Icon icon="circle" className={`me-2 ${color}`} />
+      <Icon icon="circle" className={`me-2 ${colors[status]}`} />
       <span>
-        <FormattedMessage
-          id={messages[status]?.id || messages.UnknownStatus.id}
-        />
+        <FormattedMessage id={messages[status].id} />
       </span>
     </div>
   );

--- a/frontend/src/components/UpdateTargetsTable.tsx
+++ b/frontend/src/components/UpdateTargetsTable.tsx
@@ -19,7 +19,6 @@
 */
 
 import { defineMessages, FormattedMessage } from "react-intl";
-import type { MessageDescriptor } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 
 import type {
@@ -47,24 +46,14 @@ const UPDATE_TARGETS_TABLE_FRAGMENT = graphql`
   }
 `;
 
-const getStatusColor = (status: UpdateTargetStatus) => {
-  switch (status) {
-    case "PENDING":
-      return "text-warning";
-
-    case "SUCCESSFUL":
-      return "text-success";
-
-    case "FAILED":
-      return "text-danger";
-
-    case "IDLE":
-    default:
-      return "text-muted";
-  }
+const statusColors: Record<UpdateTargetStatus, string> = {
+  IDLE: "text-muted",
+  PENDING: "text-warning",
+  SUCCESSFUL: "text-success",
+  FAILED: "text-danger",
 };
 
-const statusMessages: Record<string, MessageDescriptor> = defineMessages({
+const statusMessages = defineMessages<UpdateTargetStatus>({
   IDLE: {
     id: "components.UpdateTargetsTable.updateTargetStatus.Idle",
     defaultMessage: "Idle",
@@ -81,25 +70,16 @@ const statusMessages: Record<string, MessageDescriptor> = defineMessages({
     id: "components.UpdateTargetsTable.updateTargetStatus.Failed",
     defaultMessage: "Failed",
   },
-  UnknownStatus: {
-    id: "components.UpdateCampaignsTable.updateCampaignStatus.Unknown",
-    defaultMessage: "Unknown",
-  },
 });
 
-const TargetStatus = ({ status }: { status: UpdateTargetStatus }) => {
-  const color = getStatusColor(status);
-  return (
-    <div className="d-flex align-items-center">
-      <Icon icon="circle" className={`me-2 ${color}`} />
-      <span>
-        <FormattedMessage
-          id={statusMessages[status]?.id || statusMessages.UnknownStatus.id}
-        />
-      </span>
-    </div>
-  );
-};
+const TargetStatus = ({ status }: { status: UpdateTargetStatus }) => (
+  <div className="d-flex align-items-center">
+    <Icon icon="circle" className={`me-2 ${statusColors[status]}`} />
+    <span>
+      <FormattedMessage id={statusMessages[status].id} />
+    </span>
+  </div>
+);
 
 type TableRecord =
   UpdateTargetsTable_UpdateTargetsFragment$data["updateTargets"][number];

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -464,17 +464,11 @@
   "components.UpdateCampaignOutcome.Success": {
     "defaultMessage": "Success"
   },
-  "components.UpdateCampaignOutcome.Unknown": {
-    "defaultMessage": "Unknown"
-  },
   "components.UpdateCampaignStatus.Finished": {
     "defaultMessage": "Finished"
   },
   "components.UpdateCampaignStatus.InProgress": {
     "defaultMessage": "In progress"
-  },
-  "components.UpdateCampaignStatus.Unknown": {
-    "defaultMessage": "Unknown"
   },
   "components.UpdateCampaignsTable.baseImageCollectionNameTitle": {
     "defaultMessage": "Base Image Collection",
@@ -493,9 +487,6 @@
   },
   "components.UpdateCampaignsTable.statusTitle": {
     "defaultMessage": "Status"
-  },
-  "components.UpdateCampaignsTable.updateCampaignStatus.Unknown": {
-    "defaultMessage": "Unknown"
   },
   "components.UpdateCampaignsTable.updateChannelNameTitle": {
     "defaultMessage": "Update Channel",
@@ -807,9 +798,6 @@
   },
   "modem.technology.UTRAN_HSUPA": {
     "defaultMessage": "UTRAN with HSUPA"
-  },
-  "modem.technology.Unknown": {
-    "defaultMessage": "Unknown"
   },
   "pages.BaseImage.baseImageNotFound.message": {
     "defaultMessage": "Return to the Base Image Collection."


### PR DESCRIPTION
Move Relay Compiler configuration into separate file.
Disable Relay's catch-all entry for GraphQL enums.
Make frontend components more strict with generated types for GraphQL enums. Any change of enums in `schema.graphql` will require update of corresponding component. This way we ensure that frontend components are always updated.