### PR TITLE
Forward port backend changes from main into from-ash-we-rise

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,8 +51,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-22.04
     steps:
-    - name: Clone the repository
-      uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install OTP and Elixir
       uses: erlef/setup-beam@v1
@@ -139,8 +141,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - name: Clone the repository
-      uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install OTP and Elixir
       uses: erlef/setup-beam@v1
@@ -181,6 +185,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Build Docker image
         run: docker build .

--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,20 +45,23 @@ jobs:
     if: github.repository_owner == 'edgehog-device-manager'
     runs-on: ubuntu-22.04
     steps:
-    # Checkout the source
-    - uses: actions/checkout@v3
+    - name: Checkout the source
+      uses: actions/checkout@v4
       with:
         path: edgehog
-    # Checkout the docs repository
-    - uses: actions/checkout@v3
+        show-progress: false
+    - name: Checkout the docs repository
+      uses: actions/checkout@v4
       with:
         repository: edgehog-device-manager/docs
         path: docs
-    # Checkout the interfaces repository
-    - uses: actions/checkout@v3
+        show-progress: false
+    - name: Checkout the interfaces repository
+      uses: actions/checkout@v4
       with:
         repository: edgehog-device-manager/edgehog-astarte-interfaces
         path: edgehog-astarte-interfaces
+        show-progress: false
     - uses: actions/setup-node@v3
       with:
         node-version-file: edgehog/.tool-versions
