### PR TITLE
executor: bump retry count only when we actually retry

### DIFF
--- a/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
@@ -139,7 +139,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
     end
 
     test "returns false if the target has no retries left", ctx do
-      target = set_target_retry_count!(ctx.target, 6)
+      target = set_target_retry_count!(ctx.target, 5)
       rollout_mechanism = push_rollout_fixture(ota_request_retries: 5)
 
       assert Core.can_retry?(target, rollout_mechanism) == false


### PR DESCRIPTION
Previously the update target actually had one less retry than desired, and ended up with retry_count one higher than the actual number of retries. Adjust test to test the boundary condition.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
