### PR TITLE
tenant: add tests for default locale

### DIFF
--- a/backend/test/edgehog_web/admin_api/auth_test.exs
+++ b/backend/test/edgehog_web/admin_api/auth_test.exs
@@ -19,7 +19,8 @@
 #
 
 defmodule EdgehogWeb.AdminAPI.AuthTest do
-  use EdgehogWeb.AdminAPI.ConnCase, async: true
+  # This can't be async: true since it modifies the Application env
+  use EdgehogWeb.AdminAPI.ConnCase, async: false
   use Edgehog.ReconcilerMockCase
 
   @moduletag :ported_to_ash


### PR DESCRIPTION
Add tests to ensure that:
- the default tenant locale can be set on creation/provision.
- tenant provisioning via JsonApi allows to set custom default locale.