### PR TITLE
Add REMOTE_TERMINAL device capability and corresponding interfaces

### DIFF
--- a/backend/lib/edgehog/capabilities.ex
+++ b/backend/lib/edgehog/capabilities.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022-2023 SECO Mind Srl
+# Copyright 2022-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,6 +90,18 @@ defmodule Edgehog.Capabilities do
     operating_system: [
       %Astarte.InterfaceID{
         name: "io.edgehog.devicemanager.OSInfo",
+        major: 0,
+        minor: 1
+      }
+    ],
+    remote_terminal: [
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.ForwarderSessionRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.ForwarderSessionState",
         major: 0,
         minor: 1
       }

--- a/backend/lib/edgehog_web/schema/capabilities_types.ex
+++ b/backend/lib/edgehog_web/schema/capabilities_types.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ defmodule EdgehogWeb.Schema.CapabilitiesTypes do
     @desc "The device supports commands, for example the rebooting command."
     value :commands
     @desc "The device can be geolocated."
+    value :remote_terminal
+    @desc "The device supports remote terminal sessions."
     value :geolocation
     @desc "The device provides information about its hardware."
     value :hardware_info

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionRequest.json
@@ -1,0 +1,39 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ForwarderSessionRequest",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "server",
+  "aggregation": "object",
+  "description": "Configuration to open a session with the Edgehog Forwarder from a device to a certain host.",
+  "mappings": [
+    {
+      "endpoint": "/request/session_token",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The session token thanks to which the device can authenticates itself through Edgehog."
+    },
+    {
+      "endpoint": "/request/port",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The host port the device must connect to."
+    },
+    {
+      "endpoint": "/request/host",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The IP address or host name the device must connect to."
+    },
+    {
+      "endpoint": "/request/secure",
+      "type": "boolean",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "Indicates whether the connection should use TLS, i.e. 'ws' or 'wss' scheme."
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionState.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionState.json
@@ -1,0 +1,17 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ForwarderSessionState",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "description": "Information provided by the device about the status of a forwarder session.",
+  "mappings": [
+    {
+      "endpoint": "/%{session_token}/status",
+      "type": "string",
+      "allow_unset": true,
+      "description": "Indicates if the device is connecting, or connected to a forwarder session.",
+      "doc": "An enum with the following possible values: Connecting | Connected."
+    }
+  ]
+}

--- a/backend/test/edgehog/capabilities_test.exs
+++ b/backend/test/edgehog/capabilities_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ defmodule Edgehog.CapabilitiesTest do
           minor: 1
         },
         "io.edgehog.devicemanager.Commands" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.ForwarderSessionState" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.HardwareInfo" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.LedBehavior" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.NetworkInterfaceProperties" => %InterfaceVersion{
@@ -45,6 +46,10 @@ defmodule Edgehog.CapabilitiesTest do
           minor: 1
         },
         "io.edgehog.devicemanager.OSInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.ForwarderSessionRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
         "io.edgehog.devicemanager.RuntimeInfo" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.OTAResponse" => %InterfaceVersion{major: 0, minor: 1},
@@ -65,6 +70,7 @@ defmodule Edgehog.CapabilitiesTest do
         :led_behaviors,
         :network_interface_info,
         :operating_system,
+        :remote_terminal,
         :runtime_info,
         :software_updates,
         :storage,

--- a/backend/test/support/mocks/astarte/device/device_status.ex
+++ b/backend/test/support/mocks/astarte/device/device_status.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ defmodule Edgehog.Mocks.Astarte.Device.DeviceStatus do
     {"io.edgehog.devicemanager.BatteryStatus", 0, 1},
     {"io.edgehog.devicemanager.OTARequest", 1, 0},
     {"io.edgehog.devicemanager.OSInfo", 0, 1},
-    {"io.edgehog.devicemanager.NetworkInterfaceProperties", 0, 1}
+    {"io.edgehog.devicemanager.NetworkInterfaceProperties", 0, 1},
+    {"io.edgehog.devicemanager.ForwarderSessionState", 0, 1},
+    {"io.edgehog.devicemanager.ForwarderSessionRequest", 0, 1}
   ]
 
   @impl true


### PR DESCRIPTION
This change defines a REMOTE_TERMINAL capability for devices.

The devices have this capability if they support all interfaces relative to Forwarder Sessions: establishing those sessions is a prerequisite to expose remote terminal sessions.
This is a good approximation for the moment; in the future a system could be evaluated where devices advertise support for specific services, besides exposing them through forwarder sessions.

The required interfaces are added to the list of interfaces that are reconciled by the Tenant reconciler, to ensure that all tenants correctly have those interfaces installed.

Closes #444
