### PR TITLE
feat(push_rollout): `max_in_progress_updates` update api

### DIFF
--- a/backend/lib/edgehog/pubsub.ex
+++ b/backend/lib/edgehog/pubsub.ex
@@ -24,8 +24,9 @@ defmodule Edgehog.PubSub do
   """
 
   alias Edgehog.OSManagement.OTAOperation
+  alias Edgehog.UpdateCampaigns.UpdateCampaign
 
-  @type event :: :ota_operation_created | :ota_operation_updated
+  @type event :: :ota_operation_created | :ota_operation_updated | :update_campaign_updated
 
   @doc """
   Publish an event to the PubSub. Raises if any of the publish fails.
@@ -47,6 +48,13 @@ defmodule Edgehog.PubSub do
       topic_for_subject(ota_operation),
       wildcard_topic_for_subject(ota_operation)
     ]
+
+    broadcast_many!(topics, payload)
+  end
+
+  def publish!(:update_campaign_updated = event, %UpdateCampaign{} = update_campaign) do
+    payload = {event, update_campaign}
+    topics = [topic_for_subject(update_campaign)]
 
     broadcast_many!(topics, payload)
   end
@@ -73,4 +81,6 @@ defmodule Edgehog.PubSub do
   defp topic_for_subject(%OTAOperation{id: id}), do: "ota_operations:#{id}"
   defp topic_for_subject({:ota_operation, id}), do: "ota_operations:#{id}"
   defp topic_for_subject(:ota_operations), do: "ota_operations:*"
+  defp topic_for_subject(%UpdateCampaign{id: id}), do: "update_campaigns:#{id}"
+  defp topic_for_subject({:update_campaign, id}), do: "update_campaigns:#{id}"
 end

--- a/backend/lib/edgehog/update_campaigns.ex
+++ b/backend/lib/edgehog/update_campaigns.ex
@@ -377,6 +377,28 @@ defmodule Edgehog.UpdateCampaigns do
   end
 
   @doc """
+  Updates an update_campaign.
+
+  ## Examples
+
+      iex> update_update_campaign(update_campaign, %{field: new_value})
+      {:ok, %UpdateCampaign{}}
+
+      iex> update_update_campaign(update_campaign, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_update_campaign(%UpdateCampaign{} = update_campaign, attrs \\ %{}) do
+    update_result =
+      UpdateCampaign.changeset(update_campaign, attrs)
+      |> Repo.update()
+
+    with {:ok, update_campaign} <- update_result do
+      {:ok, preload_defaults_for_update_campaign(update_campaign)}
+    end
+  end
+
+  @doc """
   Creates an update campaign.
 
   ## Examples

--- a/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
@@ -296,6 +296,16 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Core do
   end
 
   @doc """
+  Subscribes to update events for the given Update Campaign. Raises on failure.
+  """
+  def subscribe_to_update_campaign_updates!(update_campaign_id) do
+    with {:error, reason} <-
+           PubSub.subscribe_to_events_for({:update_campaign, update_campaign_id}) do
+      raise reason
+    end
+  end
+
+  @doc """
   Subscribes to receive the events for the OTA Operation with the given id. Raises in case of failure.
   """
   def subscribe_to_ota_operation_updates!(ota_operation_id) do

--- a/backend/lib/edgehog/update_campaigns/push_rollout/executor.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout/executor.ex
@@ -86,10 +86,9 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Executor do
   end
 
   def handle_event(:internal, :init_data, :initialization, update_campaign_id) do
-    # TODO: when we expose the possibility of updating the UpdateCampaign, specifically the rollout,
-    # we should publish changes to it via PubSub, subscribing to them here, since we will allow
-    # increasing max_in_progress_updates during the campaign execution, which will affect
-    # available_slots.
+    # Subscribe to updates for the update campaign.
+    Core.subscribe_to_update_campaign_updates!(update_campaign_id)
+
     update_campaign = Core.get_update_campaign!(update_campaign_id)
     base_image = Core.get_update_campaign_base_image!(update_campaign_id)
     target_count = Core.get_target_count(update_campaign_id)
@@ -374,6 +373,16 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Executor do
   # events enqueued with the :next_event action. This means that we can be sure an :info event
   # or a timeout won't be handled, e.g., between a rollout and the handling of its error
 
