### PR TITLE
Add GraphQL APIs to request forwarder sessions

### DIFF
--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,6 +87,13 @@ config :edgehog, Edgehog.PromEx,
   drop_metrics_groups: [],
   grafana: :disabled,
   metrics_server: :disabled
+
+config :edgehog, :edgehog_forwarder, %{
+  hostname: "localhost",
+  port: 4001,
+  secure_sessions?: false,
+  enabled?: true
+}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -65,6 +65,7 @@ config :edgehog, :astarte_runtime_info_module, Edgehog.Astarte.Device.RuntimeInf
 config :edgehog, :astarte_led_behavior_module, Edgehog.Astarte.Device.LedBehaviorMock
 config :edgehog, :astarte_geolocation_module, Edgehog.Astarte.Device.GeolocationMock
 config :edgehog, :astarte_network_interface_module, Edgehog.Astarte.Device.NetworkInterfaceMock
+config :edgehog, :astarte_forwarder_session_module, Edgehog.Astarte.Device.ForwarderSessionMock
 
 config :edgehog,
        :astarte_cellular_connection_module,

--- a/backend/lib/edgehog/astarte/device/forwarder_session.ex
+++ b/backend/lib/edgehog/astarte/device/forwarder_session.ex
@@ -1,0 +1,123 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSession do
+  @type t :: %__MODULE__{
+          token: String.t(),
+          status: :connecting | :connected,
+          secure: boolean(),
+          forwarder_hostname: String.t(),
+          forwarder_port: integer()
+        }
+
+  @enforce_keys [:token, :status, :secure, :forwarder_hostname, :forwarder_port]
+  defstruct @enforce_keys
+
+  @behaviour Edgehog.Astarte.Device.ForwarderSession.Behaviour
+
+  alias Astarte.Client.AppEngine
+
+  @session_request_interface "io.edgehog.devicemanager.ForwarderSessionRequest"
+  @sessions_state_interface "io.edgehog.devicemanager.ForwarderSessionState"
+
+  @impl true
+  def list_sessions(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_properties_data(client, device_id, @sessions_state_interface) do
+      sessions = parse_session_list(data)
+
+      {:ok, sessions}
+    end
+  end
+
+  @impl true
+  def fetch_session(%AppEngine{} = client, device_id, session_token)
+      when is_binary(session_token) do
+    with {:ok, sessions} <- list_sessions(client, device_id) do
+      case Enum.find(sessions, &(&1.token == session_token)) do
+        nil -> {:error, :forwarder_session_not_found}
+        session -> {:ok, session}
+      end
+    end
+  end
+
+  @impl true
+  def request_session(
+        %AppEngine{} = client,
+        device_id,
+        session_token,
+        forwarder_hostname,
+        forwarder_port,
+        forwarder_secure_sessions?
+      )
+      when is_binary(session_token) and is_binary(forwarder_hostname) and
+             is_integer(forwarder_port) and is_boolean(forwarder_secure_sessions?) do
+    data = %{
+      session_token: session_token,
+      host: forwarder_hostname,
+      port: forwarder_port,
+      secure: forwarder_secure_sessions?
+    }
+
+    AppEngine.Devices.send_datastream(
+      client,
+      device_id,
+      @session_request_interface,
+      "/request",
+      data
+    )
+  end
+
+  defp parse_session_list(session_states) do
+    Enum.map(session_states, fn {session_token, session_state} ->
+      parse_session(session_token, session_state)
+    end)
+  end
+
+  defp parse_session(session_token, session_state) do
+    %__MODULE__{
+      token: session_token,
+      status: parse_session_status(session_state["status"]),
+      # TODO: forwarder info should be specified in the session_state.
+      # See issue: https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/68
+      secure: forwarder_secure_sessions?(),
+      forwarder_hostname: forwarder_hostname(),
+      forwarder_port: forwarder_port()
+    }
+  end
+
+  defp parse_session_status("Connected"), do: :connected
+  defp parse_session_status("Connecting"), do: :connecting
+
+  defp forwarder_hostname do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.hostname
+  end
+
+  defp forwarder_port do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.port
+  end
+
+  defp forwarder_secure_sessions? do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.secure_sessions?
+  end
+end

--- a/backend/lib/edgehog/astarte/device/forwarder_session/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/forwarder_session/behaviour.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSession.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  @callback list_sessions(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(ForwarderSession.t())} | {:error, term()}
+
+  @callback fetch_session(
+              client :: AppEngine.t(),
+              device_id :: String.t(),
+              session_token :: String.t()
+            ) ::
+              {:ok, ForwarderSession.t()} | {:error, term()}
+
+  @callback request_session(
+              client :: AppEngine.t(),
+              device_id :: String.t(),
+              session_token :: String.t(),
+              forwarder_hostname :: String.t(),
+              forwarder_port :: integer(),
+              secure_sessions? :: boolean()
+            ) ::
+              :ok | {:error, term()}
+end

--- a/backend/lib/edgehog/error.ex
+++ b/backend/lib/edgehog/error.ex
@@ -140,6 +140,8 @@ defmodule Edgehog.Error do
     {422, "The default tenant locale must be used when creating or updating this resource"}
   end
 
+  defp metadata(:device_disconnected), do: {409, "The device is not connected"}
+
   defp metadata(:unknown), do: {500, "Something went wrong"}
 
   defp metadata(code) do

--- a/backend/lib/edgehog/forwarder.ex
+++ b/backend/lib/edgehog/forwarder.ex
@@ -1,0 +1,127 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Forwarder do
+  @moduledoc """
+  The Forwarder context.
+  """
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+  alias Edgehog.Devices
+  alias Edgehog.Devices.Device
+
+  @forwarder_session_module Application.compile_env(
+                              :edgehog,
+                              :astarte_forwarder_session_module,
+                              ForwarderSession
+                            )
+
+  defp forwarder_hostname do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.hostname
+  end
+
+  defp forwarder_port do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.port
+  end
+
+  defp forwarder_secure_sessions? do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.secure_sessions?
+  end
+
+  defp forwarder_enabled? do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.enabled?
+  end
+
+  defp validate_forwarder_enabled do
+    if forwarder_enabled?() do
+      :ok
+    else
+      {:error, :edgehog_forwarder_disabled}
+    end
+  end
+
+  defp validate_device_connected(%Device{online: true}), do: :ok
+  defp validate_device_connected(%Device{online: false}), do: {:error, :device_disconnected}
+
+  defp list_forwarder_sessions(%Device{} = device) do
+    with :ok <- validate_forwarder_enabled(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.list_sessions(appengine_client, device.device_id)
+    end
+  end
+
+  def fetch_forwarder_session(%Device{} = device, session_token) do
+    with :ok <- validate_forwarder_enabled(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.fetch_session(appengine_client, device.device_id, session_token)
+    end
+  end
+
+  defp request_forwarder_session(%Device{} = device, session_token) do
+    with :ok <- validate_forwarder_enabled(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.request_session(
+        appengine_client,
+        device.device_id,
+        session_token,
+        forwarder_hostname(),
+        forwarder_port(),
+        forwarder_secure_sessions?()
+      )
+    end
+  end
+
+  defp fetch_available_forwarder_session(%Device{} = device) do
+    with {:ok, forwarder_sessions} <- list_forwarder_sessions(device) do
+      connected_session = Enum.find(forwarder_sessions, &(&1.status == :connected))
+      connecting_session = Enum.find(forwarder_sessions, &(&1.status == :connecting))
+
+      cond do
+        connected_session != nil -> {:ok, connected_session}
+        connecting_session != nil -> {:ok, connecting_session}
+        true -> {:error, :forwarder_session_not_found}
+      end
+    end
+  end
+
+  def fetch_or_request_available_forwarder_session_token(%Device{} = device) do
+    case fetch_available_forwarder_session(device) do
+      {:ok, session} ->
+        {:ok, session.token}
+
+      {:error, :forwarder_session_not_found} ->
+        session_token = Ecto.UUID.generate()
+
+        with :ok <- request_forwarder_session(device, session_token) do
+          {:ok, session_token}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
+++ b/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Resolvers.ForwarderSessions do
+  alias Edgehog.Devices
+  alias Edgehog.Forwarder
+
+  @doc """
+  Fetches a forwarder session by its token and the device ID
+  """
+  def find_forwarder_session(%{device_id: device_id, session_token: session_token}, _resolution) do
+    device =
+      device_id
+      |> Devices.get_device!()
+      |> Devices.preload_astarte_resources_for_device()
+
+    with {:error, :forwarder_session_not_found} <-
+           Forwarder.fetch_forwarder_session(device, session_token) do
+      {:ok, nil}
+    end
+  end
+end

--- a/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
+++ b/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
@@ -36,4 +36,19 @@ defmodule EdgehogWeb.Resolvers.ForwarderSessions do
       {:ok, nil}
     end
   end
+
+  @doc """
+  Requests a forwarder session for the specified device ID.
+  """
+  def request_forwarder_session(%{device_id: device_id}, _resolution) do
+    device =
+      device_id
+      |> Devices.get_device!()
+      |> Devices.preload_astarte_resources_for_device()
+
+    with {:ok, session_token} <-
+           Forwarder.fetch_or_request_available_forwarder_session_token(device) do
+      {:ok, %{session_token: session_token}}
+    end
+  end
 end

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -128,6 +128,7 @@ defmodule EdgehogWeb.Schema do
     import_fields :astarte_mutations
     import_fields :base_images_mutations
     import_fields :devices_mutations
+    import_fields :forwarder_sessions_mutations
     import_fields :groups_mutations
     import_fields :os_management_mutations
     import_fields :update_campaigns_mutations

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -25,6 +25,7 @@ defmodule EdgehogWeb.Schema do
   import_types EdgehogWeb.Schema.BaseImagesTypes
   import_types EdgehogWeb.Schema.CapabilitiesTypes
   import_types EdgehogWeb.Schema.DevicesTypes
+  import_types EdgehogWeb.Schema.ForwarderSessionsTypes
   import_types EdgehogWeb.Schema.GeolocationTypes
   import_types EdgehogWeb.Schema.GroupsTypes
   import_types EdgehogWeb.Schema.LabelingTypes
@@ -116,6 +117,7 @@ defmodule EdgehogWeb.Schema do
 
     import_fields :base_images_queries
     import_fields :devices_queries
+    import_fields :forwarder_sessions_queries
     import_fields :groups_queries
     import_fields :labeling_queries
     import_fields :tenants_queries

--- a/backend/lib/edgehog_web/schema/forwarder_types.ex
+++ b/backend/lib/edgehog_web/schema/forwarder_types.ex
@@ -1,0 +1,65 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.ForwarderSessionsTypes do
+  use Absinthe.Schema.Notation
+  use Absinthe.Relay.Schema.Notation, :modern
+
+  alias EdgehogWeb.Resolvers
+
+  @desc """
+  The status of a forwarder session
+  """
+  enum :forwarder_session_status do
+    @desc "The device is connected to the forwarder."
+    value :connected
+    @desc "The device is connecting to the forwarder."
+    value :connecting
+  end
+
+  @desc """
+  The details of a forwarder session
+  """
+  object :forwarder_session do
+    @desc "The token that identifies the session."
+    field :token, non_null(:string)
+    @desc "The status of the session."
+    field :status, non_null(:forwarder_session_status)
+    @desc "Indicates if TLS is used when the device connects to the forwarder."
+    field :secure, non_null(:boolean)
+    @desc "The hostname of the forwarder instance."
+    field :forwarder_hostname, non_null(:string)
+    @desc "The port of the forwarder instance."
+    field :forwarder_port, non_null(:integer)
+  end
+
+  object :forwarder_sessions_queries do
+    @desc "Fetches a forwarder session by its token and the device ID."
+    field :forwarder_session, :forwarder_session do
+      @desc "The GraphQL ID of the device corresponding to the session."
+      arg :device_id, non_null(:id)
+      @desc "The token that identifies the session."
+      arg :session_token, non_null(:string)
+
+      middleware Absinthe.Relay.Node.ParseIDs, device_id: :device
+      resolve &Resolvers.ForwarderSessions.find_forwarder_session/2
+    end
+  end
+end

--- a/backend/lib/edgehog_web/schema/forwarder_types.ex
+++ b/backend/lib/edgehog_web/schema/forwarder_types.ex
@@ -62,4 +62,22 @@ defmodule EdgehogWeb.Schema.ForwarderSessionsTypes do
       resolve &Resolvers.ForwarderSessions.find_forwarder_session/2
     end
   end
+
+  object :forwarder_sessions_mutations do
+    @desc "Requests a forwarder session for the specified device."
+    payload field :request_forwarder_session do
+      input do
+        @desc "The GraphQL ID of the device for the requested session."
+        field :device_id, non_null(:id)
+      end
+
+      output do
+        @desc "The token of the requested forwarder session."
+        field :session_token, non_null(:string)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, device_id: :device
+      resolve &Resolvers.ForwarderSessions.request_forwarder_session/2
+    end
+  end
 end

--- a/backend/test/edgehog/astarte/device/forwarder_session_test.exs
+++ b/backend/test/edgehog/astarte/device/forwarder_session_test.exs
@@ -1,0 +1,140 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSessionTest do
+  use Edgehog.DataCase, async: true
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  describe "forwarder_session" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = astarte_device_fixture(realm)
+
+      {:ok, appengine_client} =
+        AppEngine.new(cluster.base_api_url, realm.name, private_key: realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "list_sessions/2 correctly parses session states data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "session_token_1" => %{
+            "status" => "Connecting"
+          },
+          "session_token_2" => %{
+            "status" => "Connected"
+          }
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, sessions} =
+               ForwarderSession.list_sessions(appengine_client, device.device_id)
+
+      assert sessions == [
+               %ForwarderSession{
+                 token: "session_token_1",
+                 status: :connecting,
+                 secure: false,
+                 forwarder_hostname: "localhost",
+                 forwarder_port: 4001
+               },
+               %ForwarderSession{
+                 token: "session_token_2",
+                 status: :connected,
+                 secure: false,
+                 forwarder_hostname: "localhost",
+                 forwarder_port: 4001
+               }
+             ]
+    end
+
+    test "fetch_session/3 correctly parses session state data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "session_token_1" => %{
+            "status" => "Connecting"
+          },
+          "session_token_2" => %{
+            "status" => "Connected"
+          }
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, session} =
+               ForwarderSession.fetch_session(
+                 appengine_client,
+                 device.device_id,
+                 "session_token_1"
+               )
+
+      assert session == %ForwarderSession{
+               token: "session_token_1",
+               status: :connecting,
+               secure: false,
+               forwarder_hostname: "localhost",
+               forwarder_port: 4001
+             }
+    end
+
+    test "fetch_session/3 returns an error if the session was not found", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{}
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:error, :forwarder_session_not_found} =
+               ForwarderSession.fetch_session(
+                 appengine_client,
+                 device.device_id,
+                 "session_token"
+               )
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/mutation/request_forwarder_session_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/request_forwarder_session_test.exs
@@ -1,0 +1,199 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.RequestForwarderSessionTest do
+  use EdgehogWeb.ConnCase, async: true
+  use Edgehog.AstarteMockCase
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  import Edgehog.AstarteFixtures
+  import Edgehog.DevicesFixtures
+
+  describe "requestForwarderSession mutation" do
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+
+      {:ok, realm: realm}
+    end
+
+    @query """
+    mutation ($input: RequestForwarderSessionInput!) {
+      requestForwarderSession(input: $input) {
+        sessionToken
+      }
+    }
+    """
+
+    test "returns the token of a :connected session instead of a :connecting one", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_sessions(device, [
+        %ForwarderSession{
+          token: "connecting_session_token",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        },
+        %ForwarderSession{
+          token: "connected_session_token",
+          status: :connected,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        }
+      ])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => "connected_session_token"
+                 }
+               }
+             } = result
+    end
+
+    test "returns the token of a :connecting session, if there are no :connected sessions", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_sessions(device, [
+        %ForwarderSession{
+          token: "connecting_session_token_1",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        },
+        %ForwarderSession{
+          token: "connecting_session_token_2",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        }
+      ])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => "connecting_session_token_1"
+                 }
+               }
+             } = result
+    end
+
+    test "returns the token of a new session, if there is no available session", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+      mock_forwarder_sessions(device, [])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => session_token
+                 }
+               }
+             } = result
+
+      assert {:ok, ^session_token} = Ecto.UUID.cast(session_token)
+    end
+
+    test "returns error if the device is disconnected", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: false})
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => nil
+               },
+               "errors" => [
+                 %{
+                   "code" => "device_disconnected",
+                   "message" => "The device is not connected",
+                   "status_code" => 409
+                 }
+               ]
+             } = result
+    end
+  end
+
+  defp mock_forwarder_sessions(device, forwarder_sessions) do
+    device_id = device.device_id
+
+    Edgehog.Astarte.Device.ForwarderSessionMock
+    |> expect(:list_sessions, fn _appengine_client, ^device_id ->
+      {:ok, forwarder_sessions}
+    end)
+  end
+
+  defp run_query(conn, api_path, variables) do
+    conn
+    |> post(api_path, query: @query, variables: variables)
+    |> json_response(200)
+  end
+end

