### PR TITLE
push_rollout: rename max_errors_percentage to max_failure_percentage

### DIFF
--- a/backend/lib/edgehog/update_campaigns/push_rollout.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout.ex
@@ -26,7 +26,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout do
   @primary_key false
   embedded_schema do
     field :force_downgrade, :boolean, default: false
-    field :max_errors_percentage, :float
+    field :max_failure_percentage, :float
     field :max_in_progress_updates, :integer
     field :ota_request_retries, :integer, default: 0
     field :ota_request_timeout_seconds, :integer, default: 60
@@ -37,16 +37,16 @@ defmodule Edgehog.UpdateCampaigns.PushRollout do
     push_rollout
     |> cast(attrs, [
       :force_downgrade,
-      :max_errors_percentage,
+      :max_failure_percentage,
       :max_in_progress_updates,
       :ota_request_retries,
       :ota_request_timeout_seconds
     ])
     |> validate_required([
-      :max_errors_percentage,
+      :max_failure_percentage,
       :max_in_progress_updates
     ])
-    |> validate_number(:max_errors_percentage,
+    |> validate_number(:max_failure_percentage,
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: 100
     )

--- a/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
@@ -409,7 +409,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Core do
   Returns true if the failure threshold for the rollout has been exceeded
   """
   def failure_threshold_exceeded?(target_count, failed_count, rollout) do
-    failed_count / target_count * 100 > rollout.max_errors_percentage
+    failed_count / target_count * 100 > rollout.max_failure_percentage
   end
 
   @doc """

--- a/backend/lib/edgehog_web/schema/update_campaigns_types.ex
+++ b/backend/lib/edgehog_web/schema/update_campaigns_types.ex
@@ -47,11 +47,11 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
   """
   object :push_rollout do
     @desc """
-    The maximum percentage of errors allowed over the number of total targets. \
-    If the errors exceed this threshold, the Update Campaign terminates with \
-    an error.
+    The maximum percentage of failures allowed over the number of total targets. \
+    If the failures exceed this threshold, the Update Campaign terminates with \
+    a failure.
     """
-    field :max_errors_percentage, non_null(:float)
+    field :max_failure_percentage, non_null(:float)
 
     @desc """
     The maximum number of in progress updates. The Update Campaign will have \
@@ -99,11 +99,11 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
   """
   input_object :push_rollout_input do
     @desc """
-    The maximum percentage of errors allowed over the number of total targets. \
-    If the errors exceed this threshold, the Update Campaign terminates with \
-    an error.
+    The maximum percentage of failures allowed over the number of total targets. \
+    If the failures exceed this threshold, the Update Campaign terminates with \
+    a failure.
     """
-    field :max_errors_percentage, non_null(:float)
+    field :max_failure_percentage, non_null(:float)
 
     @desc """
     The maximum number of in progress updates. The Update Campaign will have \

--- a/backend/priv/repo/migrations/20230726165246_rename_max_errors_percentage_to_max_failure_percentage.exs
+++ b/backend/priv/repo/migrations/20230726165246_rename_max_errors_percentage_to_max_failure_percentage.exs
@@ -1,0 +1,63 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.RenameMaxErrorsPercentageToMaxFailurePercentage do
+  use Ecto.Migration
+
+  alias Edgehog.Repo
+  import Ecto.Query
+
+  @old_name "max_errors_percentage"
+  @new_name "max_failure_percentage"
+
+  def up do
+    rename_rollout_mechanism_field(@old_name, @new_name)
+  end
+
+  def down do
+    rename_rollout_mechanism_field(@new_name, @old_name)
+  end
+
+  defp rename_rollout_mechanism_field(old_name, new_name) do
+    stream =
+      from(uc in "update_campaigns",
+        select: {uc.id, uc.rollout_mechanism}
+      )
+      |> Repo.stream(skip_tenant_id: true)
+
+    Repo.transaction(fn ->
+      stream
+      |> Enum.each(fn {id, %{^old_name => value} = rollout} ->
+        updated_rollout =
+          rollout
+          |> Map.delete(old_name)
+          |> Map.put(new_name, value)
+
+        from(uc in "update_campaigns",
+          where: uc.id == ^id,
+          select: uc.id
+        )
+        |> Repo.update_all([set: [rollout_mechanism: updated_rollout]], skip_tenant_id: true)
+      end)
+    end)
+
+    :ok
+  end
+end

--- a/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
@@ -815,24 +815,24 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
   end
 
   describe "failure_threshold_exceeded?" do
-    test "returns true when exceeding max_errors_percentage" do
-      rollout = push_rollout_fixture(max_errors_percentage: 10)
+    test "returns true when exceeding max_failure_percentage" do
+      rollout = push_rollout_fixture(max_failure_percentage: 10)
       target_count = 100
       failed_count = 11
 
       assert Core.failure_threshold_exceeded?(target_count, failed_count, rollout) == true
     end
 
-    test "returns false when not exceeding max_errors_percentage" do
-      rollout = push_rollout_fixture(max_errors_percentage: 10)
+    test "returns false when not exceeding max_failure_percentage" do
+      rollout = push_rollout_fixture(max_failure_percentage: 10)
       target_count = 100
       failed_count = 9
 
       assert Core.failure_threshold_exceeded?(target_count, failed_count, rollout) == false
     end
 
-    test "returns false if the error percentage is exactly max_errors_percentage" do
-      rollout = push_rollout_fixture(max_errors_percentage: 10)
+    test "returns false if the error percentage is exactly max_failure_percentage" do
+      rollout = push_rollout_fixture(max_failure_percentage: 10)
       target_count = 100
       failed_count = 10
 
@@ -980,7 +980,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
   defp push_rollout_fixture(attrs \\ []) do
     attrs
     |> Enum.into(%{
-      max_errors_percentage: 5.0,
+      max_failure_percentage: 5.0,
       max_in_progress_updates: 10
     })
     |> then(&struct!(PushRollout, &1))

--- a/backend/test/edgehog/update_campaigns_test.exs
+++ b/backend/test/edgehog/update_campaigns_test.exs
@@ -313,7 +313,7 @@ defmodule Edgehog.UpdateCampaignsTest do
         name: "My Campaign",
         rollout_mechanism: %{
           type: "push",
-          max_errors_percentage: 10.0,
+          max_failure_percentage: 10.0,
           max_in_progress_updates: 10
         }
       }
