### PR TITLE
Increase idle timeout for prod env

### DIFF
--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -64,7 +64,8 @@ if config_env() == :prod do
       # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
       ip: {0, 0, 0, 0, 0, 0, 0, 0},
-      port: String.to_integer(System.get_env("PORT") || "4000")
+      port: String.to_integer(System.get_env("PORT") || "4000"),
+      protocol_options: [idle_timeout: 300_000]
     ],
     secret_key_base: secret_key_base
 


### PR DESCRIPTION
Increase idle timeout for Cowboy2 webserver.
Allows to respond after time consuming tasks, like creating Base Image version with large upload file (and uploading it to S3) without the connection timing out.