### PR TITLE
realm: add a specific action for global reads

### DIFF
--- a/backend/lib/edgehog/astarte/realm/realm.ex
+++ b/backend/lib/edgehog/astarte/realm/realm.ex
@@ -34,6 +34,10 @@ defmodule Edgehog.Astarte.Realm do
   actions do
     defaults [:read, :destroy]
 
+    read :global do
+      multitenancy :allow_global
+    end
+
     read :by_name do
       get_by :name
     end
@@ -84,12 +88,6 @@ defmodule Edgehog.Astarte.Realm do
   validations do
     validate Validations.realm_name(:name)
     validate {Validations.PEMPrivateKey, attribute: :private_key}
-  end
-
-  multitenancy do
-    # This is needed when we batch load realms starting from Tenants in the Reconciler
-    # TODO: should we ensure that a tenant is passed in all other queries?
-    global? true
   end
 
   postgres do

--- a/backend/test/edgehog/tenants_test.exs
+++ b/backend/test/edgehog/tenants_test.exs
@@ -175,7 +175,7 @@ defmodule Edgehog.TenantsTest do
                default_locale: ^tenant_default_locale
              } = tenant
 
-      tenant = Ash.load!(tenant, realm: [:cluster])
+      tenant = Ash.load!(tenant, [realm: [:cluster]], tenant: tenant)
 
       assert tenant.realm.cluster.base_api_url == attrs.astarte_config.base_api_url
       assert tenant.realm.name == attrs.astarte_config.realm_name

--- a/backend/test/edgehog_web/admin_api/tenants/tenant_test.exs
+++ b/backend/test/edgehog_web/admin_api/tenants/tenant_test.exs
@@ -85,7 +85,7 @@ defmodule EdgehogWeb.AdminAPI.Tenants.TenantTest do
                default_locale: ^tenant_default_locale
              } = tenant
 
-      tenant = Ash.load!(tenant, realm: [:cluster])
+      tenant = Ash.load!(tenant, [realm: [:cluster]], tenant: tenant)
 
       assert %Astarte.Realm{
                name: ^realm_name,


### PR DESCRIPTION
Instead of making the resource global, leverage the new multitenancy option to provide a single global read action and use it only in the reconciler. Add all the missing tenants where needed.
Fix #492

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
