### PR TITLE
Disable Remote Terminal feature on frontend when Edgehog Forwarder is disabled

### DIFF
--- a/backend/lib/edgehog/error.ex
+++ b/backend/lib/edgehog/error.ex
@@ -142,6 +142,11 @@ defmodule Edgehog.Error do
 
   defp metadata(:device_disconnected), do: {409, "The device is not connected"}
 
+  defp metadata(:forwarder_config_not_found),
+    do:
+      {409,
+       "A forwarder has not been configured, therefore forwarding functionalities are not available"}
+
   defp metadata(:unknown), do: {500, "Something went wrong"}
 
   defp metadata(code) do

--- a/backend/lib/edgehog/forwarder/config.ex
+++ b/backend/lib/edgehog/forwarder/config.ex
@@ -1,0 +1,30 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Forwarder.Config do
+  @type t :: %__MODULE__{
+          hostname: String.t(),
+          port: integer(),
+          secure_sessions?: boolean()
+        }
+
+  @enforce_keys [:hostname, :port, :secure_sessions?]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
+++ b/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
@@ -23,6 +23,24 @@ defmodule EdgehogWeb.Resolvers.ForwarderSessions do
   alias Edgehog.Forwarder
 
   @doc """
+  Fetches the forwarder config, if available
+  """
+  def find_forwarder_config(_args, _resolution) do
+    case Forwarder.fetch_forwarder_config() do
+      {:ok, forwarder_config} ->
+        {:ok,
+         %{
+           hostname: forwarder_config.hostname,
+           port: forwarder_config.port,
+           secure_sessions: forwarder_config.secure_sessions?
+         }}
+
+      {:error, :forwarder_config_not_found} ->
+        {:ok, nil}
+    end
+  end
+
+  @doc """
   Fetches a forwarder session by its token and the device ID
   """
   def find_forwarder_session(%{device_id: device_id, session_token: session_token}, _resolution) do

--- a/backend/lib/edgehog_web/schema/forwarder_types.ex
+++ b/backend/lib/edgehog_web/schema/forwarder_types.ex
@@ -25,6 +25,18 @@ defmodule EdgehogWeb.Schema.ForwarderSessionsTypes do
   alias EdgehogWeb.Resolvers
 
   @desc """
+  The details of a forwarder instance.
+  """
+  object :forwarder_config do
+    @desc "The hostname of the forwarder instance."
+    field :hostname, non_null(:string)
+    @desc "The port of the forwarder instance."
+    field :port, non_null(:integer)
+    @desc "Indicates if TLS should used when connecting to the forwarder."
+    field :secure_sessions, non_null(:boolean)
+  end
+
+  @desc """
   The status of a forwarder session
   """
   enum :forwarder_session_status do
@@ -51,6 +63,14 @@ defmodule EdgehogWeb.Schema.ForwarderSessionsTypes do
   end
 
   object :forwarder_sessions_queries do
+    @desc """
+    Fetches the forwarder config, if available.
+    Without a configuration, forwarding functionalities are not available.
+    """
+    field :forwarder_config, :forwarder_config do
+      resolve &Resolvers.ForwarderSessions.find_forwarder_config/2
+    end
+
     @desc "Fetches a forwarder session by its token and the device ID."
     field :forwarder_session, :forwarder_session do
       @desc "The GraphQL ID of the device corresponding to the session."

