### PR TITLE
Refactor create base image's form info

### DIFF
--- a/frontend/src/forms/CreateBaseImage.tsx
+++ b/frontend/src/forms/CreateBaseImage.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,15 @@ import {
   baseImageStartingVersionRequirementSchema,
   yup,
 } from "forms";
+import { graphql, useFragment } from "react-relay/hooks";
+import type { CreateBaseImage_BaseImageCollectionFragment$key } from "api/__generated__/CreateBaseImage_BaseImageCollectionFragment.graphql";
+
+const CREATE_BASE_IMAGE_FRAGMENT = graphql`
+  fragment CreateBaseImage_BaseImageCollectionFragment on BaseImageCollection {
+    id
+    name
+  }
+`;
 
 const FormRow = ({
   id,
@@ -128,25 +137,29 @@ type BaseImageCollection = {
 };
 
 type Props = {
-  baseImageCollection: BaseImageCollection;
+  baseImageCollectionRef: CreateBaseImage_BaseImageCollectionFragment$key;
   locale: string;
   isLoading?: boolean;
   onSubmit: (data: BaseImageData) => void;
 };
 
 const CreateBaseImageForm = ({
-  baseImageCollection,
+  baseImageCollectionRef,
   locale,
   isLoading = false,
   onSubmit,
 }: Props) => {
+  const baseImageCollectionData = useFragment(
+    CREATE_BASE_IMAGE_FRAGMENT,
+    baseImageCollectionRef,
+  );
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<FormData>({
     mode: "onTouched",
-    defaultValues: transformInputData(baseImageCollection),
+    defaultValues: transformInputData(baseImageCollectionData),
     resolver: yupResolver(baseImageSchema),
   });
 
@@ -156,7 +169,9 @@ const CreateBaseImageForm = ({
         ...data,
         file: data.file,
       };
-      onSubmit(transformOutputData(baseImageCollection, locale, baseImageData));
+      onSubmit(
+        transformOutputData(baseImageCollectionData, locale, baseImageData),
+      );
     }
   };
 

--- a/frontend/src/pages/BaseImageCreate.tsx
+++ b/frontend/src/pages/BaseImageCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -47,8 +47,7 @@ import { Link, Route, useNavigate } from "Navigation";
 const GET_BASE_IMAGE_COLLECTION_QUERY = graphql`
   query BaseImageCreate_getBaseImageCollection_Query($id: ID!) {
     baseImageCollection(id: $id) {
-      id
-      name
+      ...CreateBaseImage_BaseImageCollectionFragment
     }
     tenantInfo {
       defaultLocale
@@ -152,7 +151,7 @@ const BaseImageCreateContent = ({
           {errorFeedback}
         </Alert>
         <CreateBaseImageForm
-          baseImageCollection={baseImageCollection}
+          baseImageCollectionRef={baseImageCollection}
           locale={locale}
           onSubmit={handleCreateBaseImage}
           isLoading={isCreatingBaseImage}


### PR DESCRIPTION
Create GraphQL fragment for data into CreateBaseImage form and use it on BaseImageCreate page.
This PR also gets rid of eslint relay/unused-field warning in BaseImageCreate page.


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
