### PR TITLE
Refactor create base image collection's form info

### DIFF
--- a/frontend/src/forms/CreateBaseImageCollection.tsx
+++ b/frontend/src/forms/CreateBaseImageCollection.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { baseImageCollectionHandleSchema, yup } from "forms";
+import { graphql, useFragment } from "react-relay";
+import type { CreateBaseImageCollection_SystemModelsFragment$key } from "api/__generated__/CreateBaseImageCollection_SystemModelsFragment.graphql";
+
+const CREATE_BASE_IMAGE_COLLECTION_FRAGMENT = graphql`
+  fragment CreateBaseImageCollection_SystemModelsFragment on SystemModel
+  @relay(plural: true) {
+    id
+    name
+  }
+`;
 
 const FormRow = ({
   id,
@@ -68,23 +78,22 @@ const initialData: BaseImageCollectionData = {
   systemModelId: "",
 };
 
-type SystemModelOption = {
-  id: string;
-  name: string;
-};
-
 type Props = {
-  systemModels: SystemModelOption[];
+  systemModelsRef: CreateBaseImageCollection_SystemModelsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: BaseImageCollectionData) => void;
 };
 
 const CreateBaseImageCollectionForm = ({
-  systemModels,
+  systemModelsRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
   const intl = useIntl();
+  const systemModelsData = useFragment(
+    CREATE_BASE_IMAGE_COLLECTION_FRAGMENT,
+    systemModelsRef,
+  );
   const {
     register,
     handleSubmit,
@@ -149,7 +158,7 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select a System Model",
               })}
             </option>
-            {systemModels.map((systemModelOption) => (
+            {systemModelsData.map((systemModelOption) => (
               <option key={systemModelOption.id} value={systemModelOption.id}>
                 {systemModelOption.name}
               </option>

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -44,8 +44,7 @@ import { Link, Route, useNavigate } from "Navigation";
 const GET_SYSTEM_MODELS_QUERY = graphql`
   query BaseImageCollectionCreate_getSystemModels_Query {
     systemModels {
-      id
-      name
+      ...CreateBaseImageCollection_SystemModelsFragment
     }
   }
 `;
@@ -77,7 +76,7 @@ const BaseImageCollection = ({
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
 
-  const systemModelsData = usePreloadedQuery(
+  const { systemModels } = usePreloadedQuery(
     GET_SYSTEM_MODELS_QUERY,
     getSystemModelsQuery,
   );
@@ -88,13 +87,13 @@ const BaseImageCollection = ({
     );
 
   // TODO: handle readonly type without mapping to mutable type
-  const systemModels = useMemo(
-    () =>
-      systemModelsData.systemModels.map((systemModel) => ({
-        ...systemModel,
-      })),
-    [systemModelsData],
-  );
+  // const systemModels = useMemo(
+  //   () =>
+  //     systemModelsData.systemModels.map((systemModel) => ({
+  //       ...systemModel,
+  //     })),
+  //   [systemModelsData],
+  // );
 
   const handleCreateBaseImageCollection = useCallback(
     (baseImageCollection: BaseImageCollectionData) => {
@@ -195,7 +194,7 @@ const BaseImageCollection = ({
               {errorFeedback}
             </Alert>
             <CreateBaseImageCollectionForm
-              systemModels={systemModels}
+              systemModelsRef={systemModels}
               onSubmit={handleCreateBaseImageCollection}
               isLoading={isCreatingBaseImageCollection}
             />


### PR DESCRIPTION
Create GraphQL fragment for data into CreateBaseImageCollection form and use it in BaseImageCollectionCreate page.
This PR also gets rid of ESlint relay/unused-field warnings in BaseImageCollectionCreate page.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
