### PR TITLE
fix(seeds): match return type from release

### DIFF
--- a/backend/lib/edgehog/release.ex
+++ b/backend/lib/edgehog/release.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ defmodule Edgehog.Release do
     priv_dir = "#{:code.priv_dir(@app)}"
     seeds_file = Path.join([priv_dir, "repo", "seeds.exs"])
 
-    {:ok, _} = Code.eval_file(seeds_file)
+    {:ok, _bindings} = Code.eval_file(seeds_file)
 
     :ok
   end

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,3 +77,5 @@ _ = Edgehog.Repo.put_tenant_id(tenant.tenant_id)
     handle: "ultra-firmware",
     name: "Ultra Firmware"
   })
+
+:ok


### PR DESCRIPTION
v2 of #310, achieves the same result in an arguably better way.

Returning `:ok` from the file fixes the match and makes more sense than returning the result of `create_base_image_collection`, and it makes it clear that the script ran successfully.

`eval_file`'s match is made more explicit.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
