### PR TITLE
trigger_controller: handle empty string for OTAResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Don't crash the OTA campaign if a misconfigured device doesn't send its base image version.
 - Correctly return stats even for OTA campaigns with no targets.
+- Handle empty string when translating legacy OTAResponse messages.
 
 ## [0.7.0-alpha.1] - 2023-09-12
 ### Added

--- a/backend/lib/edgehog_web/controllers/trigger_controller.ex
+++ b/backend/lib/edgehog_web/controllers/trigger_controller.ex
@@ -129,6 +129,7 @@ defmodule EdgehogWeb.AstarteTriggerController do
   defp translate_ota_response_status("Done"), do: "Success"
 
   defp translate_ota_response_status_code(nil), do: nil
+  defp translate_ota_response_status_code(""), do: nil
   defp translate_ota_response_status_code("OTAErrorNetwork"), do: "NetworkError"
   defp translate_ota_response_status_code("OTAErrorNvs"), do: nil
   defp translate_ota_response_status_code("OTAAlreadyInProgress"), do: "UpdateAlreadyInProgress"


### PR DESCRIPTION
Don't crash if legacy devices send an empty string in OTAResponse status code

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
