### PR TITLE
Fix OTA Campaign crash triggered by missing base image version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0-alpha.2] - Unreleased
+### Fixed
+- Don't crash the OTA campaign if a misconfigured device doesn't send its base image version.
+
 ## [0.7.0-alpha.1] - 2023-09-12
 ### Added
 - Expose OTA Campaigns stats.

--- a/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
@@ -159,10 +159,18 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Core do
 
     with {:ok, client} <- Devices.appengine_client_from_device(device),
          {:ok, device_base_image} <- Astarte.fetch_base_image(client, device.device_id) do
-      case Version.parse(device_base_image.version) do
-        {:ok, version} -> {:ok, version}
-        :error -> {:error, :invalid_version}
-      end
+      parse_version(device_base_image.version)
+    end
+  end
+
+  defp parse_version(nil) do
+    {:error, :missing_version}
+  end
+
+  defp parse_version(version) when is_binary(version) do
+    case Version.parse(version) do
+      {:ok, version} -> {:ok, version}
+      :error -> {:error, :invalid_version}
     end
   end
 
@@ -354,6 +362,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Core do
 
   def error_message(:invalid_version, device_id) do
     "Device #{device_id} has an invalid BaseImage version published on Astarte"
+  end
+
+  def error_message(:missing_version, device_id) do
+    "Device #{device_id} has a null BaseImage version published on Astarte"
   end
 
   def error_message("connection refused", device_id) do

--- a/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
+++ b/backend/lib/edgehog/update_campaigns/push_rollout/core.ex
@@ -375,12 +375,12 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.Core do
 
   def error_message(%APIError{status: status} = error, device_id) when status in 400..499 do
     # Client error, assume it's always going to fail
-    "Device #{device_id} failed to send OTA Request: received status #{status} (#{error.response})"
+    "Device #{device_id} failed Astarte API call: received status #{status} (#{error.response})"
   end
 
   def error_message(%APIError{status: status} = error, device_id) when status in 500..599 do
     # Server error, assume temporary error
-    "Device #{device_id} failed to send OTA Request: received status #{status} (#{error.response})"
+    "Device #{device_id} failed Astarte API call: received status #{status} (#{error.response})"
   end
 
   def error_message(other, device_id) do

--- a/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
@@ -362,6 +362,24 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
 
       assert {:error, :invalid_version} = Core.fetch_target_current_version(target)
     end
+
+    test "returns error if the returned version is empty", ctx do
+      %{target: target} = ctx
+
+      Edgehog.Astarte.Device.BaseImageMock
+      |> expect(:get, fn _client, _device_id ->
+        base_image = %Edgehog.Astarte.Device.BaseImage{
+          name: "esp-idf",
+          version: nil,
+          build_id: "2022-01-01 12:00:00",
+          fingerprint: "b14c1457dc10469418b4154fef29a90e1ffb4dddd308bf0f2456d436963ef5b3"
+        }
+
+        {:ok, base_image}
+      end)
+
+      assert {:error, :missing_version} = Core.fetch_target_current_version(target)
+    end
   end
 
   describe "needs_update?/2" do
@@ -705,6 +723,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
         :downgrade_not_allowed,
         :ambiguous_version_ordering,
         :invalid_version,
+        :missing_version,
         "connection refused",
         %APIError{status: 422, response: "Invalid entity"},
         %APIError{status: 500, response: "Internal server error"}
@@ -741,6 +760,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
         :downgrade_not_allowed,
         :ambiguous_version_ordering,
         :invalid_version,
+        :missing_version,
         %APIError{status: 404, response: "Not found"}
       ]
 

--- a/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
@@ -587,6 +587,26 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       assert_normal_exit(pid, ref)
       assert_update_campaign_outcome(update_campaign_id, :failure)
     end
+
+    test "by targets that return an empty base image version", ctx do
+      %{
+        executor_pid: pid,
+        failing_target_count: failing_target_count,
+        monitor_ref: ref,
+        update_campaign_id: update_campaign_id
+      } = ctx
+
+      Edgehog.Astarte.Device.BaseImageMock
+      |> expect(:get, failing_target_count, fn _client, _device_id ->
+        # Reply like the target already has an incompatible version
+        {:ok, astarte_base_image_with_version(nil)}
+      end)
+
+      start_execution(pid)
+
+      assert_normal_exit(pid, ref)
+      assert_update_campaign_outcome(update_campaign_id, :failure)
+    end
   end
 
   describe "PushRollout.Executor terminates immediately" do


### PR DESCRIPTION
This also includes a separate commit which clarifies some relevant error messages

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
