### PR TITLE
[backend] Add Admin REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add Admin API ([#400](https://github.com/edgehog-device-manager/edgehog/pull/400)).
+
 ## [0.7.0] - 2023-10-06
 ### Fixed
 - Don't crash the OTA campaign if a misconfigured device doesn't send its base image version.

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -62,18 +62,23 @@ config :tesla, :adapter, {Tesla.Adapter.Finch, name: EdgehogFinch, receive_timeo
 config :ex_aws,
   json_codec: Jason
 
-config :edgehog, EdgehogWeb.Auth.Token,
-  allowed_algos: [
-    "ES256",
-    "ES384",
-    "ES512",
-    "PS256",
-    "PS384",
-    "PS512",
-    "RS256",
-    "RS384",
-    "RS512"
-  ]
+allowed_algos = [
+  "ES256",
+  "ES384",
+  "ES512",
+  "PS256",
+  "PS384",
+  "PS512",
+  "RS256",
+  "RS384",
+  "RS512"
+]
+
+config :edgehog, EdgehogWeb.Auth.Token, allowed_algos: allowed_algos
+
+config :edgehog, EdgehogWeb.AdminAPI.Auth.Token,
+  allowed_algos: allowed_algos,
+  secret_key: {Edgehog.Config, :admin_jwk!, []}
 
 # Prometheus metrics
 config :edgehog, Edgehog.PromEx,

--- a/backend/lib/edgehog/application.ex
+++ b/backend/lib/edgehog/application.ex
@@ -27,10 +27,13 @@ defmodule Edgehog.Application do
 
   use Application
   require Logger
+  alias Edgehog.Config
 
   @impl true
   def start(_type, _args) do
     Logger.info("Starting application version #{@version}.", tag: "edgehog_start")
+
+    Config.validate_admin_authentication!()
 
     children = [
       # Prometheus metrics

--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -23,8 +23,21 @@ defmodule Edgehog.Config do
   This module handles the configuration of Edgehog
   """
   use Skogsra
-  alias Edgehog.Config.{GeocodingProviders, GeolocationProviders}
+  alias Edgehog.Config.{GeocodingProviders, GeolocationProviders, JWTPublicKeyPEMType}
   alias Edgehog.Geolocation
+
+  @envdoc """
+  Disables admin authentication. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
+  """
+  app_env :disable_admin_authentication, :edgehog, :disable_admin_authentication,
+    os_env: "DISABLE_ADMIN_AUTHENTICATION",
+    type: :boolean,
+    default: false
+
+  @envdoc "The Admin API JWT public key."
+  app_env :admin_jwk, :edgehog, :admin_jwk,
+    os_env: "ADMIN_JWT_PUBLIC_KEY_PATH",
+    type: JWTPublicKeyPEMType
 
   @envdoc """
   Disables tenant authentication. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
@@ -70,6 +83,12 @@ defmodule Edgehog.Config do
     os_env: "PREFERRED_GEOCODING_PROVIDERS",
     type: GeocodingProviders,
     default: [Geolocation.Providers.GoogleGeocoding]
+
+  @doc """
+  Returns true if admin authentication is disabled.
+  """
+  @spec admin_authentication_disabled?() :: boolean()
+  def admin_authentication_disabled?, do: disable_admin_authentication!()
 
   @doc """
   Returns true if tenant authentication is disabled.

--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -120,4 +120,17 @@ defmodule Edgehog.Config do
 
     preferred_geocoding_providers!() |> Enum.reject(&disabled_providers[&1])
   end
+
+  @doc """
+  Validates admin authentication config, raises if invalid.
+  """
+  @spec validate_admin_authentication!() :: :ok | no_return()
+  def validate_admin_authentication! do
+    if admin_authentication_disabled?() do
+      :ok
+    else
+      admin_jwk!()
+      :ok
+    end
+  end
 end

--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ defmodule Edgehog.Config do
   alias Edgehog.Geolocation
 
   @envdoc """
-  Disables the authentication. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
+  Disables tenant authentication. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
   """
-  app_env :disable_authentication, :edgehog, :disable_authentication,
-    os_env: "DISABLE_AUTHENTICATION",
+  app_env :disable_tenant_authentication, :edgehog, :disable_tenant_authentication,
+    os_env: "DISABLE_TENANT_AUTHENTICATION",
     type: :boolean,
     default: false
 
@@ -72,10 +72,10 @@ defmodule Edgehog.Config do
     default: [Geolocation.Providers.GoogleGeocoding]
 
   @doc """
-  Returns true if the authentication is disabled.
+  Returns true if tenant authentication is disabled.
   """
-  @spec authentication_disabled?() :: boolean()
-  def authentication_disabled?, do: disable_authentication!()
+  @spec tenant_authentication_disabled?() :: boolean()
+  def tenant_authentication_disabled?, do: disable_tenant_authentication!()
 
   @doc """
   Returns the list of geolocation modules to use.

--- a/backend/lib/edgehog/config/jwt_public_key_pem_type.ex
+++ b/backend/lib/edgehog/config/jwt_public_key_pem_type.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Config.JWTPublicKeyPEMType do
+  use Skogsra.Type
+
+  alias JOSE.JWK
+
+  @impl Skogsra.Type
+  @spec cast(term()) :: {:ok, JOSE.JWK.t()} | :error | no_return()
+  def cast(value)
+
+  def cast(value) when is_binary(value) do
+    public_key = extract_pem!(value)
+
+    case JWK.from_pem(public_key) do
+      %JWK{} = jwk ->
+        {:ok, jwk}
+
+      _ ->
+        raise "invalid JWT public key."
+    end
+  end
+
+  def cast(_), do: :error
+
+  defp extract_pem!("-----BEGIN PUBLIC KEY-----" <> _rest = pem) do
+    pem
+  end
+
+  defp extract_pem!(path), do: File.read!(path)
+end

--- a/backend/lib/edgehog_web/admin_api/auth.ex
+++ b/backend/lib/edgehog_web/admin_api/auth.ex
@@ -1,0 +1,36 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.Auth do
+  alias Edgehog.Config
+  alias EdgehogWeb.AdminAPI.Auth.Pipeline
+
+  def init(opts) do
+    Pipeline.init(opts)
+  end
+
+  def call(conn, opts) do
+    if Config.admin_authentication_disabled?() do
+      conn
+    else
+      Pipeline.call(conn, opts)
+    end
+  end
+end

--- a/backend/lib/edgehog_web/admin_api/auth/error_handler.ex
+++ b/backend/lib/edgehog_web/admin_api/auth/error_handler.ex
@@ -1,0 +1,47 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.Auth.ErrorHandler do
+  @behaviour Guardian.Plug.ErrorHandler
+
+  import Plug.Conn
+  require Logger
+
+  @impl true
+  # This is called when no JWT token is present
+  def auth_error(conn, {:unauthenticated, reason}, _opts) do
+    _ = Logger.info("Refusing unauthenticated request: #{inspect(reason)}.")
+
+    conn
+    |> put_status(:unauthorized)
+    |> Phoenix.Controller.put_view(EdgehogWeb.ErrorView)
+    |> Phoenix.Controller.render(:"401")
+    |> halt()
+  end
+
+  # In all other cases, we reply with 403
+  def auth_error(conn, _reason, _opts) do
+    conn
+    |> put_status(:forbidden)
+    |> Phoenix.Controller.put_view(EdgehogWeb.ErrorView)
+    |> Phoenix.Controller.render(:"403")
+    |> halt()
+  end
+end

--- a/backend/lib/edgehog_web/admin_api/auth/pipeline.ex
+++ b/backend/lib/edgehog_web/admin_api/auth/pipeline.ex
@@ -1,0 +1,31 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.Auth.Pipeline do
+  use Plug.Builder
+
+  plug Guardian.Plug.Pipeline,
+    otp_app: :edgehog,
+    module: EdgehogWeb.AdminAPI.Auth.Token,
+    error_handler: EdgehogWeb.AdminAPI.Auth.ErrorHandler
+
+  plug Guardian.Plug.VerifyHeader, claims: %{e_ara: "*"}
+  plug Guardian.Plug.EnsureAuthenticated
+end

--- a/backend/lib/edgehog_web/admin_api/auth/token.ex
+++ b/backend/lib/edgehog_web/admin_api/auth/token.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.Auth.Token do
+  use Guardian, otp_app: :edgehog
+
+  # This is used only when signing tokens, and we just want to verify them
+  # However, we want to be able to generate tokens for testing purposes or
+  # allow developers to generate tokens for their local dev enviorments.
+  # For this reason we provide an implementation only for these envs
+  if Mix.env() in [:test, :dev] do
+    def subject_for_token(_resource, _claims) do
+      {:ok, "test"}
+    end
+  else
+    def subject_for_token(_resource, _claims) do
+      {:error, :cannot_sign}
+    end
+  end
+
+  def resource_from_claims(claims) do
+    # TODO: at the moment we only check if the token contains an `e_ara` claim.
+    # e_ara = Edgehog Admin REST API
+    case Map.fetch(claims, "e_ara") do
+      {:ok, claims} ->
+        {:ok, %{claims: claims}}
+
+      :error ->
+        {:error, :no_valid_claims}
+    end
+  end
+end

--- a/backend/lib/edgehog_web/admin_api/controllers/fallback_controller.ex
+++ b/backend/lib/edgehog_web/admin_api/controllers/fallback_controller.ex
@@ -1,0 +1,31 @@
+#
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.FallbackController do
+  use EdgehogWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(EdgehogWeb.AdminAPI.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+end

--- a/backend/lib/edgehog_web/admin_api/controllers/tenants_controller.ex
+++ b/backend/lib/edgehog_web/admin_api/controllers/tenants_controller.ex
@@ -1,0 +1,33 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.TenantsController do
+  use EdgehogWeb, :controller
+
+  alias Edgehog.Provisioning
+
+  action_fallback EdgehogWeb.AdminAPI.FallbackController
+
+  def create(conn, params) do
+    with {:ok, _tenant_config} <- Provisioning.provision_tenant(params) do
+      send_resp(conn, :created, "")
+    end
+  end
+end

--- a/backend/lib/edgehog_web/admin_api/views/changeset_view.ex
+++ b/backend/lib/edgehog_web/admin_api/views/changeset_view.ex
@@ -1,0 +1,32 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.ChangesetView do
+  alias EdgehogWeb.ErrorHelpers
+
+  @doc """
+  Renders changeset errors.
+  """
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: Ecto.Changeset.traverse_errors(changeset, &ErrorHelpers.translate_error/1)}
+  end
+end

--- a/backend/lib/edgehog_web/auth.ex
+++ b/backend/lib/edgehog_web/auth.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ defmodule EdgehogWeb.Auth do
   end
 
   def call(conn, opts) do
-    if Config.authentication_disabled?() do
+    if Config.tenant_authentication_disabled?() do
       # TODO: when we add Authz this path will probably have to
       # put some type of all-access Authz in the GraphQL context
       conn

--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -35,6 +35,7 @@ defmodule EdgehogWeb.Router do
 
   pipeline :admin_api do
     plug :accepts, ["json"]
+    plug EdgehogWeb.AdminAPI.Auth
   end
 
   scope "/admin-api/v1", EdgehogWeb.AdminAPI do

--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,16 @@ defmodule EdgehogWeb.Router do
   pipeline :triggers do
     plug :accepts, ["json"]
     plug EdgehogWeb.PopulateTenant
+  end
+
+  pipeline :admin_api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/admin-api/v1", EdgehogWeb.AdminAPI do
+    pipe_through :admin_api
+
+    post "/tenants", TenantsController, :create
   end
 
   forward "/graphiql", Absinthe.Plug.GraphiQL, schema: EdgehogWeb.Schema

--- a/backend/test/edgehog/config/jwt_public_key_pem_type_test.exs
+++ b/backend/test/edgehog/config/jwt_public_key_pem_type_test.exs
@@ -1,0 +1,74 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Config.JWTPublicKeyPEMTypeTest do
+  use ExUnit.Case, async: true
+
+  alias JOSE.JWK
+  alias Edgehog.Config.JWTPublicKeyPEMType
+
+  @public_key_path "admin_public_key.pem"
+
+  @valid_pem_public_key X509.PrivateKey.new_ec(:secp256r1)
+                        |> X509.PublicKey.derive()
+                        |> X509.PublicKey.to_pem()
+
+  @invalid_public_key "-----BEGIN PUBLIC KEY-----MFkwEwYH_truncated"
+
+  describe "cast/1" do
+    test "returns JWK for valid public key passed by value" do
+      assert {:ok, %JWK{}} = JWTPublicKeyPEMType.cast(@valid_pem_public_key)
+    end
+
+    test "returns JWK for valid public key passed by path" do
+      File.open!(@public_key_path, [:write])
+      File.write!(@public_key_path, @valid_pem_public_key)
+      on_exit(fn -> File.rm!(@public_key_path) end)
+
+      assert {:ok, %JWK{}} = JWTPublicKeyPEMType.cast(@public_key_path)
+    end
+
+    test "returns :error for not binary data" do
+      assert :error == JWTPublicKeyPEMType.cast(nil)
+    end
+
+    test "raise for invalid public key passed by value" do
+      assert_raise RuntimeError, fn ->
+        JWTPublicKeyPEMType.cast(@invalid_public_key)
+      end
+    end
+
+    test "raise if file does not exist" do
+      assert_raise File.Error, fn ->
+        JWTPublicKeyPEMType.cast(@public_key_path)
+      end
+    end
+
+    test "raise for invalid public key passed by path" do
+      File.open!(@public_key_path, [:write])
+      File.write!(@public_key_path, @invalid_public_key)
+      on_exit(fn -> File.rm!(@public_key_path) end)
+
+      assert_raise RuntimeError, fn ->
+        JWTPublicKeyPEMType.cast(@public_key_path)
+      end
+    end
+  end
+end

--- a/backend/test/edgehog_web/admin_api/auth_test.exs
+++ b/backend/test/edgehog_web/admin_api/auth_test.exs
@@ -1,0 +1,166 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.AuthTest do
+  use EdgehogWeb.AdminAPI.ConnCase, async: true
+
+  import Edgehog.AstarteFixtures
+  import Edgehog.TenantsFixtures
+
+  @valid_pem_public_key X509.PrivateKey.new_ec(:secp256r1)
+                        |> X509.PublicKey.derive()
+                        |> X509.PublicKey.to_pem()
+
+  @valid_pem_private_key X509.PrivateKey.new_ec(:secp256r1) |> X509.PrivateKey.to_pem()
+
+  @valid_tenant_config %{
+    name: unique_tenant_name(),
+    slug: unique_tenant_slug(),
+    public_key: @valid_pem_public_key,
+    astarte_config: %{
+      base_api_url: unique_cluster_base_api_url(),
+      realm_name: unique_realm_name(),
+      realm_private_key: @valid_pem_private_key
+    }
+  }
+
+  alias Edgehog.Config
+
+  setup %{conn: conn} do
+    path = Routes.tenants_path(conn, :create)
+
+    [path: path]
+  end
+
+  describe "disabled Admin authentication" do
+    @describetag :unconfigured
+
+    setup do
+      Config.put_disable_admin_authentication(true)
+
+      on_exit(fn ->
+        # Cleanup at the end
+        Config.reload_disable_admin_authentication()
+      end)
+
+      :ok
+    end
+
+    test "returns 201 for request without JWT", %{
+      conn: conn,
+      path: path
+    } do
+      conn = post(conn, path, @valid_tenant_config)
+
+      assert response(conn, :created)
+    end
+
+    test "returns 201 for request with random JWT", %{
+      conn: conn,
+      path: path
+    } do
+      other_private_key = X509.PrivateKey.new_ec(:secp256r1)
+
+      conn =
+        conn
+        |> authenticate_connection(other_private_key)
+        |> post(path, @valid_tenant_config)
+
+      assert response(conn, :created)
+    end
+  end
+
+  describe "unconfigured Admin authentication" do
+    @describetag :unconfigured
+
+    test "returns 401 for request without JWT", %{
+      conn: conn,
+      path: path
+    } do
+      conn = post(conn, path, @valid_tenant_config)
+
+      assert %{"errors" => %{"detail" => "Unauthorized"}} = json_response(conn, 401)
+    end
+
+    test "returns 403 for request with JWT", %{
+      conn: conn,
+      path: path
+    } do
+      other_private_key = X509.PrivateKey.new_ec(:secp256r1)
+
+      conn =
+        conn
+        |> authenticate_connection(other_private_key)
+        |> post(path, @valid_tenant_config)
+
+      assert %{"errors" => %{"detail" => "Forbidden"}} = json_response(conn, 403)
+    end
+  end
+
+  describe "configured Admin authentication" do
+    @describetag :unauthenticated
+
+    test "unauthenticated request returns 401", %{conn: conn, path: path} do
+      conn = post(conn, path)
+
+      assert %{"errors" => %{"detail" => "Unauthorized"}} = json_response(conn, 401)
+    end
+
+    test "request with JWT signed with another private key returns 403", %{
+      conn: conn,
+      path: path
+    } do
+      other_private_key = X509.PrivateKey.new_ec(:secp256r1)
+
+      conn =
+        conn
+        |> authenticate_connection(other_private_key)
+        |> post(path)
+
+      assert %{"errors" => %{"detail" => "Forbidden"}} = json_response(conn, 403)
+    end
+
+    test "request with JWT but without e_ara claim returns 403", %{
+      conn: conn,
+      path: path,
+      admin_private_key: admin_private_key
+    } do
+      conn =
+        conn
+        |> authenticate_connection(admin_private_key, %{other: "*"})
+        |> post(path)
+
+      assert %{"errors" => %{"detail" => "Forbidden"}} = json_response(conn, 403)
+    end
+
+    test "request with JWT with correct signature and claims returns 201", %{
+      conn: conn,
+      path: path,
+      admin_private_key: admin_private_key
+    } do
+      conn =
+        conn
+        |> authenticate_connection(admin_private_key, %{e_ara: "*"})
+        |> post(path, @valid_tenant_config)
+
+      assert response(conn, :created)
+    end
+  end
+end

--- a/backend/test/edgehog_web/admin_api/controllers/tenants_contoller_test.exs
+++ b/backend/test/edgehog_web/admin_api/controllers/tenants_contoller_test.exs
@@ -1,0 +1,120 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.TenantsControllerTest do
+  use EdgehogWeb.AdminAPI.ConnCase, async: true
+
+  import Ecto.Query, only: [where: 2]
+  import Edgehog.AstarteFixtures
+  import Edgehog.TenantsFixtures
+
+  alias Edgehog.Astarte
+  alias Edgehog.Repo
+  alias Edgehog.Tenants
+
+  @valid_pem_public_key X509.PrivateKey.new_ec(:secp256r1)
+                        |> X509.PublicKey.derive()
+                        |> X509.PublicKey.to_pem()
+
+  @valid_pem_private_key X509.PrivateKey.new_ec(:secp256r1) |> X509.PrivateKey.to_pem()
+
+  describe "POST /admin-api/v1/tenants" do
+    setup %{conn: conn} do
+      path = Routes.tenants_path(conn, :create)
+
+      {:ok, path: path}
+    end
+
+    test "creates tenant with valid data", %{conn: conn, path: path} do
+      tenant_name = unique_tenant_name()
+      tenant_slug = unique_tenant_slug()
+      tenant_public_key = @valid_pem_public_key
+      cluster_base_api_url = unique_cluster_base_api_url()
+      realm_name = unique_realm_name()
+      realm_private_key = @valid_pem_private_key
+
+      tenant_config = %{
+        name: tenant_name,
+        slug: tenant_slug,
+        public_key: tenant_public_key,
+        astarte_config: %{
+          base_api_url: cluster_base_api_url,
+          realm_name: realm_name,
+          realm_private_key: @valid_pem_private_key
+        }
+      }
+
+      conn = post(conn, path, tenant_config)
+
+      assert response(conn, :created)
+
+      assert {:ok, tenant} = Tenants.fetch_tenant_by_slug(tenant_slug)
+
+      assert %Tenants.Tenant{
+               name: ^tenant_name,
+               slug: ^tenant_slug,
+               public_key: ^tenant_public_key
+             } = tenant
+
+      Repo.put_tenant_id(tenant.tenant_id)
+
+      assert {:ok, realm} = Astarte.fetch_realm_by_name(realm_name)
+
+      assert %Astarte.Realm{
+               name: ^realm_name,
+               private_key: ^realm_private_key
+             } = realm
+
+      assert Astarte.Cluster
+             |> where(base_api_url: ^cluster_base_api_url)
+             |> Repo.exists?(skip_tenant_id: true)
+    end
+
+    test "render errors for invalid tenant data", %{conn: conn, path: path} do
+      conn = post(conn, path, %{})
+
+      body = json_response(conn, 422)
+
+      required_data = ["name", "slug", "public_key", "astarte_config"]
+
+      for path <- required_data do
+        assert "can't be blank" in body["errors"][path]
+      end
+    end
+
+    test "render errors for invalid astarte_config data", %{conn: conn, path: path} do
+      conn =
+        post(conn, path, %{
+          name: unique_tenant_name(),
+          slug: unique_tenant_slug(),
+          public_key: @valid_pem_public_key,
+          astarte_config: %{}
+        })
+
+      body = json_response(conn, 422)
+
+      required_data = ["base_api_url", "realm_name", "realm_private_key"]
+
+      for path <- required_data do
+        assert "can't be blank" in body["errors"]["astarte_config"][path]
+      end
+    end
+  end
+end

--- a/backend/test/edgehog_web/auth_test.exs
+++ b/backend/test/edgehog_web/auth_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,11 +43,11 @@ defmodule EdgehogWeb.AuthTest do
     conn: conn,
     api_path: api_path
   } do
-    Config.put_disable_authentication(true)
+    Config.put_disable_tenant_authentication(true)
 
     on_exit(fn ->
       # Cleanup at the end
-      Config.reload_disable_authentication()
+      Config.reload_disable_tenant_authentication()
     end)
 
     conn = get(conn, api_path, query: @query)

--- a/backend/test/support/admin_api/conn_case.ex
+++ b/backend/test/support/admin_api/conn_case.ex
@@ -1,0 +1,62 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.AdminAPI.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Such tests rely on `Phoenix.ConnTest` and also
+  import other functionality to make it easier
+  to build common data structures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use EdgehogWeb.ConnCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      import Plug.Conn
+      import Phoenix.ConnTest
+      import EdgehogWeb.AdminAPI.ConnCase
+
+      alias EdgehogWeb.Router.Helpers, as: Routes
+
+      # The default endpoint for testing
+      @endpoint EdgehogWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+
+    conn = Phoenix.ConnTest.build_conn()
+
+    {:ok, conn: conn}
+  end
+end


### PR DESCRIPTION
Add Admin REST API on `/admin-api/`.
Require JWT authentication with validation via public key.
Expose tenant provisioning via POST to `/admin-api/v1/tenants`.

Part of #290.