### PR TITLE
Document the implemented support for Edgehog Device Forwarder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.8.0-dev] - Unreleased
+### Added
+- Add support for an instance of [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). When configured, forwarding functionalities are enabled for devices that support forwarding connections to their internal services, allowing features such as remote terminal sessions ([#447](https://github.com/edgehog-device-manager/edgehog/pull/447)).
 
 ## [0.7.1] - Unreleased
 ### Added


### PR DESCRIPTION
Note down a summary of the implemented functionality in the changelog file, and expand the documentation page on deployments to describe how the [Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder) can be configured alongside Edgehog.

Closes #444, #445, #446, #447.