--- a/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
@@ -1,0 +1,118 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.ForwarderConfigTest do
+  use EdgehogWeb.ConnCase
+
+  describe "forwarderConfig query" do
+    @query """
+    query {
+      forwarderConfig {
+        hostname
+        port
+        secureSessions
+      }
+    }
+    """
+
+    test "returns the forwarder config when the forwarder is configured", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      original_config =
+        mock_configured_forwarder(
+          hostname: "some-hostname.com",
+          port: 4001,
+          secure_sessions?: true
+        )
+
+      result = run_query(conn, api_path)
+
+      assert %{
+               "data" => %{
+                 "forwarderConfig" => %{
+                   "hostname" => "some-hostname.com",
+                   "port" => 4001,
+                   "secureSessions" => true
+                 }
+               }
+             } = result
+
+      restore_forwarder_config(original_config)
+    end
+
+    test "returns null when the forwarder is not configured", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      original_config = mock_unconfigured_forwarder()
+
+      result = run_query(conn, api_path)
+
+      assert %{
+               "data" => %{
+                 "forwarderConfig" => nil
+               }
+             } = result
+
+      restore_forwarder_config(original_config)
+    end
+  end
+
+  defp mock_configured_forwarder(
+         hostname: hostname,
+         port: port,
+         secure_sessions?: secure_sessions?
+       ) do
+    original_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+
+    Application.put_env(:edgehog, :edgehog_forwarder, %{
+      hostname: hostname,
+      port: port,
+      secure_sessions?: secure_sessions?,
+      enabled?: true
+    })
+
+    original_config
+  end
+
+  defp mock_unconfigured_forwarder() do
+    original_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+
+    Application.put_env(:edgehog, :edgehog_forwarder, %{
+      hostname: nil,
+      port: nil,
+      secure_sessions?: false,
+      enabled?: false
+    })
+
+    original_config
+  end
+
+  defp restore_forwarder_config(config) do
+    Application.put_env(:edgehog, :edgehog_forwarder, config)
+  end
+
+  defp run_query(conn, api_path) do
+    conn
+    |> get(api_path, query: @query, variables: %{})
+    |> json_response(200)
+  end
+end

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -42,6 +42,12 @@ type RootQueryType {
   "Fetches a single system model."
   systemModel("The ID of the system model." id: ID!): SystemModel
 
+  """
+  Fetches the forwarder config, if available.
+  Without a configuration, forwarding functionalities are not available.
+  """
+  forwarderConfig: ForwarderConfig
+
   "Fetches a forwarder session by its token and the device ID."
   forwarderSession(
     "The GraphQL ID of the device corresponding to the session."
@@ -697,6 +703,18 @@ type DeviceLocation {
 
   "The date at which the measurement was made."
   timestamp: DateTime!
+}
+
+"The details of a forwarder instance."
+type ForwarderConfig {
+  "The hostname of the forwarder instance."
+  hostname: String!
+
+  "The port of the forwarder instance."
+  port: Int!
+
+  "Indicates if TLS should used when connecting to the forwarder."
+  secureSessions: Boolean!
 }
 
 "The status of a forwarder session"

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -219,6 +219,9 @@ const DEVICE_CONNECTION_STATUS_FRAGMENT = graphql`
 
 const GET_DEVICE_QUERY = graphql`
   query Device_getDevice_Query($id: ID!) {
+    forwarderConfig {
+      __typename
+    }
     device(id: $id) {
       id
       deviceId
@@ -1303,6 +1306,11 @@ const DeviceContent = ({
     [deviceData.device],
   );
 
+  const isForwarderEnabled = useMemo(
+    () => deviceData.forwarderConfig != null,
+    [deviceData.forwarderConfig],
+  );
+
   const [deviceDraft, setDeviceDraft] = useState(
     _.pick(device, ["name", "tags"]),
   );
@@ -1536,6 +1544,9 @@ const DeviceContent = ({
     );
   }
 
+  const isRemoteTerminalSupported =
+    isForwarderEnabled && device.capabilities.includes("REMOTE_TERMINAL");
+
   return (
     <Page>
       <Page.Header title={device.name} />
@@ -1688,7 +1699,7 @@ const DeviceContent = ({
                       />
                     </FormRow>
                   )}
-                  {device.capabilities.includes("REMOTE_TERMINAL") && (
+                  {isRemoteTerminalSupported && (
                     <FormRow
                       id="form-device-open-remote-terminal"
                       label={


### PR DESCRIPTION
The PR introduces the following changes:
- Define a GraphQL query to fetch the configuration of the forwarder instance, if available. The presence of a configuration indicates that the forwarding functionalities are supported, otherwise they are disabled.
- When there is no forwarder config available from the APIs avoid displaying the button to open remote terminal sessions, since that functionality requires a configured forwarder.