### PR TITLE
Clean up S3 after tenant deletion

### DIFF
--- a/backend/lib/edgehog/application.ex
+++ b/backend/lib/edgehog/application.ex
@@ -53,11 +53,13 @@ defmodule Edgehog.Application do
       {Finch, name: EdgehogFinch},
       # Start the UpdateCampaigns supervisor
       Edgehog.UpdateCampaigns.Supervisor,
-      # Start the Endpoint (http/https)
-      EdgehogWeb.Endpoint,
       # Start the Tenant Reconciler Supervisor
       {Edgehog.Tenants.Reconciler.Supervisor,
-       tenant_to_trigger_url_fun: tenant_to_trigger_url_fun}
+       tenant_to_trigger_url_fun: tenant_to_trigger_url_fun},
+      # Start Supervisor for Provisioning Cleanup Tasks
+      {Task.Supervisor, name: Edgehog.Provisioning.CleanupSupervisor},
+      # Start the Endpoint (http/https)
+      EdgehogWeb.Endpoint
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/backend/lib/edgehog/base_images.ex
+++ b/backend/lib/edgehog/base_images.ex
@@ -289,7 +289,7 @@ defmodule Edgehog.BaseImages do
     |> Multi.delete(:base_image, base_image)
     |> Multi.run(:image_deletion, fn _repo, %{base_image: base_image} ->
       # If version is nil, the changeset will fail below
-      with :ok <- @storage_module.delete(base_image) do
+      with :ok <- cleanup_base_image(base_image) do
         {:ok, nil}
       end
     end)
@@ -302,6 +302,11 @@ defmodule Edgehog.BaseImages do
         {:error, failed_value}
     end
   end
+
+  @doc """
+  Deletes a base_image from the storage.
+  """
+  def cleanup_base_image(%BaseImage{} = base_image), do: @storage_module.delete(base_image)
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking base_image changes.

--- a/backend/lib/edgehog/os_management.ex
+++ b/backend/lib/edgehog/os_management.ex
@@ -231,7 +231,7 @@ defmodule Edgehog.OSManagement do
   end
 
   # We only need to cleanup ephemeral images for manual OTA Operations
-  defp cleanup_ephemeral_image(%OTAOperation{manual?: true} = ota_operation) do
+  def cleanup_ephemeral_image(%OTAOperation{manual?: true} = ota_operation) do
     %OTAOperation{
       id: id,
       tenant_id: tenant_id,
@@ -246,7 +246,7 @@ defmodule Edgehog.OSManagement do
     :ok
   end
 
-  defp cleanup_ephemeral_image(_ota_operation) do
+  def cleanup_ephemeral_image(_ota_operation) do
     :ok
   end
 

--- a/backend/test/edgehog/base_images_test.exs
+++ b/backend/test/edgehog/base_images_test.exs
@@ -266,6 +266,12 @@ defmodule Edgehog.BaseImagesTest do
       assert BaseImages.fetch_base_image(base_image.id) == {:ok, base_image}
     end
 
+    test "cleanup_base_image/1 deletes the base image from the storage" do
+      base_image = base_image_fixture()
+      expect(StorageMock, :delete, &Mocks.BaseImages.Storage.delete/1)
+      assert :ok == BaseImages.cleanup_base_image(base_image)
+    end
+
     test "change_base_image/1 returns a base_image changeset" do
       base_image = base_image_fixture()
       assert %Ecto.Changeset{} = BaseImages.change_base_image(base_image)

--- a/backend/test/edgehog/os_management_test.exs
+++ b/backend/test/edgehog/os_management_test.exs
@@ -395,6 +395,28 @@ defmodule Edgehog.OSManagementTest do
       assert {:ok, %OTAOperation{}} = OSManagement.delete_ota_operation(ota_operation)
     end
 
+    test "cleanup_ephemeral_image/1 removes the ephemeral image for a manual ota_operation", %{
+      device: device
+    } do
+      ota_operation = manual_ota_operation_fixture(device)
+
+      Edgehog.OSManagement.EphemeralImageMock
+      |> expect(:delete, fn _tenant_id, _ota_operation_id, _url -> :ok end)
+
+      assert :ok == OSManagement.cleanup_ephemeral_image(ota_operation)
+    end
+
+    test "cleanup_ephemeral_image/1 doesn't remove the image for a managed ota_operation", %{
+      device: device
+    } do
+      ota_operation = managed_ota_operation_fixture(device)
+
+      Edgehog.OSManagement.EphemeralImageMock
+      |> expect(:delete, 0, fn _tenant_id, _ota_operation_id, _url -> :ok end)
+
+      assert :ok == OSManagement.cleanup_ephemeral_image(ota_operation)
+    end
+
     test "change_ota_operation/1 returns a ota_operation changeset", %{device: device} do
       ota_operation = manual_ota_operation_fixture(device)
       assert %Ecto.Changeset{} = OSManagement.change_ota_operation(ota_operation)


### PR DESCRIPTION
Clean up S3 storage files asynchronously after successfully deleting a tenant.