### PR TITLE
feat(docker-compose): use astarte network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: "3.3"
+version: "3.8"
 services:
   postgresql:
     image: postgres:14.0
@@ -97,3 +97,7 @@ volumes:
   postgresql-data:
   minio-data-v2:
     driver: local
+
+networks:
+  default:
+    name: astarte


### PR DESCRIPTION
since compose v3.5, we can declare a network by name so that it connects to it if it already exists (with a warning) and creates it if it does not exist yet.

this allows astarte's and edgehog's services to communicate while not enforcing edgehog to only exist if astarte exists as well (although in practice this will almost always be the case)

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
