### PR TITLE
Add relay fragment to System Model

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,7 +68,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "eslint-plugin-relay": "^1.8.3",
-        "eslint-plugin-testing-library": "^6.1.0",
+        "eslint-plugin-testing-library": "^6.2.0",
         "jsdom": "^22.1.0",
         "prettier": "^3.0.3",
         "react-select-event": "^5.5.1",
@@ -6092,9 +6092,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.1.0.tgz",
-      "integrity": "sha512-r7kE+az3tbp8vyRwfyAGZ6V/xw+XvdWFPicIo6jbOPZoossOFDeHizARqPGV6gEkyF8hyCFhhH3mlQOGS3N5Sg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.2.0.tgz",
+      "integrity": "sha512-+LCYJU81WF2yQ+Xu4A135CgK8IszcFcyMF4sWkbiu6Oj+Nel0TrkZq/HvDw0/1WuO3dhDQsZA/OpEMGd0NfcUw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -17739,9 +17739,9 @@
       }
     },
     "eslint-plugin-testing-library": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.1.0.tgz",
-      "integrity": "sha512-r7kE+az3tbp8vyRwfyAGZ6V/xw+XvdWFPicIo6jbOPZoossOFDeHizARqPGV6gEkyF8hyCFhhH3mlQOGS3N5Sg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.2.0.tgz",
+      "integrity": "sha512-+LCYJU81WF2yQ+Xu4A135CgK8IszcFcyMF4sWkbiu6Oj+Nel0TrkZq/HvDw0/1WuO3dhDQsZA/OpEMGd0NfcUw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.58.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "eslint-plugin-relay": "^1.8.3",
-    "eslint-plugin-testing-library": "^6.1.0",
+    "eslint-plugin-testing-library": "^6.2.0",
     "jsdom": "^22.1.0",
     "prettier": "^3.0.3",
     "react-select-event": "^5.5.1",

--- a/frontend/src/components/SystemModelsTable.tsx
+++ b/frontend/src/components/SystemModelsTable.tsx
@@ -20,21 +20,33 @@
 
 import React from "react";
 import { FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 
 import Table, { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";
+import type {
+  SystemModelsTable_SystemModelsFragment$key,
+  SystemModelsTable_SystemModelsFragment$data,
+} from "../api/__generated__/SystemModelsTable_SystemModelsFragment.graphql";
 
-type SystemModelProps = {
-  id: string;
-  handle: string;
-  name: string;
-  hardwareType: {
-    name: string;
-  };
-  partNumbers: string[];
-};
+// We use graphql fields below in columns configuration
+/* eslint-disable relay/unused-fields */
+const SYSTEM_MODELS_TABLE_FRAGMENT = graphql`
+  fragment SystemModelsTable_SystemModelsFragment on SystemModel
+  @relay(plural: true) {
+    id
+    handle
+    name
+    hardwareType {
+      name
+    }
+    partNumbers
+  }
+`;
 
-const columnHelper = createColumnHelper<SystemModelProps>();
+type TableRecord = SystemModelsTable_SystemModelsFragment$data[number];
+
+const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
   columnHelper.accessor("name", {
     header: () => (
@@ -90,13 +102,17 @@ const columns = [
 
 type Props = {
   className?: string;
-  data: SystemModelProps[];
+  systemModelsRef: SystemModelsTable_SystemModelsFragment$key;
 };
 
-const SystemModelsTable = ({ className, data }: Props) => {
-  return <Table className={className} columns={columns} data={data} />;
+const SystemModelsTable = ({ className, systemModelsRef }: Props) => {
+  const systemModels = useFragment(
+    SYSTEM_MODELS_TABLE_FRAGMENT,
+    systemModelsRef,
+  );
+  return <Table className={className} columns={columns} data={systemModels} />;
 };
 
-export type { SystemModelProps };
+export type { TableRecord };
 
 export default SystemModelsTable;

--- a/frontend/src/pages/SystemModels.tsx
+++ b/frontend/src/pages/SystemModels.tsx
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
  */
 
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -36,13 +36,7 @@ import { Link, Route } from "Navigation";
 const GET_SYSTEM_MODELS_QUERY = graphql`
   query SystemModels_getSystemModels_Query {
     systemModels {
-      id
-      handle
-      name
-      hardwareType {
-        name
-      }
-      partNumbers
+      ...SystemModelsTable_SystemModelsFragment
     }
   }
 `;
@@ -54,19 +48,9 @@ type SystemModelsContentProps = {
 const SystemModelsContent = ({
   getSystemModelsQuery,
 }: SystemModelsContentProps) => {
-  const systemModelsData = usePreloadedQuery(
+  const { systemModels } = usePreloadedQuery(
     GET_SYSTEM_MODELS_QUERY,
     getSystemModelsQuery,
-  );
-
-  // TODO: handle readonly type without mapping to mutable type
-  const systemModels = useMemo(
-    () =>
-      systemModelsData.systemModels.map((systemModel) => ({
-        ...systemModel,
-        partNumbers: [...systemModel.partNumbers],
-      })),
-    [systemModelsData],
   );
 
   return (
@@ -102,7 +86,7 @@ const SystemModelsContent = ({
             />
           </Result.EmptyList>
         ) : (
-          <SystemModelsTable data={systemModels} />
+          <SystemModelsTable systemModelsRef={systemModels} />
         )}
       </Page.Main>
     </Page>


### PR DESCRIPTION
This PR creates GraphQL fragment for data into SystemModelsTable component and use it on System Models page where this data is rendered inside a table. 
This also gets rid of relay/unused-fields lint warnings.

Updates the ESLint plugin for Testing Library as a  dependency using _**npm install eslint-plugin-testing-library --save-dev**_

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
