### PR TITLE
[frontend] Move Relay test package into dev dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,6 @@
         "react-select": "^5.7.5",
         "relay-compiler": "^15.0.0",
         "relay-runtime": "^15.0.0",
-        "relay-test-utils": "^15.0.0",
         "sass": "^1.68.0",
         "semver": "^7.3.8",
         "typescript": "^5.2.2",
@@ -72,6 +71,7 @@
         "jsdom": "^22.1.0",
         "prettier": "^3.0.3",
         "react-select-event": "^5.5.1",
+        "relay-test-utils": "^15.0.0",
         "vitest": "^0.34.5"
       }
     },
@@ -11283,6 +11283,7 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/relay-test-utils/-/relay-test-utils-15.0.0.tgz",
       "integrity": "sha512-0e0hLdH7YbPhsEBNgx2FGvWz/MROHiDhz6TH79QcuylNnVHS/M9rpPQt2EpxfGTu0yUfvW62B3UuFHo6I0QnCA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.2",
@@ -21396,6 +21397,7 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/relay-test-utils/-/relay-test-utils-15.0.0.tgz",
       "integrity": "sha512-0e0hLdH7YbPhsEBNgx2FGvWz/MROHiDhz6TH79QcuylNnVHS/M9rpPQt2EpxfGTu0yUfvW62B3UuFHo6I0QnCA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "react-select": "^5.7.5",
     "relay-compiler": "^15.0.0",
     "relay-runtime": "^15.0.0",
-    "relay-test-utils": "^15.0.0",
     "sass": "^1.68.0",
     "semver": "^7.3.8",
     "typescript": "^5.2.2",
@@ -110,6 +109,7 @@
     "jsdom": "^22.1.0",
     "prettier": "^3.0.3",
     "react-select-event": "^5.5.1",
+    "relay-test-utils": "^15.0.0",
     "vitest": "^0.34.5"
   }
 }

--- a/frontend/tsconfig.build.json
+++ b/frontend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/setupTests.tsx", "**/*.test.tsx"]
+  "exclude": ["src/setupTests.tsx", "src/mocks/*", "**/*.test.tsx"]
 }


### PR DESCRIPTION
Move Relay test package into dev dependencies

- move `relay-test-utils` into dev dependencies
- exclude Relay mocks when building for production