### PR TITLE
Allow to delete Tenant via Admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - Unreleased
 ### Added
-- Add Admin API ([#400](https://github.com/edgehog-device-manager/edgehog/pull/400)).
+- Add Admin API to [create](https://github.com/edgehog-device-manager/edgehog/pull/400) and
+  to [delete](https://github.com/edgehog-device-manager/edgehog/pull/416) tenants.
 - Add a reconciler that takes care of installing Astarte resources (interfaces and triggers) for a
-  tenant ([#403](https://github.com/edgehog-device-manager/edgehog/pull/403))
+  tenant ([#403](https://github.com/edgehog-device-manager/edgehog/pull/403)).
 - BREAKING: Add mandatory `URL_HOST` env variable. It must point to the host where the Edgehog
   backend is exposed.
 
 ### Fixed
-- Fix seeds not working when used outside docker
-- Fix seeds's default values not working correctly
+- Fix seeds not working when used outside docker.
+- Fix seeds's default values not working correctly.
 
 ## [0.7.0] - 2023-10-06
 ### Fixed
@@ -28,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose OTA Campaigns stats.
 
 ### Fixed
-- Fix DevicesTable component for devices without SystemModel
+- Fix DevicesTable component for devices without SystemModel.
 
 ### Changed
 - Enhance the OTA Campaigns frontend, using the exposed stats.

--- a/backend/lib/edgehog/provisioning.ex
+++ b/backend/lib/edgehog/provisioning.ex
@@ -34,6 +34,14 @@ defmodule Edgehog.Provisioning do
     end
   end
 
+  def delete_tenant_by_slug(tenant_slug) do
+    with {:ok, tenant} <- Tenants.fetch_tenant_by_slug(tenant_slug) do
+      # TODO: clean up Astarte resources
+      # TODO: clean up S3 storage (base and ephemeral images)
+      Tenants.delete_tenant(tenant)
+    end
+  end
+
   defp provision_tenant_from_config(tenant_config) do
     %TenantConfig{astarte_config: astarte_config} = tenant_config
 

--- a/backend/lib/edgehog/provisioning.ex
+++ b/backend/lib/edgehog/provisioning.ex
@@ -35,10 +35,13 @@ defmodule Edgehog.Provisioning do
   end
 
   def delete_tenant_by_slug(tenant_slug) do
-    with {:ok, tenant} <- Tenants.fetch_tenant_by_slug(tenant_slug) do
-      # TODO: clean up Astarte resources
+    with {:ok, tenant} <- Tenants.fetch_tenant_by_slug(tenant_slug),
+         tenant = Tenants.preload_astarte_resources_for_tenant(tenant),
+         {:ok, deleted_tenant} <- Tenants.delete_tenant(tenant) do
       # TODO: clean up S3 storage (base and ephemeral images)
-      Tenants.delete_tenant(tenant)
+      Tenants.cleanup_tenant(tenant)
+
+      {:ok, deleted_tenant}
     end
   end
 

--- a/backend/lib/edgehog/tenants.ex
+++ b/backend/lib/edgehog/tenants.ex
@@ -158,6 +158,10 @@ defmodule Edgehog.Tenants do
     @reconciler_module.reconcile_tenant(tenant)
   end
 
+  def cleanup_tenant(%Tenant{} = tenant) do
+    @reconciler_module.cleanup_tenant(tenant)
+  end
+
   @doc """
   Returns an `%Astarte.Client.RealmManagement{}` for the given tenant.
 

--- a/backend/lib/edgehog/tenants/reconciler.ex
+++ b/backend/lib/edgehog/tenants/reconciler.ex
@@ -38,6 +38,11 @@ defmodule Edgehog.Tenants.Reconciler do
     GenServer.cast(__MODULE__, {:reconcile_tenant, tenant})
   end
 
+  @impl Edgehog.Tenants.Reconciler.Behaviour
+  def cleanup_tenant(%Tenant{} = tenant) do
+    GenServer.cast(__MODULE__, {:cleanup_tenant, tenant})
+  end
+
   @impl GenServer
   def init(opts) do
     tenant_to_trigger_url_fun = Keyword.fetch!(opts, :tenant_to_trigger_url_fun)
@@ -82,6 +87,24 @@ defmodule Edgehog.Tenants.Reconciler do
     tenant
     |> Tenants.preload_astarte_resources_for_tenant()
     |> start_reconciliation_task(tenant_to_trigger_url_fun)
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:cleanup_tenant, tenant}, state) do
+    %{
+      tenant_to_trigger_url_fun: tenant_to_trigger_url_fun
+    } = state
+
+    Task.Supervisor.start_child(TaskSupervisor, fn ->
+      {:ok, rm_client} = Tenants.realm_management_client_from_tenant(tenant)
+
+      trigger_url = tenant_to_trigger_url_fun.(tenant)
+
+      Core.list_required_triggers(trigger_url)
+      |> Enum.each(&Core.cleanup_trigger(rm_client, &1))
+    end)
 
     {:noreply, state}
   end

--- a/backend/lib/edgehog/tenants/reconciler/behaviour.ex
+++ b/backend/lib/edgehog/tenants/reconciler/behaviour.ex
@@ -22,4 +22,6 @@ defmodule Edgehog.Tenants.Reconciler.Behaviour do
   alias Edgehog.Tenants.Tenant
 
   @callback reconcile_tenant(tenant :: Tenant.t()) :: :ok
+
+  @callback cleanup_tenant(tenant :: Tenant.t()) :: :ok
 end

--- a/backend/lib/edgehog/tenants/reconciler/core.ex
+++ b/backend/lib/edgehog/tenants/reconciler/core.ex
@@ -82,6 +82,14 @@ defmodule Edgehog.Tenants.Reconciler.Core do
     end
   end
 
+  def cleanup_trigger(%Client.RealmManagement{} = client, trigger) do
+    %{
+      "name" => trigger_name
+    } = trigger
+
+    Astarte.delete_trigger(client, trigger_name)
+  end
+
   defp update_interface!(rm_client, name, major, interface_json) do
     # TODO: crash with a nicer exception instead of MatchError
     :ok = Astarte.update_interface(rm_client, name, major, interface_json)

--- a/backend/lib/edgehog_web/admin_api/controllers/fallback_controller.ex
+++ b/backend/lib/edgehog_web/admin_api/controllers/fallback_controller.ex
@@ -1,5 +1,4 @@
 #
-#
 # This file is part of Edgehog.
 #
 # Copyright 2023 SECO Mind Srl
@@ -27,5 +26,12 @@ defmodule EdgehogWeb.AdminAPI.FallbackController do
     |> put_status(:unprocessable_entity)
     |> put_view(EdgehogWeb.AdminAPI.ChangesetView)
     |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(EdgehogWeb.ErrorView)
+    |> render(:"404")
   end
 end

--- a/backend/lib/edgehog_web/admin_api/controllers/tenants_controller.ex
+++ b/backend/lib/edgehog_web/admin_api/controllers/tenants_controller.ex
@@ -30,4 +30,10 @@ defmodule EdgehogWeb.AdminAPI.TenantsController do
       send_resp(conn, :created, "")
     end
   end
+
+  def delete_by_slug(conn, %{"tenant_slug" => tenant_slug}) do
+    with {:ok, _tenant} <- Provisioning.delete_tenant_by_slug(tenant_slug) do
+      send_resp(conn, :no_content, "")
+    end
+  end
 end

--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -42,6 +42,7 @@ defmodule EdgehogWeb.Router do
     pipe_through :admin_api
 
     post "/tenants", TenantsController, :create
+    delete "/tenants/:tenant_slug", TenantsController, :delete_by_slug
   end
 
   forward "/graphiql", Absinthe.Plug.GraphiQL, schema: EdgehogWeb.Schema

--- a/backend/test/edgehog/provisioning_test.exs
+++ b/backend/test/edgehog/provisioning_test.exs
@@ -161,6 +161,18 @@ defmodule Edgehog.ProvisioningTest do
     end
   end
 
+  describe "delete_tenant_by_slug/1" do
+    test "returns {:error, :not_found} for unexisting tenant" do
+      assert {:error, :not_found} = Provisioning.delete_tenant_by_slug("not_existing_slug")
+    end
+
+    test "deletes existing tenant", %{tenant: tenant} do
+      assert {:ok, ^tenant} = Tenants.fetch_tenant_by_slug(tenant.slug)
+      assert {:ok, _tenant} = Provisioning.delete_tenant_by_slug(tenant.slug)
+      assert {:error, :not_found} = Tenants.fetch_tenant_by_slug(tenant.slug)
+    end
+  end
+
   defp provision_tenant(opts) do
     {astarte_config, opts} = Keyword.pop(opts, :astarte_config, [])
 

--- a/backend/test/edgehog/provisioning_test.exs
+++ b/backend/test/edgehog/provisioning_test.exs
@@ -171,6 +171,20 @@ defmodule Edgehog.ProvisioningTest do
       assert {:ok, _tenant} = Provisioning.delete_tenant_by_slug(tenant.slug)
       assert {:error, :not_found} = Tenants.fetch_tenant_by_slug(tenant.slug)
     end
+
+    test "triggers tenant clean up", %{tenant: tenant} do
+      cluster = cluster_fixture()
+      _realm = realm_fixture(cluster)
+
+      Edgehog.Tenants.ReconcilerMock
+      |> expect(:cleanup_tenant, fn %Tenants.Tenant{} = cleanup_tenant ->
+        assert cleanup_tenant.tenant_id == tenant.tenant_id
+
+        :ok
+      end)
+
+      assert {:ok, _tenant} = Provisioning.delete_tenant_by_slug(tenant.slug)
+    end
   end
 
   defp provision_tenant(opts) do

--- a/backend/test/edgehog_web/admin_api/controllers/tenants_contoller_test.exs
+++ b/backend/test/edgehog_web/admin_api/controllers/tenants_contoller_test.exs
@@ -118,4 +118,25 @@ defmodule EdgehogWeb.AdminAPI.TenantsControllerTest do
       end
     end
   end
+
+  describe "DELETE /admin-api/v1/tenants/:tenant_slug" do
+    test "deletes tenant with valid slug", %{conn: conn} do
+      tenant = tenant_fixture()
+      path = Routes.tenants_path(conn, :delete_by_slug, tenant.slug)
+
+      conn = delete(conn, path)
+
+      assert response(conn, :no_content)
+
+      assert assert {:error, :not_found} = Tenants.fetch_tenant_by_slug(tenant.slug)
+    end
+
+    test "returns error for invalid tenant slug", %{conn: conn} do
+      path = Routes.tenants_path(conn, :delete_by_slug, "not_existing_slug")
+
+      conn = delete(conn, path)
+
+      assert json_response(conn, 404) == %{"errors" => %{"detail" => "Not Found"}}
+    end
+  end
 end

--- a/backend/test/support/mocks/tenants/reconciler.ex
+++ b/backend/test/support/mocks/tenants/reconciler.ex
@@ -25,4 +25,7 @@ defmodule Edgehog.Mocks.Tenants.Reconciler do
 
   @impl true
   def reconcile_tenant(%Tenant{} = _tenant), do: :ok
+
+  @impl true
+  def cleanup_tenant(%Tenant{} = _tenant), do: :ok
 end


### PR DESCRIPTION
Admin REST API: Add option to delete Tenant via DELETE to `/admin-api/v1/tenants/:tenant_slug`.
Clean up Astarte triggers on Tenant deletion.

Part of #290.
