### PR TITLE
Add relay fragment to Hardware Types

### DIFF
--- a/frontend/src/components/HardwareTypesTable.tsx
+++ b/frontend/src/components/HardwareTypesTable.tsx
@@ -20,18 +20,30 @@
 
 import React from "react";
 import { FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 
 import Table, { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";
+import type {
+  HardwareTypesTable_HardwareTypesFragment$key,
+  HardwareTypesTable_HardwareTypesFragment$data,
+} from "api/__generated__/HardwareTypesTable_HardwareTypesFragment.graphql";
 
-type HardwareTypeProps = {
-  id: string;
-  handle: string;
-  name: string;
-  partNumbers: string[];
-};
+// We use graphql fields below in columns configuration
+/* eslint-disable relay/unused-fields */
+const HARDWARE_TYPES_TABLE_FRAGMENT = graphql`
+  fragment HardwareTypesTable_HardwareTypesFragment on HardwareType
+  @relay(plural: true) {
+    id
+    handle
+    name
+    partNumbers
+  }
+`;
 
-const columnHelper = createColumnHelper<HardwareTypeProps>();
+type TableRecord = HardwareTypesTable_HardwareTypesFragment$data[number];
+
+const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
   columnHelper.accessor("name", {
     header: () => (
@@ -78,13 +90,18 @@ const columns = [
 
 type Props = {
   className?: string;
-  data: HardwareTypeProps[];
+  hardwareTypesRef: HardwareTypesTable_HardwareTypesFragment$key;
 };
 
-const HardwareTypesTable = ({ className, data }: Props) => {
-  return <Table className={className} columns={columns} data={data} />;
+const HardwareTypesTable = ({ className, hardwareTypesRef }: Props) => {
+  const hardwareTypes = useFragment(
+    HARDWARE_TYPES_TABLE_FRAGMENT,
+    hardwareTypesRef,
+  );
+
+  return <Table className={className} columns={columns} data={hardwareTypes} />;
 };
 
-export type { HardwareTypeProps };
+export type { TableRecord };
 
 export default HardwareTypesTable;

--- a/frontend/src/pages/HardwareTypes.tsx
+++ b/frontend/src/pages/HardwareTypes.tsx
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -36,10 +36,7 @@ import { Link, Route } from "Navigation";
 const GET_HARDWARE_TYPES_QUERY = graphql`
   query HardwareTypes_getHardwareTypes_Query {
     hardwareTypes {
-      id
-      handle
-      name
-      partNumbers
+      ...HardwareTypesTable_HardwareTypesFragment
     }
   }
 `;
@@ -51,19 +48,9 @@ interface HardwareTypesContentProps {
 const HardwareTypesContent = ({
   getHardwareTypesQuery,
 }: HardwareTypesContentProps) => {
-  const hardwareTypesData = usePreloadedQuery(
+  const { hardwareTypes } = usePreloadedQuery(
     GET_HARDWARE_TYPES_QUERY,
     getHardwareTypesQuery,
-  );
-
-  // TODO: handle readonly type without mapping to mutable type
-  const hardwareTypes = useMemo(
-    () =>
-      hardwareTypesData.hardwareTypes.map((hardwareType) => ({
-        ...hardwareType,
-        partNumbers: [...hardwareType.partNumbers],
-      })),
-    [hardwareTypesData],
   );
 
   return (
@@ -99,7 +86,7 @@ const HardwareTypesContent = ({
             />
           </Result.EmptyList>
         ) : (
-          <HardwareTypesTable data={hardwareTypes} />
+          <HardwareTypesTable hardwareTypesRef={hardwareTypes} />
         )}
       </Page.Main>
     </Page>


### PR DESCRIPTION
This PR creates GraphQL fragment for data into HardwareTypesTable component
and use it on Hardware Types page where this data is rendered inside a table. 
This also gets rid of relay/unused-fields lint warnings.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
