### PR TITLE
Disable REMOTE_TERMINAL capability for devices when Edgehog Forwarder is disabled

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -74,6 +74,8 @@ config :edgehog,
 config :edgehog, :astarte_interfaces_module, Edgehog.Astarte.Realm.InterfacesMock
 config :edgehog, :astarte_triggers_module, Edgehog.Astarte.Realm.TriggersMock
 
+config :edgehog, :forwarder_module, Edgehog.ForwarderMock
+
 # Reconciler mock for tests
 config :edgehog, :reconciler_module, Edgehog.Tenants.ReconcilerMock
 

--- a/backend/lib/edgehog/capabilities.ex
+++ b/backend/lib/edgehog/capabilities.ex
@@ -24,6 +24,13 @@ defmodule Edgehog.Capabilities do
   """
 
   alias Edgehog.Astarte
+  alias Edgehog.Forwarder
+
+  @forwarder_module Application.compile_env(
+                      :edgehog,
+                      :forwarder_module,
+                      Forwarder
+                    )
 
   # This is a keyword list that maps a capability, represented as an atom, to the set of all
   # interfaces that the device must support to claim to support the capability.
@@ -188,6 +195,13 @@ defmodule Edgehog.Capabilities do
             acc
           end
       end)
+
+    capabilities =
+      if @forwarder_module.forwarder_enabled?() do
+        capabilities
+      else
+        MapSet.delete(capabilities, :remote_terminal)
+      end
 
     # TODO add checks on device privacy settings and geolocation providers
     MapSet.put(capabilities, :geolocation)

--- a/backend/lib/edgehog/forwarder.ex
+++ b/backend/lib/edgehog/forwarder.ex
@@ -48,7 +48,7 @@ defmodule Edgehog.Forwarder do
     forwarder_config.secure_sessions?
   end
 
-  defp forwarder_enabled? do
+  def forwarder_enabled? do
     forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
     forwarder_config.enabled?
   end

--- a/backend/lib/edgehog/forwarder/behaviour.ex
+++ b/backend/lib/edgehog/forwarder/behaviour.ex
@@ -1,0 +1,32 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Forwarder.Behaviour do
+  alias Edgehog.Astarte.Device.ForwarderSession
+  alias Edgehog.Devices.Device
+
+  @callback forwarder_enabled?() :: boolean()
+
+  @callback fetch_forwarder_session(device :: %Device{}, session_token :: String.t()) ::
+              {:ok, ForwarderSession.t()} | {:error, term()}
+
+  @callback fetch_or_request_available_forwarder_session_token(device :: %Device{}) ::
+              {:ok, session_token :: String.t()} | {:error, term()}
+end

--- a/backend/test/edgehog_web/resolvers/capabilities_test.exs
+++ b/backend/test/edgehog_web/resolvers/capabilities_test.exs
@@ -21,6 +21,7 @@
 defmodule EdgehogWeb.Resolvers.CapabilitiesTest do
   use EdgehogWeb.ConnCase, async: true
   use Edgehog.AstarteMockCase
+  use Edgehog.ForwarderMockCase
   use Edgehog.GeolocationMockCase
 
   alias Astarte.Client.APIError

--- a/backend/test/support/forwarder_mock_case.ex
+++ b/backend/test/support/forwarder_mock_case.ex
@@ -1,0 +1,58 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021-2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.ForwarderMockCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's data layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use Edgehog.DataCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Mox
+      import Edgehog.ForwarderMockCase
+    end
+  end
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  setup do
+    Mox.stub_with(
+      Edgehog.ForwarderMock,
+      Edgehog.Mocks.Forwarder
+    )
+
+    :ok
+  end
+end

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -86,6 +86,10 @@ Mox.defmock(Edgehog.Astarte.Realm.TriggersMock,
   for: Edgehog.Astarte.Realm.Triggers.Behaviour
 )
 
+Mox.defmock(Edgehog.ForwarderMock,
+  for: Edgehog.Forwarder.Behaviour
+)
+
 Mox.defmock(Edgehog.Geolocation.GeolocationProviderMock,
   for: Edgehog.Geolocation.GeolocationProvider
 )

--- a/backend/test/support/mocks/forwarder.ex
+++ b/backend/test/support/mocks/forwarder.ex
@@ -1,0 +1,53 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Mocks.Forwarder do
+  @behaviour Edgehog.Forwarder.Behaviour
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+  alias Edgehog.Devices.Device
+
+  @forwarder_hostname "localhost"
+  @forwarder_port 4001
+  @secure_sessions? false
+
+  @impl true
+  def forwarder_enabled? do
+    true
+  end
+
+  @impl true
+  def fetch_forwarder_session(%Device{} = _device, session_token) do
+    session = %ForwarderSession{
+      token: session_token,
+      status: :connected,
+      secure: @secure_sessions?,
+      forwarder_hostname: @forwarder_hostname,
+      forwarder_port: @forwarder_port
+    }
+
+    {:ok, session}
+  end
+
+  @impl true
+  def fetch_or_request_available_forwarder_session_token(%Device{} = _device) do
+    {:ok, "session_token"}
+  end
+end


### PR DESCRIPTION
Currently, if devices supports the Astarte interfaces for Forwarder sessions but a Forwarder instance is not configured in Edgehog, the devices still reports a REMOTE_TERMINAL capability.

Since the presence of the capability controls whether the remote terminal functionality is enabled on Edgehog frontend, and it would be odd to display it enabled without a supporting Forwarder instance, this PR disables the capability on devices if a Forwarder instance is not configured.
