### PR TITLE
Increase the transaction timeout

### DIFF
--- a/backend/lib/edgehog/base_images.ex
+++ b/backend/lib/edgehog/base_images.ex
@@ -247,7 +247,7 @@ defmodule Edgehog.BaseImages do
       %{no_file_base_image: base_image, image_upload: url} = changes
       Ecto.Changeset.change(base_image, url: url)
     end)
-    |> Repo.transaction()
+    |> Repo.transaction(timeout: 120_000)
     |> case do
       {:ok, %{base_image: base_image}} ->
         {:ok, preload_defaults_for_base_image(base_image)}


### PR DESCRIPTION
The default of 15 seconds is too low for big image uploads

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
