### PR TITLE
reconciler: normalize triggers before comparing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - Unreleased
 ### Changed
 - Configure cookie attribute based on protocol.
+- Normalize triggers when comparing them for reconciliation to avoid useless reconciliations.
 
 ## [0.8.0-rc.1] - 2024-03-22
 ### Fixed


### PR DESCRIPTION
Avoid continuous reconciliation for triggers which are the same but have explicit defaults in their map

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
