### PR TITLE
Use warning instead of warn in logging

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -44,7 +44,7 @@ config :edgehog, EdgehogWeb.Endpoint,
 config :edgehog, Edgehog.Mailer, adapter: Swoosh.Adapters.Test
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/backend/lib/edgehog/error.ex
+++ b/backend/lib/edgehog/error.ex
@@ -104,7 +104,7 @@ defmodule Edgehog.Error do
 
       # If something else comes up, we return the status and print out an error
       response ->
-        Logger.warn("Unhandled API Error: #{inspect(response)}")
+        Logger.warning("Unhandled API Error: #{inspect(response)}")
 
         %Error{
           code: :astarte_api_error,
@@ -115,7 +115,7 @@ defmodule Edgehog.Error do
   end
 
   defp handle(other) do
-    Logger.warn("Unhandled error term: #{inspect(other)}")
+    Logger.warning("Unhandled error term: #{inspect(other)}")
     handle(:unknown)
   end
 
@@ -143,7 +143,7 @@ defmodule Edgehog.Error do
   defp metadata(:unknown), do: {500, "Something went wrong"}
 
   defp metadata(code) do
-    Logger.warn("Unhandled error code: #{inspect(code)}")
+    Logger.warning("Unhandled error code: #{inspect(code)}")
     {422, to_string(code)}
   end
 end


### PR DESCRIPTION
Avoid warnings about warn being deprecated

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