+  def handle_event(:info, {:update_campaign_updated, update_campaign}, state, data) do
+    new_data = update_rollout_mechanism(data, update_campaign.rollout_mechanism)
+
+    if state == :wait_for_available_slots and slot_available?(new_data) do
+      {:next_state, :rollout, new_data, internal_event(:fetch_next_target)}
+    else
+      {:keep_state, new_data, []}
+    end
+  end
+
   def handle_event(:info, {:ota_operation_updated, ota_operation}, _state, _data) do
     # Event generated from PubSub when an OTAOperation is updated
     additional_actions =
@@ -606,5 +615,16 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Executor do
 
   defp targets_in_progress?(data) do
     data.in_progress_count > 0
+  end
+
+  defp update_rollout_mechanism(data, rollout) do
+    current_in_progress = data.in_progress_count
+    available_slots = Core.available_update_slots(rollout, current_in_progress)
+
+    %{
+      data
+      | rollout_mechanism: rollout,
+        available_slots: available_slots
+    }
   end
 end

--- a/backend/lib/edgehog_web/resolvers/update_campaigns.ex
+++ b/backend/lib/edgehog_web/resolvers/update_campaigns.ex
@@ -107,6 +107,20 @@ defmodule EdgehogWeb.Resolvers.UpdateCampaigns do
     end
   end
 
+  def update_rollout_mechanism(args, _resolution, mechanism_type) do
+    rollout_args =
+      args
+      |> Map.delete(:update_campaign_id)
+      |> Map.put(:type, mechanism_type)
+
+    update_args = %{rollout_mechanism: rollout_args}
+
+    with {:ok, campaign} <- UpdateCampaigns.fetch_update_campaign(args.update_campaign_id),
+         {:ok, updated_campaign} <- UpdateCampaigns.update_update_campaign(campaign, update_args) do
+      {:ok, %{update_campaign: updated_campaign}}
+    end
+  end
+
   # This moves the type tag from the outer key to the inner map, which adapts the behaviour
   # offered by GraphQL to the one required by PolymorphicEmbed in the changeset
   defp tag_rollout_mechanism(%{push: push_rollout_mechanism}) do

--- a/backend/lib/edgehog_web/schema/update_campaigns_types.ex
+++ b/backend/lib/edgehog_web/schema/update_campaigns_types.ex
@@ -161,7 +161,7 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
 
     Must be greater than (or equal to) the current value.
     """
-    field :max_in_progress_updates, :integer
+    field :max_in_progress_updates, non_null(:integer)
   end
 
   @desc """

--- a/backend/lib/edgehog_web/schema/update_campaigns_types.ex
+++ b/backend/lib/edgehog_web/schema/update_campaigns_types.ex
@@ -151,6 +151,20 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
   end
 
   @desc """
+  Properties that can be updated for a Push Rollout Mechanism
+  """
+  input_object :push_rollout_update do
+    @desc """
+    The maximum number of in progress updates. The Update Campaign will have \
+    at most this number of OTA Operations that are started but not yet \
+    finished (either successfully or not).
+
+    Must be greater than (or equal to) the current value.
+    """
+    field :max_in_progress_updates, :integer
+  end
+
+  @desc """
   The status of an Update Target
   """
   enum :update_target_status do
@@ -392,6 +406,25 @@ defmodule EdgehogWeb.Schema.UpdateCampaignsTypes do
         update_channel_id: :update_channel
 
       resolve &Resolvers.UpdateCampaigns.create_update_campaign/2
+    end
+
+    @desc "Update an update campaign's push rollout mechanism"
+    payload field :update_push_rollout do
+      input do
+        @desc "The id of the Campaign."
+        field :update_campaign_id, non_null(:id)
+
+        import_fields :push_rollout_update
+      end
+
+      output do
+        @desc "The updated Update Campaign."
+        field :update_campaign, non_null(:update_campaign)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, update_campaign_id: :update_campaign
+
+      resolve &Resolvers.UpdateCampaigns.update_rollout_mechanism(&1, &2, :push)
     end
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/update_push_rollout_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_push_rollout_test.exs
@@ -18,17 +18,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule EdgehogWeb.Schema.Mutation.UpdateRolloutMechanismTest do
+defmodule EdgehogWeb.Schema.Mutation.UpdatePushRolloutTest do
   use EdgehogWeb.ConnCase
 
   import Edgehog.UpdateCampaignsFixtures
 
-  describe "updateUpdateCampaign mutation" do
+  describe "updatePushRollout mutation" do
     setup do
       {:ok, update_campaign: update_campaign_fixture()}
     end
 
