### PR TITLE
Fix query limits on Astarte datastream interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0-rc.1] - Unreleased
+### Fixed
+- Fix query limits on Astarte datastream interfaces, leading to parsing failures on some interfaces.
+
 ## [0.8.0-rc.0] - 2024-03-21
 ### Added
 - Add support for an instance of [Edgehog Device

--- a/backend/lib/edgehog/astarte/device/battery_status.ex
+++ b/backend/lib/edgehog/astarte/device/battery_status.ex
@@ -28,7 +28,7 @@ defmodule Edgehog.Astarte.Device.BatteryStatus do
 
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, query: [limit: 1]) do
       battery_slots =
         data
         |> Enum.map(fn

--- a/backend/lib/edgehog/astarte/device/cellular_connection.ex
+++ b/backend/lib/edgehog/astarte/device/cellular_connection.ex
@@ -55,7 +55,9 @@ defmodule Edgehog.Astarte.Device.CellularConnection do
     # type Object Aggregrate.
     # For details, see https://github.com/astarte-platform/astarte/issues/630
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @status_interface, limit: 1) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @status_interface,
+             query: [limit: 1]
+           ) do
       modems = parse_status_data(data)
 
       {:ok, modems}

--- a/backend/lib/edgehog/astarte/device/geolocation.ex
+++ b/backend/lib/edgehog/astarte/device/geolocation.ex
@@ -28,7 +28,7 @@ defmodule Edgehog.Astarte.Device.Geolocation do
 
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, query: [limit: 1]) do
       parse_data(data)
     end
   end

--- a/backend/lib/edgehog/astarte/device/storage_usage.ex
+++ b/backend/lib/edgehog/astarte/device/storage_usage.ex
@@ -32,7 +32,7 @@ defmodule Edgehog.Astarte.Device.StorageUsage do
     # type Object Aggregrate.
     # For details, see https://github.com/astarte-platform/astarte/issues/630
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, query: [limit: 1]) do
       storage_units =
         data
         |> Enum.map(fn

--- a/backend/lib/edgehog/astarte/device/system_status.ex
+++ b/backend/lib/edgehog/astarte/device/system_status.ex
@@ -49,7 +49,7 @@ defmodule Edgehog.Astarte.Device.SystemStatus do
     # type Object Aggregrate.
     # For details, see https://github.com/astarte-platform/astarte/issues/630
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface, query: [limit: 1]) do
       case Map.fetch(data, "systemStatus") do
         {:ok, [status]} ->
           {:ok,

--- a/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
+++ b/backend/lib/edgehog/astarte/device/wifi_scan_result.ex
@@ -47,7 +47,9 @@ defmodule Edgehog.Astarte.Device.WiFiScanResult do
 
   def get(%AppEngine{} = client, device_id) do
     with {:ok, %{"data" => data}} <-
-           AppEngine.Devices.get_datastream_data(client, device_id, @interface, limit: 1000) do
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface,
+             query: [limit: 1000]
+           ) do
       wifi_scan_results =
         Map.get(data, "ap", [])
         |> Enum.map(fn ap ->


### PR DESCRIPTION
Astarte Client expects a `query` key to pass query parameters, that was missing, so the limit was not actually passed. This went unnoticed because most of the interfaces involved here were not actually used on physical devices, and tests mock the Astarte response so always returned a single value.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