--- a/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
@@ -1,0 +1,147 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.ForwarderSessionTest do
+  use EdgehogWeb.ConnCase, async: true
+  use Edgehog.AstarteMockCase
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  import Edgehog.AstarteFixtures
+  import Edgehog.DevicesFixtures
+
+  describe "forwarderSession query" do
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+
+      {:ok, realm: realm}
+    end
+
+    @query """
+    query ($device_id: ID!, $session_token: String!) {
+      forwarderSession(deviceId: $device_id, sessionToken: $session_token) {
+        token
+        status
+        forwarderHostname
+        forwarderPort
+      }
+    }
+    """
+
+    test "returns the forwarder session", %{conn: conn, api_path: api_path, realm: realm} do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_session(device, "session_token", %ForwarderSession{
+        token: "session_token",
+        status: :connected,
+        secure: false,
+        forwarder_hostname: "localhost",
+        forwarder_port: 4001
+      })
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "forwarderSession" => %{
+                   "token" => "session_token",
+                   "status" => "CONNECTED",
+                   "forwarderHostname" => "localhost",
+                   "forwarderPort" => 4001
+                 }
+               }
+             } = result
+    end
+
+    test "returns null if the session does not exist", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_session(device, "session_token", nil)
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "forwarderSession" => nil
+               }
+             } = result
+    end
+
+    test "returns error if the device is disconnected", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: false})
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{"forwarderSession" => nil},
+               "errors" => [
+                 %{
+                   "code" => "device_disconnected",
+                   "message" => "The device is not connected",
+                   "status_code" => 409
+                 }
+               ]
+             } = result
+    end
+  end
+
+  defp mock_forwarder_session(device, session_token, forwarder_session) do
+    device_id = device.device_id
+
+    Edgehog.Astarte.Device.ForwarderSessionMock
+    |> expect(:fetch_session, fn _appengine_client, ^device_id, ^session_token ->
+      if forwarder_session != nil do
+        {:ok, forwarder_session}
+      else
+        {:error, :forwarder_session_not_found}
+      end
+    end)
+  end
+
+  defp run_query(conn, api_path, variables) do
+    conn
+    |> get(api_path, query: @query, variables: variables)
+    |> json_response(200)
+  end
+end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -128,6 +128,11 @@ defmodule Edgehog.AstarteMockCase do
       Edgehog.Mocks.Astarte.Realm.Triggers
     )
 