-    test "updates the update campaign with valid data", %{
+    test "updates the push rollout with valid data", %{
       conn: conn,
       api_path: api_path,
       update_campaign: update_campaign
@@ -40,15 +40,26 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateRolloutMechanismTest do
       mutation_opts =
         update_data
         |> Map.put(:update_campaign_id, update_campaign.id)
-        |> Enum.into([])
+        |> Keyword.new()
 
-      response = update_update_campaign_mutation(conn, api_path, mutation_opts)
+      response = update_push_rollout_mutation(conn, api_path, mutation_opts)
 
       updated_update_campaign = response["data"]["updatePushRollout"]["updateCampaign"]
       assert updated_update_campaign["name"] == update_campaign.name
 
       assert updated_update_campaign["rolloutMechanism"]["maxInProgressUpdates"] ==
                update_data.max_in_progress_updates
+    end
+
+    test "fails when trying to use a non-existing update campaign", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      non_existing_id = "123456"
+      args = [update_campaign_id: non_existing_id, max_in_progress_updates: 10]
+      response = update_push_rollout_mutation(conn, api_path, args)
+
+      assert %{"errors" => [%{"status_code" => 404, "code" => "not_found"}]} = response
     end
   end
 
@@ -86,14 +97,14 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateRolloutMechanismTest do
     }
   }
   """
-  defp update_update_campaign_mutation(conn, api_path, opts) do
+  defp update_push_rollout_mutation(conn, api_path, opts) do
     input =
       opts
       |> Keyword.update!(
         :update_campaign_id,
         &Absinthe.Relay.Node.to_global_id(:update_campaign, &1, EdgehogWeb.Schema)
       )
-      |> Enum.into(%{})
+      |> Map.new()
 
     variables = %{input: input}
 

--- a/backend/test/edgehog_web/schema/mutation/update_rollout_mechanism_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_rollout_mechanism_test.exs
@@ -1,0 +1,104 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.UpdateRolloutMechanismTest do
+  use EdgehogWeb.ConnCase
+
+  import Edgehog.UpdateCampaignsFixtures
+
+  describe "updateUpdateCampaign mutation" do
+    setup do
+      {:ok, update_campaign: update_campaign_fixture()}
+    end
+
+    test "updates the update campaign with valid data", %{
+      conn: conn,
+      api_path: api_path,
+      update_campaign: update_campaign
+    } do
+      update_data = %{
+        max_in_progress_updates: update_campaign.rollout_mechanism.max_in_progress_updates + 1
+      }
+
+      mutation_opts =
+        update_data
+        |> Map.put(:update_campaign_id, update_campaign.id)
+        |> Enum.into([])
+
+      response = update_update_campaign_mutation(conn, api_path, mutation_opts)
+
+      updated_update_campaign = response["data"]["updatePushRollout"]["updateCampaign"]
+      assert updated_update_campaign["name"] == update_campaign.name
+
+      assert updated_update_campaign["rolloutMechanism"]["maxInProgressUpdates"] ==
+               update_data.max_in_progress_updates
+    end
+  end
+
+  @query """
+  mutation UpdatePushRollout($input: UpdatePushRolloutInput!) {
+    updatePushRollout(input: $input) {
+      updateCampaign {
+        name
+        status
+        outcome
+        rolloutMechanism {
+          ... on PushRollout {
+            maxFailurePercentage
+            maxInProgressUpdates
+            otaRequestRetries
+            otaRequestTimeoutSeconds
+            forceDowngrade
+          }
+        }
+        baseImage {
+          version
+          url
+        }
+        updateChannel {
+          name
+          handle
+        }
+        updateTargets {
+          status
+          device {
+            id
+          }
+        }
+      }
+    }
+  }
+  """
+  defp update_update_campaign_mutation(conn, api_path, opts) do
+    input =
+      opts
+      |> Keyword.update!(
+        :update_campaign_id,
+        &Absinthe.Relay.Node.to_global_id(:update_campaign, &1, EdgehogWeb.Schema)
+      )
+      |> Enum.into(%{})
+
+    variables = %{input: input}
+
+    conn = post(conn, api_path, query: @query, variables: variables)
+
+    json_response(conn, 200)
+  end
+end


### PR DESCRIPTION
provide an api for updating push_rollout.
for now, only the field `max_in_progress_updates` is exposed through the graphql mutation.

includes edits to `push_rollout_executor` to handle the updates.

closes #278
re-implementation of #305
adapts and includes #325
