### PR TITLE
[frontend] Add OTA Updates group into sidebar

### DIFF
--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -36,6 +36,7 @@ import {
   faCheck,
   faTimes,
   faDatabase,
+  faCloud,
 } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 
@@ -57,6 +58,7 @@ const icons = {
   search: faSearch,
   check: faCheck,
   close: faTimes,
+  otaUpdates: faCloud,
 } as const;
 
 type FontAwesomeIconProps = React.ComponentProps<typeof FontAwesomeIcon>;

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -30,6 +30,28 @@ it("renders correctly", async () => {
   expect(devicesLink).toBeInTheDocument();
   expect(devicesLink).toHaveTextContent("Devices");
 
+  const groupsLink = container.querySelector("a[href='/device-groups']");
+  expect(groupsLink).toBeInTheDocument();
+  expect(groupsLink).toHaveTextContent("Groups");
+
+  const updateCampaignsLink = container.querySelector(
+    "a[href='/update-campaigns']"
+  );
+  expect(updateCampaignsLink).toBeInTheDocument();
+  expect(updateCampaignsLink).toHaveTextContent("Update Campaigns");
+
+  const updateChannelsLink = container.querySelector(
+    "a[href='/update-channels']"
+  );
+  expect(updateChannelsLink).toBeInTheDocument();
+  expect(updateChannelsLink).toHaveTextContent("Update Channels");
+
+  const baseImageCollectionsLink = container.querySelector(
+    "a[href='/base-image-collections']"
+  );
+  expect(baseImageCollectionsLink).toBeInTheDocument();
+  expect(baseImageCollectionsLink).toHaveTextContent("Base Image Collections");
+
   const systemModelsLink = container.querySelector("a[href='/system-models']");
   expect(systemModelsLink).toBeInTheDocument();
   expect(systemModelsLink).toHaveTextContent("System Models");
@@ -41,9 +63,14 @@ it("renders correctly", async () => {
   expect(hardwareTypesLink).toHaveTextContent("Hardware Types");
 
   const menuGroups = container.querySelectorAll(".accordion");
-  expect(menuGroups).toHaveLength(1);
-  expect(menuGroups[0]).toHaveTextContent("System Models");
-  expect(menuGroups[0]).toHaveTextContent("Hardware Types");
+  expect(menuGroups).toHaveLength(2);
+
+  expect(menuGroups[0]).toHaveTextContent("Update Campaigns");
+  expect(menuGroups[0]).toHaveTextContent("Update Channels");
+  expect(menuGroups[0]).toHaveTextContent("Base Image Collections");
+
+  expect(menuGroups[1]).toHaveTextContent("System Models");
+  expect(menuGroups[1]).toHaveTextContent("Hardware Types");
 });
 
 it("shows links as active when route matches", async () => {
@@ -52,7 +79,31 @@ it("shows links as active when route matches", async () => {
   });
 
   const devicesLink = container.querySelector("a[href='/devices']");
-  const systemModelsLink = container.querySelector("a[href='/system-models']");
   expect(devicesLink).toHaveClass("bg-primary");
+
+  const groupsLink = container.querySelector("a[href='/device-groups']");
+  expect(groupsLink).not.toHaveClass("bg-primary");
+
+  const updateCampaignsLink = container.querySelector(
+    "a[href='/update-campaigns']"
+  );
+  expect(updateCampaignsLink).not.toHaveClass("bg-primary");
+
+  const updateChannelsLink = container.querySelector(
+    "a[href='/update-channels']"
+  );
+  expect(updateChannelsLink).not.toHaveClass("bg-primary");
+
+  const baseImageCollectionsLink = container.querySelector(
+    "a[href='/base-image-collections']"
+  );
+  expect(baseImageCollectionsLink).not.toHaveClass("bg-primary");
+
+  const systemModelsLink = container.querySelector("a[href='/system-models']");
   expect(systemModelsLink).not.toHaveClass("bg-primary");
+
+  const hardwareTypesLink = container.querySelector(
+    "a[href='/hardware-types']"
+  );
+  expect(hardwareTypesLink).not.toHaveClass("bg-primary");
 });

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -120,6 +120,56 @@ const Sidebar = () => (
     <SidebarItemGroup
       label={
         <FormattedMessage
+          id="components.Sidebar.otaUpdatesGroupLabel"
+          defaultMessage="OTA Updates"
+        />
+      }
+      icon="otaUpdates"
+    >
+      <SidebarItem
+        label={
+          <FormattedMessage
+            id="components.Sidebar.updateCampaignsLabel"
+            defaultMessage="Update Campaigns"
+          />
+        }
+        route={Route.updateCampaigns}
+        activeRoutes={[Route.updateCampaigns, Route.updateCampaignsEdit]}
+      />
+      <SidebarItem
+        label={
+          <FormattedMessage
+            id="components.Sidebar.updateChannelsLabel"
+            defaultMessage="Update Channels"
+          />
+        }
+        route={Route.updateChannels}
+        activeRoutes={[
+          Route.updateChannels,
+          Route.updateChannelsEdit,
+          Route.updateChannelsNew,
+        ]}
+      />
+      <SidebarItem
+        label={
+          <FormattedMessage
+            id="components.Sidebar.baseImageCollectionsLabel"
+            defaultMessage="Base Image Collections"
+          />
+        }
+        route={Route.baseImageCollections}
+        activeRoutes={[
+          Route.baseImageCollections,
+          Route.baseImageCollectionsNew,
+          Route.baseImageCollectionsEdit,
+          Route.baseImagesNew,
+          Route.baseImagesEdit,
+        ]}
+      />
+    </SidebarItemGroup>
+    <SidebarItemGroup
+      label={
+        <FormattedMessage
           id="components.Sidebar.modelsGroupLabel"
           defaultMessage="Models"
         />
@@ -153,46 +203,6 @@ const Sidebar = () => (
           Route.hardwareTypesNew,
           Route.hardwareTypesEdit,
         ]}
-      />
-      <SidebarItem
-        label={
-          <FormattedMessage
-            id="components.Sidebar.baseImageCollectionsLabel"
-            defaultMessage="Base Image Collections"
-          />
-        }
-        route={Route.baseImageCollections}
-        activeRoutes={[
-          Route.baseImageCollections,
-          Route.baseImageCollectionsNew,
-          Route.baseImageCollectionsEdit,
-          Route.baseImagesNew,
-          Route.baseImagesEdit,
-        ]}
-      />
-      <SidebarItem
-        label={
-          <FormattedMessage
-            id="components.Sidebar.updateChannelsLabel"
-            defaultMessage="Update Channels"
-          />
-        }
-        route={Route.updateChannels}
-        activeRoutes={[
-          Route.updateChannels,
-          Route.updateChannelsEdit,
-          Route.updateChannelsNew,
-        ]}
-      />
-      <SidebarItem
-        label={
-          <FormattedMessage
-            id="components.Sidebar.updateCampaignsLabel"
-            defaultMessage="Update Campaigns"
-          />
-        }
-        route={Route.updateCampaigns}
-        activeRoutes={[Route.updateCampaigns, Route.updateCampaignsEdit]}
       />
     </SidebarItemGroup>
   </Navbar>

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -407,6 +407,9 @@
   "components.Sidebar.modelsLabel": {
     "defaultMessage": "System Models"
   },
+  "components.Sidebar.otaUpdatesGroupLabel": {
+    "defaultMessage": "OTA Updates"
+  },
   "components.Sidebar.updateCampaignsLabel": {
     "defaultMessage": "Update Campaigns"
   },


### PR DESCRIPTION
Move `Update Campaigns`, `Update Channels` and `Base Image Collections` Sidebar items into new `OTA Updates` group.

![Screenshot from 2023-07-28 15-56-50](https://github.com/edgehog-device-manager/edgehog/assets/26611935/776ad0de-0692-487a-947f-0ae532ea5f0e)