@@ -322,7 +322,7 @@ defmodule Edgehog.UpdateCampaignsTest do
                UpdateCampaigns.create_update_campaign(update_channel, base_image, attrs)
 
       assert %PushRollout{
-               max_errors_percentage: 10.0,
+               max_failure_percentage: 10.0,
                max_in_progress_updates: 10,
                # Default value
                ota_request_retries: 0,
@@ -374,11 +374,11 @@ defmodule Edgehog.UpdateCampaignsTest do
       assert "is invalid" in errors_on(changeset).rollout_mechanism
     end
 
-    test "fails with invalid max_errors_percentage in rollout_mechanism" do
+    test "fails with invalid max_failure_percentage in rollout_mechanism" do
       assert {:error, %Ecto.Changeset{} = changeset} =
-               create_update_campaign(rollout_mechanism: [max_errors_percentage: 120.0])
+               create_update_campaign(rollout_mechanism: [max_failure_percentage: 120.0])
 
-      assert "must be less than or equal to 100" in errors_on(changeset).rollout_mechanism.max_errors_percentage
+      assert "must be less than or equal to 100" in errors_on(changeset).rollout_mechanism.max_failure_percentage
     end
 
     test "fails with invalid max_in_progress_updates in rollout_mechanism" do
@@ -546,7 +546,7 @@ defmodule Edgehog.UpdateCampaignsTest do
     rollout_mechanism =
       Enum.into(rollout_mechanism_opts, %{
         type: "push",
-        max_errors_percentage: 10.0,
+        max_failure_percentage: 10.0,
         max_in_progress_updates: 10
       })
 

--- a/backend/test/edgehog_web/schema/mutation/create_update_campaign_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_update_campaign_test.exs
@@ -41,7 +41,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
 
       rollout_mechanism = %{
         push: %{
-          max_errors_percentage: 5.0,
+          max_failure_percentage: 5.0,
           max_in_progress_updates: 5,
           ota_request_retries: 10,
           ota_request_timeout_seconds: 120,
@@ -66,7 +66,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
       assert update_campaign["updateChannel"]["name"] == update_channel.name
       assert update_campaign["updateChannel"]["handle"] == update_channel.handle
       assert response_rollout_mechanism = update_campaign["rolloutMechanism"]
-      assert response_rollout_mechanism["maxErrorsPercentage"] == 5.0
+      assert response_rollout_mechanism["maxFailurePercentage"] == 5.0
       assert response_rollout_mechanism["maxInProgressUpdates"] == 5
       assert response_rollout_mechanism["otaRequestRetries"] == 10
       assert response_rollout_mechanism["otaRequestTimeoutSeconds"] == 120
@@ -112,7 +112,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
       response =
         create_update_campaign_mutation(conn, api_path,
           rollout_mechanism: %{
-            push: %{max_errors_percentage: -10.0, max_in_progress_updates: 5}
+            push: %{max_failure_percentage: -10.0, max_in_progress_updates: 5}
           }
         )
 
@@ -131,7 +131,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
         outcome
         rolloutMechanism {
           ... on PushRollout {
-            maxErrorsPercentage
+            maxFailurePercentage
             maxInProgressUpdates
             otaRequestRetries
             otaRequestTimeoutSeconds
@@ -177,7 +177,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
 
     {rollout_mechanism, opts} =
       Keyword.pop_lazy(opts, :rollout_mechanism, fn ->
-        %{push: %{max_errors_percentage: 10.0, max_in_progress_updates: 10}}
+        %{push: %{max_failure_percentage: 10.0, max_in_progress_updates: 10}}
       end)
 
     input =

--- a/backend/test/edgehog_web/schema/query/update_campaign_test.exs
+++ b/backend/test/edgehog_web/schema/query/update_campaign_test.exs
@@ -72,8 +72,8 @@ defmodule EdgehogWeb.Schema.Query.UpdateCampaignTest do
       assert update_campaign_data["updateChannel"]["handle"] == update_channel.handle
       assert response_rollout_mechanism = update_campaign_data["rolloutMechanism"]
 
-      assert response_rollout_mechanism["maxErrorsPercentage"] ==
-               update_campaign.rollout_mechanism.max_errors_percentage
+      assert response_rollout_mechanism["maxFailurePercentage"] ==
+               update_campaign.rollout_mechanism.max_failure_percentage
 
       assert response_rollout_mechanism["maxInProgressUpdates"] ==
                update_campaign.rollout_mechanism.max_in_progress_updates
@@ -109,7 +109,7 @@ defmodule EdgehogWeb.Schema.Query.UpdateCampaignTest do
       outcome
       rolloutMechanism {
         ... on PushRollout {
-          maxErrorsPercentage
+          maxFailurePercentage
           maxInProgressUpdates
           otaRequestRetries
           otaRequestTimeoutSeconds

--- a/backend/test/edgehog_web/schema/query/update_campaigns_test.exs
+++ b/backend/test/edgehog_web/schema/query/update_campaigns_test.exs
@@ -75,8 +75,8 @@ defmodule EdgehogWeb.Schema.Query.UpdateCampaignsTest do
       assert update_campaign_data["updateChannel"]["handle"] == update_channel.handle
       assert response_rollout_mechanism = update_campaign_data["rolloutMechanism"]
 
-      assert response_rollout_mechanism["maxErrorsPercentage"] ==
-               update_campaign.rollout_mechanism.max_errors_percentage
+      assert response_rollout_mechanism["maxFailurePercentage"] ==
+               update_campaign.rollout_mechanism.max_failure_percentage
 
       assert response_rollout_mechanism["maxInProgressUpdates"] ==
                update_campaign.rollout_mechanism.max_in_progress_updates
@@ -106,7 +106,7 @@ defmodule EdgehogWeb.Schema.Query.UpdateCampaignsTest do
       outcome
       rolloutMechanism {
         ... on PushRollout {
-          maxErrorsPercentage
+          maxFailurePercentage
           maxInProgressUpdates
           otaRequestRetries
           otaRequestTimeoutSeconds

--- a/backend/test/support/fixtures/update_campaigns_fixtures.ex
+++ b/backend/test/support/fixtures/update_campaigns_fixtures.ex
@@ -76,7 +76,7 @@ defmodule Edgehog.UpdateCampaignsFixtures do
     rollout_mechanism_attrs =
       Enum.into(rollout_mechanism_attrs, %{
         type: "push",
-        max_errors_percentage: 50.0,
+        max_failure_percentage: 50.0,
         max_in_progress_updates: 100
       })
 

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -240,8 +240,8 @@ enum DeviceAttributeNamespace {
 
 "An object representing the properties of a Push Rollout Mechanism"
 type PushRollout {
-  "The maximum percentage of errors allowed over the number of total targets. If the errors exceed this threshold, the Update Campaign terminates with an error."
-  maxErrorsPercentage: Float!
+  "The maximum percentage of failures allowed over the number of total targets. If the failures exceed this threshold, the Update Campaign terminates with a failure."
+  maxFailurePercentage: Float!
 
   "The maximum number of in progress updates. The Update Campaign will have at most this number of OTA Operations that are started but not yet finished (either successfully or not)."
   maxInProgressUpdates: Int!
@@ -675,8 +675,8 @@ scalar Upload
 
 "An input object to set the properties of a Push Rollout Mechanism"
 input PushRolloutInput {
-  "The maximum percentage of errors allowed over the number of total targets. If the errors exceed this threshold, the Update Campaign terminates with an error."
-  maxErrorsPercentage: Float!
+  "The maximum percentage of failures allowed over the number of total targets. If the failures exceed this threshold, the Update Campaign terminates with a failure."
+  maxFailurePercentage: Float!
 
   "The maximum number of in progress updates. The Update Campaign will have at most this number of OTA Operations that are started but not yet finished (either successfully or not)."
   maxInProgressUpdates: Int!

--- a/frontend/src/forms/CreateUpdateCampaign.tsx
+++ b/frontend/src/forms/CreateUpdateCampaign.tsx
@@ -72,7 +72,7 @@ type UpdateCampaignData = {
   name: string;
   rolloutMechanism: {
     push: {
-      maxErrorsPercentage: number;
+      maxFailurePercentage: number;
       maxInProgressUpdates: number;
       otaRequestRetries: number;
       otaRequestTimeoutSeconds: number;
@@ -86,7 +86,7 @@ type FormData = {
   updateChannelId: string;
   baseImageCollectionId: string;
   baseImageId: string;
-  maxErrorsPercentage: number | string;
+  maxFailurePercentage: number | string;
   maxInProgressUpdates: number | string;
   otaRequestRetries: number;
   otaRequestTimeoutSeconds: number;
@@ -98,7 +98,7 @@ const initialData: FormData = {
   updateChannelId: "",
   baseImageCollectionId: "",
   baseImageId: "",
-  maxErrorsPercentage: "",
+  maxFailurePercentage: "",
   maxInProgressUpdates: "",
   otaRequestRetries: 0,
   otaRequestTimeoutSeconds: 60,
@@ -110,7 +110,7 @@ const transformOutputData = (data: FormData): UpdateCampaignData => {
     name,
     baseImageId,
     updateChannelId,
-    maxErrorsPercentage,
+    maxFailurePercentage,
     maxInProgressUpdates,
     otaRequestRetries,
     otaRequestTimeoutSeconds,
@@ -123,10 +123,10 @@ const transformOutputData = (data: FormData): UpdateCampaignData => {
     updateChannelId,
     rolloutMechanism: {
       push: {
-        maxErrorsPercentage:
-          typeof maxErrorsPercentage === "string"
-            ? parseFloat(maxErrorsPercentage)
-            : maxErrorsPercentage,
+        maxFailurePercentage:
+          typeof maxFailurePercentage === "string"
+            ? parseFloat(maxFailurePercentage)
+            : maxFailurePercentage,
         maxInProgressUpdates:
           typeof maxInProgressUpdates === "string"
             ? parseInt(maxInProgressUpdates)
@@ -167,13 +167,13 @@ const CreateBaseImageCollectionForm = ({
             defaultMessage: "Max Pending Operations",
           })
         ),
-      maxErrorsPercentage: numberSchema
+      maxFailurePercentage: numberSchema
         .min(0)
         .max(100)
         .label(
           intl.formatMessage({
-            id: "forms.CreateUpdateCampaign.maxErrorsPercentageValidationLabel",
-            defaultMessage: "Max Errors",
+            id: "forms.CreateUpdateCampaign.maxFailurePercentageValidationLabel",
+            defaultMessage: "Max Failures",
           })
         ),
       otaRequestTimeoutSeconds: numberSchema
@@ -334,11 +334,11 @@ const CreateBaseImageCollectionForm = ({
           <FormFeedback feedback={errors.maxInProgressUpdates?.message} />
         </FormRow>
         <FormRow
-          id="create-update-campaign-form-max-errors-percentage"
+          id="create-update-campaign-form-max-failure-percentage"
           label={
             <FormattedMessage
-              id="forms.CreateUpdateCampaign.maxErrorsPercentageLabel"
-              defaultMessage="Max Errors <muted>(%)</muted>"
+              id="forms.CreateUpdateCampaign.maxFailurePercentageLabel"
+              defaultMessage="Max Failures <muted>(%)</muted>"
               values={{
                 muted: (chunks: React.ReactNode) => (
                   <span className="small text-muted">{chunks}</span>
@@ -348,13 +348,13 @@ const CreateBaseImageCollectionForm = ({
           }
         >
           <Form.Control
-            {...register("maxErrorsPercentage")}
+            {...register("maxFailurePercentage")}
             type="number"
             min="0"
             max="100"
-            isInvalid={!!errors.maxErrorsPercentage}
+            isInvalid={!!errors.maxFailurePercentage}
           />
-          <FormFeedback feedback={errors.maxErrorsPercentage?.message} />
+          <FormFeedback feedback={errors.maxFailurePercentage?.message} />
         </FormRow>
         <FormRow
           id="create-update-campaign-form-ota-request-timeout"

--- a/frontend/src/forms/UpdateCampaignForm.tsx
+++ b/frontend/src/forms/UpdateCampaignForm.tsx
@@ -51,7 +51,7 @@ const UPDATE_CAMPAIGN_FORM_FRAGMENT = graphql`
     }
     rolloutMechanism {
       ... on PushRollout {
-        maxErrorsPercentage
+        maxFailurePercentage
         maxInProgressUpdates
         otaRequestRetries
         otaRequestTimeoutSeconds
@@ -88,7 +88,7 @@ const UpdateCampaign = ({ updateCampaignRef }: UpdateCampaignProps) => {
   const { baseImageCollection } = baseImage;
   const {
     maxInProgressUpdates,
-    maxErrorsPercentage,
+    maxFailurePercentage,
     otaRequestTimeoutSeconds,
     otaRequestRetries,
     forceDowngrade,
@@ -178,12 +178,12 @@ const UpdateCampaign = ({ updateCampaignRef }: UpdateCampaignProps) => {
             {maxInProgressUpdates}
           </FormRow>
         )}
-        {maxErrorsPercentage !== undefined && (
+        {maxFailurePercentage !== undefined && (
           <FormRow
             label={
               <FormattedMessage
-                id="forms.UpdateCampaignForm.maxErrorsPercentageLabel"
-                defaultMessage="Max Errors <muted>(%)</muted>"
+                id="forms.UpdateCampaignForm.maxFailurePercentageLabel"
+                defaultMessage="Max Failures <muted>(%)</muted>"
                 values={{
                   muted: (chunks: React.ReactNode) => (
                     <span className="small text-muted">{chunks}</span>
@@ -192,7 +192,7 @@ const UpdateCampaign = ({ updateCampaignRef }: UpdateCampaignProps) => {
               />
             }
           >
-            {maxErrorsPercentage}
+            {maxFailurePercentage}
           </FormRow>
         )}
         {otaRequestTimeoutSeconds !== undefined && (

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -638,11 +638,11 @@
   "forms.CreateUpdateCampaign.forceDowngradeLabel": {
     "defaultMessage": "Force Downgrade"
   },
-  "forms.CreateUpdateCampaign.maxErrorsPercentageLabel": {
-    "defaultMessage": "Max Errors <muted>(%)</muted>"
+  "forms.CreateUpdateCampaign.maxFailurePercentageLabel": {
+    "defaultMessage": "Max Failures <muted>(%)</muted>"
   },
-  "forms.CreateUpdateCampaign.maxErrorsPercentageValidationLabel": {
-    "defaultMessage": "Max Errors"
+  "forms.CreateUpdateCampaign.maxFailurePercentageValidationLabel": {
+    "defaultMessage": "Max Failures"
   },
   "forms.CreateUpdateCampaign.maxInProgressUpdatesLabel": {
     "defaultMessage": "Max Pending Operations"
@@ -717,8 +717,8 @@
   "forms.UpdateCampaignForm.forceDowngradeLabel": {
     "defaultMessage": "Force Downgrade"
   },
-  "forms.UpdateCampaignForm.maxErrorsPercentageLabel": {
-    "defaultMessage": "Max Errors <muted>(%)</muted>"
+  "forms.UpdateCampaignForm.maxFailurePercentageLabel": {
+    "defaultMessage": "Max Failures <muted>(%)</muted>"
   },
   "forms.UpdateCampaignForm.maxInProgressUpdatesLabel": {
     "defaultMessage": "Max Pending Operations"

--- a/frontend/src/mocks/relay.ts
+++ b/frontend/src/mocks/relay.ts
@@ -190,7 +190,7 @@ const relayMockResolvers: MockPayloadGenerator.MockResolvers = {
       status: "IN_PROGRESS",
       outcome: null,
       rolloutMechanism: {
-        maxErrorsPercentage: 5,
+        maxFailurePercentage: 5,
         maxInProgressUpdates: 2,
         otaRequestRetries: 10,
         otaRequestTimeoutSeconds: 120,


### PR DESCRIPTION
This fixes two different problems: one, the plural "errors" was grammatically incorrect, and the correct concept is "failure", since that's the term we use for exceptions which result in a final state, while error is a possibly temporary condition.
Add a migration to rename the field in the database and replace all occurrences both in frontend and backend. The only remaining occurrence is in the docs, but they have to be completely revamped anyway so it doesn't make sense to touch them here.

Close #287

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
