### PR TITLE
Expose new UpdateTarget fields in GraphQL

### DIFF
--- a/backend/lib/edgehog/update_campaigns.ex
+++ b/backend/lib/edgehog/update_campaigns.ex
@@ -329,7 +329,8 @@ defmodule Edgehog.UpdateCampaigns do
           tags: [],
           custom_attributes: [],
           system_model: [:hardware_type, :part_numbers]
-        ]
+        ],
+        ota_operation: []
       ]
     ]
 
@@ -466,7 +467,8 @@ defmodule Edgehog.UpdateCampaigns do
         tags: [],
         custom_attributes: [],
         system_model: [:hardware_type, :part_numbers]
-      ]
+      ],
+      ota_operation: []
     ]
 
     Repo.preload(target_or_targets, preloads, opts)

--- a/backend/lib/edgehog/update_campaigns/target.ex
+++ b/backend/lib/edgehog/update_campaigns/target.ex
@@ -23,6 +23,7 @@ defmodule Edgehog.UpdateCampaigns.Target do
   import Ecto.Changeset
 
   alias Edgehog.Devices
+  alias Edgehog.OSManagement
   alias Edgehog.UpdateCampaigns.UpdateCampaign
 
   schema "update_campaign_targets" do
@@ -30,10 +31,10 @@ defmodule Edgehog.UpdateCampaigns.Target do
     field :status, Ecto.Enum, values: [:idle, :in_progress, :failed, :successful]
     field :retry_count, :integer, default: 0
     field :latest_attempt, :utc_datetime_usec
-    field :ota_operation_id, :binary_id
     field :completion_timestamp, :utc_datetime_usec
     belongs_to :update_campaign, UpdateCampaign
     belongs_to :device, Devices.Device
+    belongs_to :ota_operation, OSManagement.OTAOperation, type: :binary_id
 
     timestamps()
   end

--- a/backend/lib/edgehog_web/schema/update_campaigns_types.ex
+++ b/backend/lib/edgehog_web/schema/update_campaigns_types.ex
@@ -175,8 +175,26 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
     @desc "The status of the Update Target."
     field :status, non_null(:update_target_status)
 
+    @desc """
+    The retry count of the Update Target. This indicates how many times Edgehog \
+    has tried to send an OTA Update towards the device without receiving an ack.
+    """
+    field :retry_count, non_null(:integer)
+
+    @desc "The timestamp of the latest attempt to update the Update Target"
+    field :latest_attempt, :datetime
+
+    @desc """
+    The timestamp when the Update Target completed its update, either with a \
+    success or a failure
+    """
+    field :completion_timestamp, :datetime
+
     @desc "The Target device."
     field :device, non_null(:device)
+
+    @desc "The OTA Operation that tracks the Update Target in-progress update"
+    field :ota_operation, :ota_operation
   end
 
   @desc """


### PR DESCRIPTION
Allow querying `retry`, `latest_attempt`, `completion_timestamp` and `ota_operation`

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