@@ -102,6 +105,8 @@ jobs:
         cd docs && git restore $DOCS_DIRNAME/device-sdks || true && cd ..
         # Copy doc pages
         cp -r edgehog/doc/doc/* docs/$DOCS_DIRNAME/
+        # Copy version dropdown config
+        cp edgehog/doc/versions.js docs/
         # Copy GraphQL docs
         cp -r ./edgehog/backend/graphql-api-docs docs/$DOCS_DIRNAME/
     - name: Commit files

--- a/.github/workflows/frontend-codeql-analysis.yaml
+++ b/.github/workflows/frontend-codeql-analysis.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,13 +46,15 @@ jobs:
         language: [ 'javascript' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/frontend-test.yaml
+++ b/.github/workflows/frontend-test.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Build Docker image
         working-directory: frontend

--- a/.github/workflows/reuse-lint.yaml
+++ b/.github/workflows/reuse-lint.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: 2022-2024 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -10,6 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,10 @@ Files: doc/images/*
 Copyright: 2021-2023 SECO Mind Srl
 License: Apache-2.0
 
+Files: doc/versions.js
+Copyright: 2024 SECO Mind Srl
+License: CC0-1.0
+
 Files: CHANGELOG.md
 Copyright: 2021-2023 SECO Mind Srl
 License: CC0-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0-dev] - Unreleased
+## [0.9.0-dev] - Unreleased
 
-## [0.7.1] - Unreleased
+## [0.8.0-rc.0] - 2024-03-21
 ### Added
-- Add Admin API ([#400](https://github.com/edgehog-device-manager/edgehog/pull/400)).
+- Add support for an instance of [Edgehog Device
+  Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). When configured,
+  forwarding functionalities are enabled for devices that support forwarding connections to their
+  internal services, allowing features such as remote terminal sessions
+  ([#447](https://github.com/edgehog-device-manager/edgehog/pull/447)).
+
+## [0.7.1] - 2024-02-01
+### Added
+- Add Admin API to [create](https://github.com/edgehog-device-manager/edgehog/pull/400) and
+  to [delete](https://github.com/edgehog-device-manager/edgehog/pull/416) tenants.
 - Add a reconciler that takes care of installing Astarte resources (interfaces and triggers) for a
-  tenant ([#403](https://github.com/edgehog-device-manager/edgehog/pull/403))
+  tenant ([#403](https://github.com/edgehog-device-manager/edgehog/pull/403)).
 - BREAKING: Add mandatory `URL_HOST` env variable. It must point to the host where the Edgehog
   backend is exposed.
 
 ### Fixed
-- Fix seeds not working when used outside docker
-- Fix seeds's default values not working correctly
+- Fix seeds not working when used outside docker.
+- Fix seeds's default values not working correctly.
 
 ## [0.7.0] - 2023-10-06
 ### Fixed
@@ -30,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose OTA Campaigns stats.
 
 ### Fixed
-- Fix DevicesTable component for devices without SystemModel
+- Fix DevicesTable component for devices without SystemModel.
 
 ### Changed
 - Enhance the OTA Campaigns frontend, using the exposed stats.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!---
-  Copyright 2022 SECO Mind Srl
+  Copyright 2022-2024 SECO Mind Srl
 
   SPDX-License-Identifier: Apache-2.0
 -->
@@ -10,8 +10,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| < 0.5   | :x:                |
-| 0.5.x   | :white_check_mark: |
+| < 0.7   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| 0.8.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -136,6 +136,13 @@ config :mime, :extensions, %{
   "json" => "application/vnd.api+json"
 }
 
+config :edgehog, :edgehog_forwarder, %{
+  hostname: "localhost",
+  port: 4001,
+  secure_sessions?: false,
+  enabled?: true
+}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ if config_env() == :prod do
       """
 
   # We're in the prod env, so assume https unless otherwise specified
-  url_port = System.get_env("URL_PORT", 443)
+  url_port = System.get_env("URL_PORT", "443")
   url_scheme = System.get_env("URL_SCHEME", "https")
 
   config :edgehog, EdgehogWeb.Endpoint,
@@ -78,12 +78,12 @@ if config_env() == :prod do
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
       ip: {0, 0, 0, 0, 0, 0, 0, 0},
       port: String.to_integer(System.get_env("PORT") || "4000"),
-      protocol_options: [idle_timeout: 300_000],
-      url: [
-        host: url_host,
-        scheme: url_scheme,
-        port: url_port
-      ]
+      protocol_options: [idle_timeout: 300_000]
+    ],
+    url: [
+      host: url_host,
+      scheme: url_scheme,
+      port: url_port
     ],
     secret_key_base: secret_key_base
 
@@ -145,6 +145,36 @@ if config_env() == :prod do
   config :goth,
     disabled: !use_google_cloud_storage,
     json: s3.gcp_credentials
+
+  forwarder_secure_sessions? =
+    System.get_env("EDGEHOG_FORWARDER_SECURE_SESSIONS", "true") == "true"
+
+  forwarder_hostname = System.get_env("EDGEHOG_FORWARDER_HOSTNAME")
+
+  if forwarder_hostname != nil &&
+       (String.starts_with?(forwarder_hostname, "http://") ||
+          String.starts_with?(forwarder_hostname, "https://")) do
+    raise """
+    environment variable EDGEHOG_FORWARDER_HOSTNAME must contain only the
+    hostname without the http:// or https:// scheme.
+    """
+  end
+
+  forwarder_port = System.get_env("EDGEHOG_FORWARDER_PORT")
+
+  forwarder_port =
+    cond do
+      forwarder_port != nil -> String.to_integer(forwarder_port)
+      forwarder_secure_sessions? -> 443
+      true -> 80
+    end
+
+  config :edgehog, :edgehog_forwarder, %{
+    hostname: forwarder_hostname,
+    port: forwarder_port,
+    secure_sessions?: forwarder_secure_sessions?,
+    enabled?: forwarder_hostname != nil
+  }
 
   # ## Using releases
   #

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -66,6 +66,7 @@ config :edgehog, :astarte_runtime_info_module, Edgehog.Astarte.Device.RuntimeInf
 config :edgehog, :astarte_led_behavior_module, Edgehog.Astarte.Device.LedBehaviorMock
 config :edgehog, :astarte_geolocation_module, Edgehog.Astarte.Device.GeolocationMock
 config :edgehog, :astarte_network_interface_module, Edgehog.Astarte.Device.NetworkInterfaceMock
+config :edgehog, :astarte_forwarder_session_module, Edgehog.Astarte.Device.ForwarderSessionMock
 
 config :edgehog,
        :astarte_cellular_connection_module,

--- a/backend/flake.lock
+++ b/backend/flake.lock
@@ -2,16 +2,19 @@
   "nodes": {
     "elixir-utils": {
       "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1696521035,
-        "narHash": "sha256-IW9AyjOc48mxXMR3xZzDNWPZRnUfU4eW1H6MyHyYZmQ=",
+        "lastModified": 1703156846,
+        "narHash": "sha256-VnYe8pWHMiltpjwcD2vSw3/+VObxF9c0q553yw6jIbw=",
         "owner": "noaccOS",
         "repo": "elixir-utils",
-        "rev": "7babc3e6072fb14463b6aa97c24cb5b57bb4517a",
+        "rev": "875e52710e28f154cda0a27300485b29dadd3615",
         "type": "github"
       },
       "original": {
@@ -41,11 +44,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -56,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696419054,
-        "narHash": "sha256-EdR+dIKCfqL3voZUDYwcvgRDOektQB9KbhBVcE0/3Mo=",
+        "lastModified": 1703105089,
+        "narHash": "sha256-1F7hDLj58OQCADRtG2DRKpmJ8QVza0M0NK/kfLWLs3k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7131f3c223a2d799568e4b278380cd9dac2b8579",
+        "rev": "2b9c57d33e3d5be6262e124fc66e3a8bc650b93d",
         "type": "github"
       },
       "original": {

--- a/backend/flake.nix
+++ b/backend/flake.nix
@@ -22,7 +22,7 @@
   description = "Open Source software focused on the management of the whole life-cycle of IoT devices";
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-    elixir-utils = { url = github:noaccOS/elixir-utils; inputs.nixpkgs.follows = "nixpkgs"; };
+    elixir-utils = { url = github:noaccOS/elixir-utils; inputs.nixpkgs.follows = "nixpkgs"; inputs.flake-utils.follows = "flake-utils"; };
     flake-utils.url = github:numtide/flake-utils;
     flake-compat = {
       url = github:edolstra/flake-compat;
@@ -31,7 +31,7 @@
   };
   outputs = { self, nixpkgs, elixir-utils, flake-utils, ... }:
     {
-      overlays.tools = elixir-utils.lib.asdfOverlay { src = ../.; };
+      overlays.tools = elixir-utils.lib.asdfOverlay { src = ../.; wxSupport = false; };
     } //
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.tools ]; };

--- a/backend/lib/edgehog/astarte/device/forwarder_session.ex
+++ b/backend/lib/edgehog/astarte/device/forwarder_session.ex
@@ -1,0 +1,123 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSession do
+  @type t :: %__MODULE__{
+          token: String.t(),
+          status: :connecting | :connected,
+          secure: boolean(),
+          forwarder_hostname: String.t(),
+          forwarder_port: integer()
+        }
+
+  @enforce_keys [:token, :status, :secure, :forwarder_hostname, :forwarder_port]
+  defstruct @enforce_keys
+
+  @behaviour Edgehog.Astarte.Device.ForwarderSession.Behaviour
+
+  alias Astarte.Client.AppEngine
+
+  @session_request_interface "io.edgehog.devicemanager.ForwarderSessionRequest"
+  @sessions_state_interface "io.edgehog.devicemanager.ForwarderSessionState"
+
+  @impl true
+  def list_sessions(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_properties_data(client, device_id, @sessions_state_interface) do
+      sessions = parse_session_list(data)
+
+      {:ok, sessions}
+    end
+  end
+
+  @impl true
+  def fetch_session(%AppEngine{} = client, device_id, session_token)
+      when is_binary(session_token) do
+    with {:ok, sessions} <- list_sessions(client, device_id) do
+      case Enum.find(sessions, &(&1.token == session_token)) do
+        nil -> {:error, :forwarder_session_not_found}
+        session -> {:ok, session}
+      end
+    end
+  end
+
+  @impl true
+  def request_session(
+        %AppEngine{} = client,
+        device_id,
+        session_token,
+        forwarder_hostname,
+        forwarder_port,
+        forwarder_secure_sessions?
+      )
+      when is_binary(session_token) and is_binary(forwarder_hostname) and
+             is_integer(forwarder_port) and is_boolean(forwarder_secure_sessions?) do
+    data = %{
+      session_token: session_token,
+      host: forwarder_hostname,
+      port: forwarder_port,
+      secure: forwarder_secure_sessions?
+    }
+
+    AppEngine.Devices.send_datastream(
+      client,
+      device_id,
+      @session_request_interface,
+      "/request",
+      data
+    )
+  end
+
+  defp parse_session_list(session_states) do
+    Enum.map(session_states, fn {session_token, session_state} ->
+      parse_session(session_token, session_state)
+    end)
+  end
+
+  defp parse_session(session_token, session_state) do
+    %__MODULE__{
+      token: session_token,
+      status: parse_session_status(session_state["status"]),
+      # TODO: forwarder info should be specified in the session_state.
+      # See issue: https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/68
+      secure: forwarder_secure_sessions?(),
+      forwarder_hostname: forwarder_hostname(),
+      forwarder_port: forwarder_port()
+    }
+  end
+
+  defp parse_session_status("Connected"), do: :connected
+  defp parse_session_status("Connecting"), do: :connecting
+
+  defp forwarder_hostname do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.hostname
+  end
+
+  defp forwarder_port do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.port
+  end
+
+  defp forwarder_secure_sessions? do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+    forwarder_config.secure_sessions?
+  end
+end

--- a/backend/lib/edgehog/astarte/device/forwarder_session/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/forwarder_session/behaviour.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSession.Behaviour do
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  @callback list_sessions(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(ForwarderSession.t())} | {:error, term()}
+
+  @callback fetch_session(
+              client :: AppEngine.t(),
+              device_id :: String.t(),
+              session_token :: String.t()
+            ) ::
+              {:ok, ForwarderSession.t()} | {:error, term()}
+
+  @callback request_session(
+              client :: AppEngine.t(),
+              device_id :: String.t(),
+              session_token :: String.t(),
+              forwarder_hostname :: String.t(),
+              forwarder_port :: integer(),
+              secure_sessions? :: boolean()
+            ) ::
+              :ok | {:error, term()}
+end

--- a/backend/lib/edgehog/capabilities.ex
+++ b/backend/lib/edgehog/capabilities.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022-2023 SECO Mind Srl
+# Copyright 2022-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,6 +90,18 @@ defmodule Edgehog.Capabilities do
     operating_system: [
       %Astarte.InterfaceID{
         name: "io.edgehog.devicemanager.OSInfo",
+        major: 0,
+        minor: 1
+      }
+    ],
+    remote_terminal: [
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.ForwarderSessionRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.ForwarderSessionState",
         major: 0,
         minor: 1
       }

--- a/backend/lib/edgehog/devices/device/types/capability.ex
+++ b/backend/lib/edgehog/devices/device/types/capability.ex
@@ -30,6 +30,7 @@ defmodule Edgehog.Devices.Device.Types.Capability do
       led_behaviors: "The device can be asked to blink its LED in a specific pattern.",
       network_interface_info: "The device can provide information about its network interfaces.",
       operating_system: "The device provides information about its operating system.",
+      remote_terminal: "The device supports remote terminal sessions.",
       runtime_info: "The device provides information about its runtime.",
       software_updates: "The device can be updated remotely.",
       storage: "The device provides information about its storage units.",

--- a/backend/lib/edgehog/forwarder.ex
+++ b/backend/lib/edgehog/forwarder.ex
@@ -1,0 +1,121 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Forwarder do
+  @moduledoc """
+  The Forwarder context.
+  """
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+  alias Edgehog.Devices
+  alias Edgehog.Devices.Device
+  alias Edgehog.Forwarder
+
+  @forwarder_session_module Application.compile_env(
+                              :edgehog,
+                              :astarte_forwarder_session_module,
+                              ForwarderSession
+                            )
+
+  def fetch_forwarder_config do
+    forwarder_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+
+    if forwarder_config.enabled? do
+      {:ok,
+       %Forwarder.Config{
+         hostname: forwarder_config.hostname,
+         port: forwarder_config.port,
+         secure_sessions?: forwarder_config.secure_sessions?
+       }}
+    else
+      {:error, :forwarder_config_not_found}
+    end
+  end
+
+  defp validate_forwarder_enabled do
+    with {:ok, _forwarder_config} <- fetch_forwarder_config() do
+      :ok
+    end
+  end
+
+  defp validate_device_connected(%Device{online: true}), do: :ok
+  defp validate_device_connected(%Device{online: false}), do: {:error, :device_disconnected}
+
+  defp list_forwarder_sessions(%Device{} = device) do
+    with :ok <- validate_forwarder_enabled(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.list_sessions(appengine_client, device.device_id)
+    end
+  end
+
+  def fetch_forwarder_session(%Device{} = device, session_token) do
+    with :ok <- validate_forwarder_enabled(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.fetch_session(appengine_client, device.device_id, session_token)
+    end
+  end
+
+  defp request_forwarder_session(%Device{} = device, session_token) do
+    with {:ok, forwarder_config} <- fetch_forwarder_config(),
+         :ok <- validate_device_connected(device),
+         {:ok, appengine_client} <- Devices.appengine_client_from_device(device) do
+      @forwarder_session_module.request_session(
+        appengine_client,
+        device.device_id,
+        session_token,
+        forwarder_config.hostname,
+        forwarder_config.port,
+        forwarder_config.secure_sessions?
+      )
+    end
+  end
+
+  defp fetch_available_forwarder_session(%Device{} = device) do
+    with {:ok, forwarder_sessions} <- list_forwarder_sessions(device) do
+      connected_session = Enum.find(forwarder_sessions, &(&1.status == :connected))
+      connecting_session = Enum.find(forwarder_sessions, &(&1.status == :connecting))
+
+      cond do
+        connected_session != nil -> {:ok, connected_session}
+        connecting_session != nil -> {:ok, connecting_session}
+        true -> {:error, :forwarder_session_not_found}
+      end
+    end
+  end
+
+  def fetch_or_request_available_forwarder_session_token(%Device{} = device) do
+    case fetch_available_forwarder_session(device) do
+      {:ok, session} ->
+        {:ok, session.token}
+
+      {:error, :forwarder_session_not_found} ->
+        session_token = Ecto.UUID.generate()
+
+        with :ok <- request_forwarder_session(device, session_token) do
+          {:ok, session_token}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/backend/lib/edgehog/forwarder/config.ex
+++ b/backend/lib/edgehog/forwarder/config.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023-2024 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,21 +18,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-IPBASE_API_KEY=
-GOOGLE_GEOLOCATION_API_KEY=
-GOOGLE_GEOCODING_API_KEY=
+defmodule Edgehog.Forwarder.Config do
+  @type t :: %__MODULE__{
+          hostname: String.t(),
+          port: integer(),
+          secure_sessions?: boolean()
+        }
 
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
-S3_REGION=local
-S3_SCHEME=http://
-S3_HOST=minio
-S3_PORT=9000
-S3_BUCKET=edgehog
-S3_ASSET_HOST=http://minio-storage.edgehog.localhost/edgehog
-S3_GCP_CREDENTIALS=
-
-SEEDS_REALM=test
-SEEDS_REALM_PRIVATE_KEY_FILE=./backend/priv/repo/seeds/keys/realm_private.pem
-SEEDS_TENANT_PRIVATE_KEY_FILE=./backend/priv/repo/seeds/keys/tenant_private.pem
-SEEDS_ASTARTE_BASE_API_URL=http://api.astarte.localhost
+  @enforce_keys [:hostname, :port, :secure_sessions?]
+  defstruct @enforce_keys
+end

--- a/backend/lib/edgehog/tenants/reconciler/core.ex
+++ b/backend/lib/edgehog/tenants/reconciler/core.ex
@@ -83,6 +83,14 @@ defmodule Edgehog.Tenants.Reconciler.Core do
     end
   end
 
+  def cleanup_trigger(%Client.RealmManagement{} = client, trigger) do
+    %{
+      "name" => trigger_name
+    } = trigger
+
+    Astarte.delete_trigger(client, trigger_name)
+  end
+
   defp update_interface!(rm_client, name, major, interface_json) do
     # TODO: crash with a nicer exception instead of MatchError
     :ok = Interface.update(rm_client, name, major, interface_json)

--- a/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
+++ b/backend/lib/edgehog_web/resolvers/forwarder_sessions.ex
@@ -1,0 +1,72 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Resolvers.ForwarderSessions do
+  alias Edgehog.Devices
+  alias Edgehog.Forwarder
+
+  @doc """
+  Fetches the forwarder config, if available
+  """
+  def find_forwarder_config(_args, _resolution) do
+    case Forwarder.fetch_forwarder_config() do
+      {:ok, forwarder_config} ->
+        {:ok,
+         %{
+           hostname: forwarder_config.hostname,
+           port: forwarder_config.port,
+           secure_sessions: forwarder_config.secure_sessions?
+         }}
+
+      {:error, :forwarder_config_not_found} ->
+        {:ok, nil}
+    end
+  end
+
+  @doc """
+  Fetches a forwarder session by its token and the device ID
+  """
+  def find_forwarder_session(%{device_id: device_id, session_token: session_token}, _resolution) do
+    device =
+      device_id
+      |> Devices.get_device!()
+      |> Devices.preload_astarte_resources_for_device()
+
+    with {:error, :forwarder_session_not_found} <-
+           Forwarder.fetch_forwarder_session(device, session_token) do
+      {:ok, nil}
+    end
+  end
+
+  @doc """
+  Requests a forwarder session for the specified device ID.
+  """
+  def request_forwarder_session(%{device_id: device_id}, _resolution) do
+    device =
+      device_id
+      |> Devices.get_device!()
+      |> Devices.preload_astarte_resources_for_device()
+
+    with {:ok, session_token} <-
+           Forwarder.fetch_or_request_available_forwarder_session_token(device) do
+      {:ok, %{session_token: session_token}}
+    end
+  end
+end

--- a/backend/lib/edgehog_web/schema.ex
+++ b/backend/lib/edgehog_web/schema.ex
@@ -23,6 +23,7 @@ defmodule EdgehogWeb.Schema do
   use Absinthe.Relay.Schema, :modern
   import_types EdgehogWeb.Schema.AstarteTypes
   import_types EdgehogWeb.Schema.BaseImagesTypes
+  import_types EdgehogWeb.Schema.ForwarderSessionsTypes
   import_types EdgehogWeb.Schema.GeolocationTypes
   import_types EdgehogWeb.Schema.LocalizationTypes
   import_types EdgehogWeb.Schema.OSManagementTypes
@@ -114,12 +115,14 @@ defmodule EdgehogWeb.Schema do
     end
 
     import_fields :base_images_queries
+    import_fields :forwarder_sessions_queries
     import_fields :update_campaigns_queries
   end
 
   mutation do
     import_fields :astarte_mutations
     import_fields :base_images_mutations
+    import_fields :forwarder_sessions_mutations
     import_fields :os_management_mutations
     import_fields :update_campaigns_mutations
   end

--- a/backend/lib/edgehog_web/schema/forwarder_types.ex
+++ b/backend/lib/edgehog_web/schema/forwarder_types.ex
@@ -1,0 +1,103 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.ForwarderSessionsTypes do
+  use Absinthe.Schema.Notation
+  use Absinthe.Relay.Schema.Notation, :modern
+
+  alias EdgehogWeb.Resolvers
+
+  @desc """
+  The details of a forwarder instance.
+  """
+  object :forwarder_config do
+    @desc "The hostname of the forwarder instance."
+    field :hostname, non_null(:string)
+    @desc "The port of the forwarder instance."
+    field :port, non_null(:integer)
+    @desc "Indicates if TLS should used when connecting to the forwarder."
+    field :secure_sessions, non_null(:boolean)
+  end
+
+  @desc """
+  The status of a forwarder session
+  """
+  enum :forwarder_session_status do
+    @desc "The device is connected to the forwarder."
+    value :connected
+    @desc "The device is connecting to the forwarder."
+    value :connecting
+  end
+
+  @desc """
+  The details of a forwarder session
+  """
+  object :forwarder_session do
+    @desc "The token that identifies the session."
+    field :token, non_null(:string)
+    @desc "The status of the session."
+    field :status, non_null(:forwarder_session_status)
+    @desc "Indicates if TLS is used when the device connects to the forwarder."
+    field :secure, non_null(:boolean)
+    @desc "The hostname of the forwarder instance."
+    field :forwarder_hostname, non_null(:string)
+    @desc "The port of the forwarder instance."
+    field :forwarder_port, non_null(:integer)
+  end
+
+  object :forwarder_sessions_queries do
+    @desc """
+    Fetches the forwarder config, if available.
+    Without a configuration, forwarding functionalities are not available.
+    """
+    field :forwarder_config, :forwarder_config do
+      resolve &Resolvers.ForwarderSessions.find_forwarder_config/2
+    end
+
+    @desc "Fetches a forwarder session by its token and the device ID."
+    field :forwarder_session, :forwarder_session do
+      @desc "The GraphQL ID of the device corresponding to the session."
+      arg :device_id, non_null(:id)
+      @desc "The token that identifies the session."
+      arg :session_token, non_null(:string)
+
+      middleware Absinthe.Relay.Node.ParseIDs, device_id: :device
+      resolve &Resolvers.ForwarderSessions.find_forwarder_session/2
+    end
+  end
+
+  object :forwarder_sessions_mutations do
+    @desc "Requests a forwarder session for the specified device."
+    payload field :request_forwarder_session do
+      input do
+        @desc "The GraphQL ID of the device for the requested session."
+        field :device_id, non_null(:id)
+      end
+
+      output do
+        @desc "The token of the requested forwarder session."
+        field :session_token, non_null(:string)
+      end
+
+      middleware Absinthe.Relay.Node.ParseIDs, device_id: :device
+      resolve &Resolvers.ForwarderSessions.request_forwarder_session/2
+    end
+  end
+end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -24,7 +24,7 @@ defmodule Edgehog.MixProject do
   def project do
     [
       app: :edgehog,
-      version: "0.8.0-dev",
+      version: "0.9.0-dev",
       elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionRequest.json
@@ -1,0 +1,39 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ForwarderSessionRequest",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "server",
+  "aggregation": "object",
+  "description": "Configuration to open a session with the Edgehog Forwarder from a device to a certain host.",
+  "mappings": [
+    {
+      "endpoint": "/request/session_token",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The session token thanks to which the device can authenticates itself through Edgehog."
+    },
+    {
+      "endpoint": "/request/port",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The host port the device must connect to."
+    },
+    {
+      "endpoint": "/request/host",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The IP address or host name the device must connect to."
+    },
+    {
+      "endpoint": "/request/secure",
+      "type": "boolean",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "Indicates whether the connection should use TLS, i.e. 'ws' or 'wss' scheme."
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionState.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.ForwarderSessionState.json
@@ -1,0 +1,17 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ForwarderSessionState",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "description": "Information provided by the device about the status of a forwarder session.",
+  "mappings": [
+    {
+      "endpoint": "/%{session_token}/status",
+      "type": "string",
+      "allow_unset": true,
+      "description": "Indicates if the device is connecting, or connected to a forwarder session.",
+      "doc": "An enum with the following possible values: Connecting | Connected."
+    }
+  ]
+}

--- a/backend/test/edgehog/astarte/device/forwarder_session_test.exs
+++ b/backend/test/edgehog/astarte/device/forwarder_session_test.exs
@@ -1,0 +1,140 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.ForwarderSessionTest do
+  use Edgehog.DataCase, async: true
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  describe "forwarder_session" do
+    import Edgehog.AstarteFixtures
+    import Tesla.Mock
+
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+      device = astarte_device_fixture(realm)
+
+      {:ok, appengine_client} =
+        AppEngine.new(cluster.base_api_url, realm.name, private_key: realm.private_key)
+
+      {:ok, cluster: cluster, realm: realm, device: device, appengine_client: appengine_client}
+    end
+
+    test "list_sessions/2 correctly parses session states data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "session_token_1" => %{
+            "status" => "Connecting"
+          },
+          "session_token_2" => %{
+            "status" => "Connected"
+          }
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, sessions} =
+               ForwarderSession.list_sessions(appengine_client, device.device_id)
+
+      assert sessions == [
+               %ForwarderSession{
+                 token: "session_token_1",
+                 status: :connecting,
+                 secure: false,
+                 forwarder_hostname: "localhost",
+                 forwarder_port: 4001
+               },
+               %ForwarderSession{
+                 token: "session_token_2",
+                 status: :connected,
+                 secure: false,
+                 forwarder_hostname: "localhost",
+                 forwarder_port: 4001
+               }
+             ]
+    end
+
+    test "fetch_session/3 correctly parses session state data", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{
+          "session_token_1" => %{
+            "status" => "Connecting"
+          },
+          "session_token_2" => %{
+            "status" => "Connected"
+          }
+        }
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:ok, session} =
+               ForwarderSession.fetch_session(
+                 appengine_client,
+                 device.device_id,
+                 "session_token_1"
+               )
+
+      assert session == %ForwarderSession{
+               token: "session_token_1",
+               status: :connecting,
+               secure: false,
+               forwarder_hostname: "localhost",
+               forwarder_port: 4001
+             }
+    end
+
+    test "fetch_session/3 returns an error if the session was not found", %{
+      device: device,
+      appengine_client: appengine_client
+    } do
+      response = %{
+        "data" => %{}
+      }
+
+      mock(fn
+        %{method: :get, url: _api_url} ->
+          json(response)
+      end)
+
+      assert {:error, :forwarder_session_not_found} =
+               ForwarderSession.fetch_session(
+                 appengine_client,
+                 device.device_id,
+                 "session_token"
+               )
+    end
+  end
+end

--- a/backend/test/edgehog/capabilities_test.exs
+++ b/backend/test/edgehog/capabilities_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ defmodule Edgehog.CapabilitiesTest do
           minor: 1
         },
         "io.edgehog.devicemanager.Commands" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.ForwarderSessionState" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.HardwareInfo" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.LedBehavior" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.NetworkInterfaceProperties" => %InterfaceVersion{
@@ -45,6 +46,10 @@ defmodule Edgehog.CapabilitiesTest do
           minor: 1
         },
         "io.edgehog.devicemanager.OSInfo" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.ForwarderSessionRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
         "io.edgehog.devicemanager.RuntimeInfo" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.OTARequest" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.OTAResponse" => %InterfaceVersion{major: 0, minor: 1},
@@ -65,6 +70,7 @@ defmodule Edgehog.CapabilitiesTest do
         :led_behaviors,
         :network_interface_info,
         :operating_system,
+        :remote_terminal,
         :runtime_info,
         :software_updates,
         :storage,

--- a/backend/test/edgehog_web/schema/mutation/request_forwarder_session_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/request_forwarder_session_test.exs
@@ -1,0 +1,199 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.RequestForwarderSessionTest do
+  use EdgehogWeb.ConnCase, async: true
+  use Edgehog.AstarteMockCase
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  import Edgehog.AstarteFixtures
+  import Edgehog.DevicesFixtures
+
+  describe "requestForwarderSession mutation" do
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+
+      {:ok, realm: realm}
+    end
+
+    @query """
+    mutation ($input: RequestForwarderSessionInput!) {
+      requestForwarderSession(input: $input) {
+        sessionToken
+      }
+    }
+    """
+
+    test "returns the token of a :connected session instead of a :connecting one", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_sessions(device, [
+        %ForwarderSession{
+          token: "connecting_session_token",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        },
+        %ForwarderSession{
+          token: "connected_session_token",
+          status: :connected,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        }
+      ])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => "connected_session_token"
+                 }
+               }
+             } = result
+    end
+
+    test "returns the token of a :connecting session, if there are no :connected sessions", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_sessions(device, [
+        %ForwarderSession{
+          token: "connecting_session_token_1",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        },
+        %ForwarderSession{
+          token: "connecting_session_token_2",
+          status: :connecting,
+          secure: false,
+          forwarder_hostname: "localhost",
+          forwarder_port: 4001
+        }
+      ])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => "connecting_session_token_1"
+                 }
+               }
+             } = result
+    end
+
+    test "returns the token of a new session, if there is no available session", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+      mock_forwarder_sessions(device, [])
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => %{
+                   "sessionToken" => session_token
+                 }
+               }
+             } = result
+
+      assert {:ok, ^session_token} = Ecto.UUID.cast(session_token)
+    end
+
+    test "returns error if the device is disconnected", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: false})
+
+      variables = %{
+        input: %{
+          device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema)
+        }
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "requestForwarderSession" => nil
+               },
+               "errors" => [
+                 %{
+                   "code" => "device_disconnected",
+                   "message" => "The device is not connected",
+                   "status_code" => 409
+                 }
+               ]
+             } = result
+    end
+  end
+
+  defp mock_forwarder_sessions(device, forwarder_sessions) do
+    device_id = device.device_id
+
+    Edgehog.Astarte.Device.ForwarderSessionMock
+    |> expect(:list_sessions, fn _appengine_client, ^device_id ->
+      {:ok, forwarder_sessions}
+    end)
+  end
+
+  defp run_query(conn, api_path, variables) do
+    conn
+    |> post(api_path, query: @query, variables: variables)
+    |> json_response(200)
+  end
+end

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -400,6 +400,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
         "LED_BEHAVIORS",
         "NETWORK_INTERFACE_INFO",
         "OPERATING_SYSTEM",
+        "REMOTE_TERMINAL",
         "RUNTIME_INFO",
         "SOFTWARE_UPDATES",
         "STORAGE",

--- a/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
@@ -1,0 +1,118 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.ForwarderConfigTest do
+  use EdgehogWeb.ConnCase
+
+  describe "forwarderConfig query" do
+    @query """
+    query {
+      forwarderConfig {
+        hostname
+        port
+        secureSessions
+      }
+    }
+    """
+
+    test "returns the forwarder config when the forwarder is configured", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      original_config =
+        mock_configured_forwarder(
+          hostname: "some-hostname.com",
+          port: 4001,
+          secure_sessions?: true
+        )
+
+      result = run_query(conn, api_path)
+
+      assert %{
+               "data" => %{
+                 "forwarderConfig" => %{
+                   "hostname" => "some-hostname.com",
+                   "port" => 4001,
+                   "secureSessions" => true
+                 }
+               }
+             } = result
+
+      restore_forwarder_config(original_config)
+    end
+
+    test "returns null when the forwarder is not configured", %{
+      conn: conn,
+      api_path: api_path
+    } do
+      original_config = mock_unconfigured_forwarder()
+
+      result = run_query(conn, api_path)
+
+      assert %{
+               "data" => %{
+                 "forwarderConfig" => nil
+               }
+             } = result
+
+      restore_forwarder_config(original_config)
+    end
+  end
+
+  defp mock_configured_forwarder(
+         hostname: hostname,
+         port: port,
+         secure_sessions?: secure_sessions?
+       ) do
+    original_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+
+    Application.put_env(:edgehog, :edgehog_forwarder, %{
+      hostname: hostname,
+      port: port,
+      secure_sessions?: secure_sessions?,
+      enabled?: true
+    })
+
+    original_config
+  end
+
+  defp mock_unconfigured_forwarder() do
+    original_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
+
+    Application.put_env(:edgehog, :edgehog_forwarder, %{
+      hostname: nil,
+      port: nil,
+      secure_sessions?: false,
+      enabled?: false
+    })
+
+    original_config
+  end
+
+  defp restore_forwarder_config(config) do
+    Application.put_env(:edgehog, :edgehog_forwarder, config)
+  end
+
+  defp run_query(conn, api_path) do
+    conn
+    |> get(api_path, query: @query, variables: %{})
+    |> json_response(200)
+  end
+end

--- a/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
@@ -1,0 +1,147 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.ForwarderSessionTest do
+  use EdgehogWeb.ConnCase, async: true
+  use Edgehog.AstarteMockCase
+
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  import Edgehog.AstarteFixtures
+  import Edgehog.DevicesFixtures
+
+  describe "forwarderSession query" do
+    setup do
+      cluster = cluster_fixture()
+      realm = realm_fixture(cluster)
+
+      {:ok, realm: realm}
+    end
+
+    @query """
+    query ($device_id: ID!, $session_token: String!) {
+      forwarderSession(deviceId: $device_id, sessionToken: $session_token) {
+        token
+        status
+        forwarderHostname
+        forwarderPort
+      }
+    }
+    """
+
+    test "returns the forwarder session", %{conn: conn, api_path: api_path, realm: realm} do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_session(device, "session_token", %ForwarderSession{
+        token: "session_token",
+        status: :connected,
+        secure: false,
+        forwarder_hostname: "localhost",
+        forwarder_port: 4001
+      })
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "forwarderSession" => %{
+                   "token" => "session_token",
+                   "status" => "CONNECTED",
+                   "forwarderHostname" => "localhost",
+                   "forwarderPort" => 4001
+                 }
+               }
+             } = result
+    end
+
+    test "returns null if the session does not exist", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: true})
+
+      mock_forwarder_session(device, "session_token", nil)
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{
+                 "forwarderSession" => nil
+               }
+             } = result
+    end
+
+    test "returns error if the device is disconnected", %{
+      conn: conn,
+      api_path: api_path,
+      realm: realm
+    } do
+      device = device_fixture(realm, %{online: false})
+
+      variables = %{
+        device_id: Absinthe.Relay.Node.to_global_id(:device, device.id, EdgehogWeb.Schema),
+        session_token: "session_token"
+      }
+
+      result = run_query(conn, api_path, variables)
+
+      assert %{
+               "data" => %{"forwarderSession" => nil},
+               "errors" => [
+                 %{
+                   "code" => "device_disconnected",
+                   "message" => "The device is not connected",
+                   "status_code" => 409
+                 }
+               ]
+             } = result
+    end
+  end
+
+  defp mock_forwarder_session(device, session_token, forwarder_session) do
+    device_id = device.device_id
+
+    Edgehog.Astarte.Device.ForwarderSessionMock
+    |> expect(:fetch_session, fn _appengine_client, ^device_id, ^session_token ->
+      if forwarder_session != nil do
+        {:ok, forwarder_session}
+      else
+        {:error, :forwarder_session_not_found}
+      end
+    end)
+  end
+
+  defp run_query(conn, api_path, variables) do
+    conn
+    |> get(api_path, query: @query, variables: variables)
+    |> json_response(200)
+  end
+end

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -118,6 +118,11 @@ defmodule Edgehog.AstarteMockCase do
       Edgehog.Mocks.Astarte.Device.LedBehavior
     )
 
+    Mox.stub_with(
+      Edgehog.Astarte.Device.ForwarderSessionMock,
+      Edgehog.Mocks.Astarte.Device.ForwarderSession
+    )
+
     :ok
   end
 end

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -78,6 +78,10 @@ Mox.defmock(Edgehog.Astarte.Device.LedBehaviorMock,
   for: Edgehog.Astarte.Device.LedBehavior.Behaviour
 )
 
+Mox.defmock(Edgehog.Astarte.Device.ForwarderSessionMock,
+  for: Edgehog.Astarte.Device.ForwarderSession.Behaviour
+)
+
 Mox.defmock(Edgehog.Astarte.Interface.MockDataLayer,
   for: Edgehog.Astarte.Interface.DataLayer
 )

--- a/backend/test/support/mocks/astarte/device/device_status.ex
+++ b/backend/test/support/mocks/astarte/device/device_status.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ defmodule Edgehog.Mocks.Astarte.Device.DeviceStatus do
     {"io.edgehog.devicemanager.BatteryStatus", 0, 1},
     {"io.edgehog.devicemanager.OTARequest", 1, 0},
     {"io.edgehog.devicemanager.OSInfo", 0, 1},
-    {"io.edgehog.devicemanager.NetworkInterfaceProperties", 0, 1}
+    {"io.edgehog.devicemanager.NetworkInterfaceProperties", 0, 1},
+    {"io.edgehog.devicemanager.ForwarderSessionState", 0, 1},
+    {"io.edgehog.devicemanager.ForwarderSessionRequest", 0, 1}
   ]
 
   @impl true

--- a/backend/test/support/mocks/astarte/device/forwarder_session.ex
+++ b/backend/test/support/mocks/astarte/device/forwarder_session.ex
@@ -1,0 +1,77 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Mocks.Astarte.Device.ForwarderSession do
+  @behaviour Edgehog.Astarte.Device.ForwarderSession.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.ForwarderSession
+
+  @forwarder_hostname "localhost"
+  @forwarder_port 4001
+  @secure_sessions? false
+
+  @impl true
+  def list_sessions(%AppEngine{} = _client, _device_id) do
+    sessions = [
+      %ForwarderSession{
+        token: "session_token_1",
+        status: :connecting,
+        secure: @secure_sessions?,
+        forwarder_hostname: @forwarder_hostname,
+        forwarder_port: @forwarder_port
+      },
+      %ForwarderSession{
+        token: "session_token_2",
+        status: :connected,
+        secure: @secure_sessions?,
+        forwarder_hostname: @forwarder_hostname,
+        forwarder_port: @forwarder_port
+      }
+    ]
+
+    {:ok, sessions}
+  end
+
+  @impl true
+  def fetch_session(%AppEngine{} = _client, _device_id, session_token) do
+    session = %ForwarderSession{
+      token: session_token,
+      status: :connected,
+      secure: @secure_sessions?,
+      forwarder_hostname: @forwarder_hostname,
+      forwarder_port: @forwarder_port
+    }
+
+    {:ok, session}
+  end
+
+  @impl true
+  def request_session(
+        %AppEngine{} = _client,
+        _device_id,
+        _session_token,
+        _forwarder_hostname,
+        _forwarder_port,
+        _forwarder_secure_sessions?
+      ) do
+    :ok
+  end
+end

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -24,7 +24,7 @@ defmodule Doc.MixProject do
   def project do
     [
       app: :doc,
-      version: "0.8.0-dev",
+      version: "0.9.0-dev",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -51,9 +51,11 @@ defmodule Doc.MixProject do
         "OTA Updates": ~r"/ota_updates/",
         Architecture: ~r"/architecture/",
         "Admin Guide": ~r"/admin/",
-        "Integrating with Edgehog": ~r"/integrating/"
+        "Integrating with Edgehog": ~r"/integrating/",
+        Tutorials: ~r"/tutorials/"
       ],
-      groups_for_modules: []
+      groups_for_modules: [],
+      javascript_config_path: "../versions.js"
     ]
   end
 
@@ -74,6 +76,7 @@ defmodule Doc.MixProject do
       "pages/ota_updates/update_channels.md",
       "pages/ota_updates/update_campaigns.md",
       "pages/ota_updates/ota_updates.md",
+      "pages/tutorials/edgehog_in_5_minutes.md",
       "pages/architecture/overview.md",
       "pages/integrating/interacting_with_edgehog.md",
       "pages/integrating/astarte_interfaces.md",

--- a/doc/pages/admin/deploying_with_kubernetes.md
+++ b/doc/pages/admin/deploying_with_kubernetes.md
@@ -81,10 +81,9 @@ Controllers are outside the scope of this guide.
 
 Once you have the Load Balancer IP (obtained in the [previous
 step](#installing-nginx-ingress-controller-and-cert-manager-example)), head to your DNS provider and
-point two domains (one for the backend and one for the frontend) to that IP address.
+point three domains (one for the backend, one for the frontend, and one for the [Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder)) to that IP address.
 
-Save the two hosts (e.g. `api.edgehog.example.com` and `edgehog.example.com`) since they're going to
-be needed for the following steps.
+Save the three hosts (e.g. `api.edgehog.example.com`, `edgehog.example.com`, and `forwarder.edgehog.example.com`) since they're going to be needed for the following steps.
 
 ### Secrets
 
@@ -108,10 +107,17 @@ Values to be replaced
 
 #### Secret key base
 
-This command creates the secret key base used by Phoenix:
+This command creates the secret key base used by Phoenix for the backend:
 
 ```bash
 $ kubectl create secret generic -n edgehog edgehog-secret-key-base \
+  --from-literal="secret-key-base=$(openssl rand -base64 48)"
+```
+
+Another secret key base can be generated for the device forwarder:
+
+```bash
+$ kubectl create secret generic -n edgehog edgehog-device-forwarder-secret-key-base \
   --from-literal="secret-key-base=$(openssl rand -base64 48)"
 ```
 
@@ -341,6 +347,12 @@ spec:
           value: <S3-ASSET-HOST>
         - name: S3_REGION
           value: <S3-REGION>
+        - name: EDGEHOG_FORWARDER_HOSTNAME
+          value: <EDGEHOG-FORWARDER-HOSTNAME>
+        - name: EDGEHOG_FORWARDER_PORT
+          value: <EDGEHOG-FORWARDER-PORT>
+        - name: EDGEHOG_FORWARDER_SECURE_SESSIONS
+          value: <EDGEHOG-FORWARDER-SECURE-SESSIONS>
         image: edgehogdevicemanager/edgehog-backend:snapshot
         imagePullPolicy: Always
         name: edgehog-backend
@@ -364,6 +376,9 @@ Values to be replaced
 - `S3-ASSET-HOST`: the asset host for the S3 storage, e.g. `storage.googleapis.com/<S3-BUCKET>` for
   GCP or `<S3-BUCKET>.s3.amazonaws.com` for AWS.
 - `S3-REGION`: the region where the S3 storage resides.
+- `EDGEHOG-FORWARDER-HOSTNAME`: the host for the instance of [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It should only contain the hostname without the `http://` or `https://` scheme.
+- `EDGEHOG-FORWARDER-PORT`: the port for the instance of [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It defaults to `443`.
+- `EDGEHOG-FORWARDER-SECURE-SESSIONS`: either `true` or `false`, indicates whether devices use TLS to connect to the [Edgehog Device Forwarder](https://github.com/edgehog-device-manager/edgehog_device_forwarder). It defaults to `true`.
 
 The optional env variable in the `yaml` also have to be uncommented where relevant (see comments
 above the commented blocks for more information).
@@ -411,6 +426,58 @@ spec:
 Values to be replaced
 - `BACKEND-URL`: the API base URL of the Edgehog backend (see the [Creating DNS
   entries](#creating-dns-entries) section). This should be, e.g., `https://<BACKEND-HOST>`.
+
+#### Device Forwarder
+
+To deploy the device forwarder, copy the following `yaml` snippet in `device-forwarder-deployment.yaml`, fill the
+missing values (detailed below) and execute
+
+```bash
+$ kubectl apply -f device-forwarder-deployment.yaml
+```
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: edgehog-device-forwarder
+  name: edgehog-device-forwarder
+  namespace: edgehog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edgehog-device-forwarder
+  template:
+    metadata:
+      labels:
+        app: edgehog-device-forwarder
+    spec:
+      containers:
+      - env:
+        - name: RELEASE_NAME
+          value: edgehog-device-forwarder
+        - name: PORT
+          value: "4000"
+        - name: PHX_HOST
+          value: <DEVICE-FORWARDER-HOST>
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              key: secret-key-base
+              name: edgehog-device-forwarder-secret-key-base
+        image: edgehogdevicemanager/edgehog-device-forwarder:0.1.0
+        imagePullPolicy: Always
+        name: edgehog-device-forwarder
+        ports:
+        - containerPort: 4000
+          name: http
+          protocol: TCP
+```
+
+Values to be replaced
+- `DEVICE-FORWARDER-HOST`: the host of the Edgehog Device Forwarder (see the [Creating DNS entries](#creating-dns-entries) section).
 
 ### Services
 
@@ -464,6 +531,32 @@ spec:
     targetPort: 80
   selector:
     app: edgehog-frontend
+```
+
+#### Device Forwarder
+
+To deploy the device forwarder service, copy the following `yaml` snippet in `device-forwarder-service.yaml` and
+execute
+
+```bash
+$ kubectl apply -f device-forwarder-service.yaml
+```
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: edgehog-device-forwarder
+  name: edgehog-device-forwarder
+  namespace: edgehog
+spec:
+  ports:
+  - port: 4000
+    protocol: TCP
+    targetPort: 4000
+  selector:
+    app: edgehog-device-forwarder
 ```
 
 ### Exposing Edgehog to the Internet
@@ -520,6 +613,7 @@ spec:
   dnsNames:
   - <FRONTEND-HOST>
   - <BACKEND-HOST>
+  - <DEVICE-FORWARDER-HOST>
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
@@ -529,6 +623,7 @@ spec:
 Values to be replaced
 - `FRONTEND-HOST`: the frontend host.
 - `BACKEND-HOST`: the backend host.
+- `DEVICE-FORWARDER-HOST`: the device forwarder host.
 
 Note that this step must be performed after DNS for the frontend and backend hosts are correctly
 propagated (see [Creating DNS Entries](#creating-dns-entries)).
@@ -553,6 +648,8 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: <MAX-UPLOAD-SIZE>
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "120"
   name: edgehog-ingress
   namespace: edgehog
 spec:
@@ -577,21 +674,38 @@ spec:
               number: 4000
         path: /
         pathType: Prefix
+  - host: <DEVICE-FORWARDER-HOST>
+    http:
+      paths:
+      - backend:
+          service:
+            name: edgehog-device-forwarder
+            port:
+              number: 4000
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - <FRONTEND-HOST>
     - <BACKEND-HOST>
+    - <DEVICE-FORWARDER-HOST>
     secretName: tls-secret
 ```
 
 Values to be replaced
 - `FRONTEND-HOST`: the frontend host.
 - `BACKEND-HOST`: the backend host.
+- `DEVICE-FORWARDER-HOST`: the device forwarder host.
 - `MAX-UPLOAD-SIZE`: the maximum upload size that you defined in the [Edgehog backend
   deployment](https://edgehog-device-manager.github.io/docs/snapshot/deploying_with_kubernetes.html#deployments).
   Note that NGINX accepts also size suffixes, so you can put, e.g., `4G` for 4 gigabytes. Also note
   that, differently from the value in the Deployment, this is required because NGINX default is 1
   megabyte.
+
+Note that we are setting `proxy-read-timeout` and `proxy-send-timeout` to 120 seconds.
+This value represents the timeout after which inactive connections are terminated.
+This configuration has implications on the inactive sessions of the Device Forwarder: the forwarder has its own default timeout of 1 minute for terminating inactive WebSocket connections, and setting a lower timeout here would conflict with the forwarder's internal processes. For this reason, we leave that responsibility to the forwarder by setting a slightly higher timeout here, such as 2 minutes.
+When changing the value, one should also evaluate the implications on connections to Edgehog's frontend and backend. In addition, higher values may lead to higher risk of DoS attacks. 
 
 ## Edgehog Initialization
 

--- a/doc/pages/tutorials/edgehog_in_5_minutes.md
+++ b/doc/pages/tutorials/edgehog_in_5_minutes.md
@@ -1,0 +1,158 @@
+<!---
+  Copyright 2023 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Edgehog in 5 minutes
+
+## Prerequisite: setup your local Astarte instance
+
+You need a working astarte instance for edgehog to connect to. If you don't already have one, the
+easiest way is by following the [Astarte in 5 minutes](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html)
+guide, up until the creation of a `test` realm.
+
+To make sure your astarte instance is working and up to date, try running this command:
+
+```sh
+$ curl api.astarte.localhost &> /dev/null && echo 'Connected!' || echo 'Astarte is unreachable'
+```
+
+If you get "Astarte is unreachable", make sure your running astarte version is >= v1.1.0
+
+## Run a local Edgehog instance
+
+To setup edgehog, you must first clone a copy of edgehog locally
+
+```sh
+$ git clone https://github.com/edgehog-device-manager/edgehog && cd edgehog
+```
+
+You can then run edgehog with
+
+```sh
+$ docker-compose up -d
+```
+
+Try navigating to `http://edgehog.localhost`: you should be presented with a login screen!
+
+## Setup the environment
+
+> If you just want to try out Edgehog, you can jump to
+> [the next section](#populate-the-database-and-log-in-to-edgehog).
+> Astarte communication will not work this way though.
+
+Open the `.env` file in your favorite text editor.
+Here you can edit docker's variables to match your current environment.
+Right now we're only interested in the `SEEDS_*` variables, which are used to populate the database.
+
+| Variable                        | Description                                                                                           |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `SEEDS_REALM`                   | The name of your astarte realm. It should match what you've created in your astarte setup             |
+| `SEEDS_REALM_PRIVATE_KEY_FILE`  | The location of the realm's private key file (`test_private.pem` from the Astarte in 5 minutes guide) |
+| `SEEDS_TENANT_PRIVATE_KEY_FILE` | The location of the [tenant's private key file](#generate-a-key-pair-for-the-tenant)                  |
+| `SEEDS_ASTARTE_BASE_API_URL`    | The endpoint for Astarte API.                                                                         |
+
+If for whatever reason you don't want to edit the `.env` file, you can also export
+environment variables of the same name.
+
+`SEEDS_REALM` and `SEEDS_ASTARTE_BASE_API_URL` should already be set for you, so only edit those if
+needed.
+
+### Generate a key pair for the tenant
+
+Although it is possible to use a default key, it is recommended to have your own key pair for the
+tenant.
+
+You should already have [`astartectl`](https://github.com/astarte-platform/astartectl#installation)
+installed from the Astarte in 5 minutes guide.
+
+```sh
+$ astartectl utils gen-keypair acme
+```
+
+**Remember to update** the `.env` file with the `acme_private.pem` location!
+
+## Populate the database and log in to Edgehog
+
+Run this command to populate the database
+
+```sh
+$ docker-compose exec edgehog-backend bin/edgehog eval Edgehog.Release.seed
+```
+
+This will create the tenant `acme-inc` and add a sample device to it.
+
+> _"I had the wrong variables set, and now I can't run the seed again. What now?"_
+> If this happens, the easiest solution is to just recreate the edgehog volumes:
+>
+> ```sh
+> $ docker-compose down -v && docker-compose up -d
+> ```
+
+Nice! Now we have our tenant but we can't access to it yet, we need a token.
+Luckily Edgehog includes a scripts to generate one!
+
+First you'll need to make sure to have python version 3 installed.
+
+```sh
+$ python3 --version
+Python 3.x.y
+```
+
+> While not mandatory, it is advised to use a python virtual environment to make sure your
+> globally installed python packages don't mess with this script's dependencies and vice versa.
+> Doing this is pretty straightforward, but you may need to install the `python3-venv` package if
+> you are using a Debian/Ubuntu-based system.
+>
+> ```sh
+> $ python3 -m venv pyenv
+> $ source pyenv/bin/activate
+> ```
+
+Then, navigate to the `tools/` subdirectory and install the required dependencies
+
+```sh
+$ cd tools && pip install -r requirements.txt
+```
+
+Now you can generate the login token with
+
+```sh
+$ ./gen-edgehog-jwt -k ../acme_private.pem
+```
+
+> If in the previous section you had decided not to use a custom key, use this command instead
+>
+> ```sh
+> $ ./gen-edgehog-jwt -k ../backend/priv/repo/seeds/keys/tenant_private.pem
+> ```
+
+You can finally navigate to `http://edgehog.localhost` in your browser and login to the
+`acme-inc` tenant using your newly generated token.
+
+## Test Astarte connection
+
+Astarte connectivity may not work right away, as edgehog has not yet reconciled
+its interfaces and triggers with astarte. Without waiting, we can force it to execute
+the reconciler using:
+
+```sh
+$ docker compose exec edgehog-backend bin/edgehog rpc "Edgehog.Tenants.list_tenants |> Enum.each(&Edgehog.Tenants.reconcile_tenant/1)"
+```
+
+If you now connect a device to astarte and open or reload the edgehog web page,
+you should see the new device in the appropriate section.
+
+> You can use [stream-qt5-test](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html#stream-data).
+> If you do so the device won't have any edgehog interface, but it will still show up as connected.
+
+## Cleaning up
+
+As with astarte, you can clean your environment by running
+
+```sh
+$ docker-compose down
+```
+
+to stop all the running edgehog containers.

--- a/doc/versions.js
+++ b/doc/versions.js
@@ -1,0 +1,14 @@
+var versionNodes = [
+  {
+    version: "v0.9.0-dev",
+    url: "https://docs.edgehog.io/snapshot"
+  },
+  {
+    version: "v0.8.0-rc.0",
+    url: "https://docs.edgehog.io/0.8"
+  },
+  {
+    version: "v0.7.1",
+    url: "https://docs.edgehog.io/0.7"
+  }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,8 +43,9 @@ services:
       SEEDS_TENANT_PRIVATE_KEY_FILE: /keys/tenant_private.pem
       SEEDS_REALM_ORIGINAL_FILE: ${SEEDS_REALM_PRIVATE_KEY_FILE}
       SEEDS_TENANT_ORIGINAL_FILE: ${SEEDS_TENANT_PRIVATE_KEY_FILE}
-    ports:
-      - 4000:4000
+      URL_HOST: edgehog-backend
+      URL_PORT: 4000
+      URL_SCHEME: http
     restart: on-failure
     volumes:
       - type: bind
@@ -57,28 +58,45 @@ services:
       - postgresql
       - minio
       - minio-init
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.edgehog-backend.rule=Host(`api.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-backend.entrypoints=web"
+      - "traefik.http.routers.edgehog-backend.service=edgehog-backend"
+      - "traefik.http.services.edgehog-backend.loadbalancer.server.port=4000"
 
   edgehog-frontend:
     image: edgehogdevicemanager/edgehog-frontend:snapshot
     build:
       context: frontend
     environment:
-      BACKEND_URL: http://localhost:4000/
-    ports:
-      - 8080:80
+      BACKEND_URL: http://api.edgehog.localhost/
     restart: on-failure
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.edgehog-frontend.rule=Host(`edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-frontend.entrypoints=web"
+      - "traefik.http.routers.edgehog-frontend.service=edgehog-frontend"
+      - "traefik.http.services.edgehog-frontend.loadbalancer.server.port=80"
 
   minio:
     image: minio/minio:RELEASE.2023-01-18T04-36-38Z
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     volumes:
       - "minio-data-v2:/data"
     environment:
       MINIO_ROOT_USER: "minioadmin"
       MINIO_ROOT_PASSWORD: "minioadmin"
     command: server --console-address ":9001" /data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.edgehog-minio-storage.rule=Host(`minio-storage.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-minio-storage.entrypoints=web"
+      - "traefik.http.routers.edgehog-minio-storage.service=edgehog-minio-storage"
+      - "traefik.http.services.edgehog-minio-storage.loadbalancer.server.port=9000"
+      - "traefik.http.routers.edgehog-minio-console.rule=Host(`minio.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-minio-console.entrypoints=web"
+      - "traefik.http.routers.edgehog-minio-console.service=edgehog-minio-console"
+      - "traefik.http.services.edgehog-minio-console.loadbalancer.server.port=9001"
 
   minio-init:
     image: minio/mc:RELEASE.2023-01-11T03-14-16Z
@@ -101,3 +119,4 @@ volumes:
 networks:
   default:
     name: astarte
+    external: true


### PR DESCRIPTION
Skip frontend changes, they will be handled in a separate PR.
Also, skip the tenant cleanup changes, they will be reimplemented with Ash separately.