+    Mox.stub_with(
+      Edgehog.Astarte.Device.ForwarderSessionMock,
+      Edgehog.Mocks.Astarte.Device.ForwarderSession
+    )
+
     :ok
   end
 end

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -74,6 +74,10 @@ Mox.defmock(Edgehog.Astarte.Device.LedBehaviorMock,
   for: Edgehog.Astarte.Device.LedBehavior.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.ForwarderSessionMock,
+  for: Edgehog.Astarte.Device.ForwarderSession.Behaviour
+)
+
 Mox.defmock(Edgehog.Astarte.Realm.InterfacesMock,
   for: Edgehog.Astarte.Realm.Interfaces.Behaviour
 )

--- a/backend/test/support/mocks/astarte/device/forwarder_session.ex
+++ b/backend/test/support/mocks/astarte/device/forwarder_session.ex
@@ -1,0 +1,77 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.ForwarderSession do
+  @behaviour Edgehog.Astarte.Device.ForwarderSession.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  @forwarder_hostname "localhost"
+  @forwarder_port 4001
+  @secure_sessions? false
+
+  @impl true
+  def list_sessions(%AppEngine{} = _client, _device_id) do
+    sessions = [
+      %ForwarderSession{
+        token: "session_token_1",
+        status: :connecting,
+        secure: @secure_sessions?,
+        forwarder_hostname: @forwarder_hostname,
+        forwarder_port: @forwarder_port
+      },
+      %ForwarderSession{
+        token: "session_token_2",
+        status: :connected,
+        secure: @secure_sessions?,
+        forwarder_hostname: @forwarder_hostname,
+        forwarder_port: @forwarder_port
+      }
+    ]
+
+    {:ok, sessions}
+  end
+
+  @impl true
+  def fetch_session(%AppEngine{} = _client, _device_id, session_token) do
+    session = %ForwarderSession{
+      token: session_token,
+      status: :connected,
+      secure: @secure_sessions?,
+      forwarder_hostname: @forwarder_hostname,
+      forwarder_port: @forwarder_port
+    }
+
+    {:ok, session}
+  end
+
+  @impl true
+  def request_session(
+        %AppEngine{} = _client,
+        _device_id,
+        _session_token,
+        _forwarder_hostname,
+        _forwarder_port,
+        _forwarder_secure_sessions?
+      ) do
+    :ok
+  end
+end

