### PR TITLE
CI: don't build docs on tag creation

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -32,8 +32,6 @@ on:
     # Create the snapshot only when it matters
     - 'main'
     - 'release-*'
-  # Run on branch/tag creation
-  create:
 
 jobs:
   docs:

--- a/.github/workflows/graphql-doc.yaml
+++ b/.github/workflows/graphql-doc.yaml
@@ -37,8 +37,6 @@ on:
     # Create the snapshot only when it matters
     - 'main'
     - 'release-*'
-  # Run on branch/tag creation
-  create:
 
 jobs:
   docs:


### PR DESCRIPTION
Docs are only exposed from branches, for the latest tag of the branch

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