--- a/doc/pages/admin/deploying_with_kubernetes.md
+++ b/doc/pages/admin/deploying_with_kubernetes.md
@@ -341,6 +341,12 @@ spec:
           value: <S3-ASSET-HOST>
         - name: S3_REGION
           value: <S3-REGION>
+        - name: EDGEHOG_FORWARDER_HOSTNAME
+          value: <EDGEHOG-FORWARDER-HOSTNAME>
+        - name: EDGEHOG_FORWARDER_PORT
+          value: <EDGEHOG-FORWARDER-PORT>
+        - name: EDGEHOG_FORWARDER_SECURE_SESSIONS
+          value: <EDGEHOG-FORWARDER-SECURE-SESSIONS>
         image: edgehogdevicemanager/edgehog-backend:snapshot
         imagePullPolicy: Always
         name: edgehog-backend
@@ -364,6 +370,9 @@ Values to be replaced
 - `S3-ASSET-HOST`: the asset host for the S3 storage, e.g. `storage.googleapis.com/<S3-BUCKET>` for
   GCP or `<S3-BUCKET>.s3.amazonaws.com` for AWS.
 - `S3-REGION`: the region where the S3 storage resides.
+- `EDGEHOG-FORWARDER-HOSTNAME`: the host for the instance of [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It should only contain the hostname without the `http://` or `https://` scheme.
+- `EDGEHOG-FORWARDER-PORT`: the port for the instance of [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It defaults to `443`.
+- `EDGEHOG-FORWARDER-SECURE-SESSIONS`: either `true` or `false`, indicates whether devices use TLS to connect to the [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It defaults to `true`.
 
 The optional env variable in the `yaml` also have to be uncommented where relevant (see comments
 above the commented blocks for more information).


### PR DESCRIPTION
The PR implements:
- A `forwarderSession` GraphQL query that can be used by clients to inspect the status of a device → Forwarder session, and know whether the session is ready to be accessed and it is closed.
- A `requestForwarderSession` mutation to allow clients to request a device → Forwarder session for a specific deviceId.

To support the request of a forwarder session, the backend does the following:
- It checks whether the device is online. If not, an error is returned.
- It queries the existing forwarder sessions for the device.
  - If there is a session that is either connected or re-connecting then the backend returns the session token of that session. An already connected session takes precedence.
  - If there is no available session, it generates a new session token and sends a request to the device asking to establish that session. It then returns the session token of that session.

With this approach, any existing forwarder sessions is reused whenever possible, and devices are not forced to establish a high number of simultaneous connections.

The backend assumes that there is a single instance of the [cloud Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder), and it expects to be configured with the host, port and protocol relative to forwarder's instance. The configuration is supplied through environment variables.

Closes #445, #446