### PR TITLE
[frontend] Refactor page/form components with Relay fragments

### DIFF
--- a/frontend/src/forms/CreateBaseImage.tsx
+++ b/frontend/src/forms/CreateBaseImage.tsx
@@ -21,6 +21,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
 import Button from "components/Button";
@@ -35,13 +36,25 @@ import {
   baseImageStartingVersionRequirementSchema,
   yup,
 } from "forms";
-import { graphql, useFragment } from "react-relay/hooks";
-import type { CreateBaseImage_BaseImageCollectionFragment$key } from "api/__generated__/CreateBaseImage_BaseImageCollectionFragment.graphql";
+
+import type {
+  CreateBaseImage_BaseImageCollectionFragment$key,
+  CreateBaseImage_BaseImageCollectionFragment$data,
+} from "api/__generated__/CreateBaseImage_BaseImageCollectionFragment.graphql";
+import type { CreateBaseImage_OptionsFragment$key } from "api/__generated__/CreateBaseImage_OptionsFragment.graphql";
 
 const CREATE_BASE_IMAGE_FRAGMENT = graphql`
   fragment CreateBaseImage_BaseImageCollectionFragment on BaseImageCollection {
     id
     name
+  }
+`;
+
+const CREATE_BASE_IMAGE_OPTIONS_FRAGMENT = graphql`
+  fragment CreateBaseImage_OptionsFragment on RootQueryType {
+    tenantInfo {
+      defaultLocale
+    }
   }
 `;
 
@@ -98,7 +111,7 @@ const baseImageSchema = yup
   .required();
 
 const transformInputData = (
-  baseImageCollection: BaseImageCollection,
+  baseImageCollection: CreateBaseImage_BaseImageCollectionFragment$data,
 ): FormData => ({
   baseImageCollection: baseImageCollection.name,
   file: null,
@@ -113,7 +126,7 @@ type FormOutput = FormData & {
 };
 
 const transformOutputData = (
-  baseImageCollection: BaseImageCollection,
+  baseImageCollection: CreateBaseImage_BaseImageCollectionFragment$data,
   locale: string,
   data: FormOutput,
 ): BaseImageData => ({
@@ -131,21 +144,16 @@ const transformOutputData = (
   },
 });
 
-type BaseImageCollection = {
-  id: string;
-  name: string;
-};
-
 type Props = {
   baseImageCollectionRef: CreateBaseImage_BaseImageCollectionFragment$key;
-  locale: string;
+  optionsRef: CreateBaseImage_OptionsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: BaseImageData) => void;
 };
 
 const CreateBaseImageForm = ({
   baseImageCollectionRef,
-  locale,
+  optionsRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
@@ -153,6 +161,10 @@ const CreateBaseImageForm = ({
     CREATE_BASE_IMAGE_FRAGMENT,
     baseImageCollectionRef,
   );
+  const {
+    tenantInfo: { defaultLocale: locale },
+  } = useFragment(CREATE_BASE_IMAGE_OPTIONS_FRAGMENT, optionsRef);
+
   const {
     register,
     handleSubmit,

--- a/frontend/src/forms/CreateBaseImage.tsx
+++ b/frontend/src/forms/CreateBaseImage.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,15 @@ import {
   baseImageStartingVersionRequirementSchema,
   yup,
 } from "forms";
+import { graphql, useFragment } from "react-relay/hooks";
+import type { CreateBaseImage_BaseImageCollectionFragment$key } from "api/__generated__/CreateBaseImage_BaseImageCollectionFragment.graphql";
+
+const CREATE_BASE_IMAGE_FRAGMENT = graphql`
+  fragment CreateBaseImage_BaseImageCollectionFragment on BaseImageCollection {
+    id
+    name
+  }
+`;
 
 const FormRow = ({
   id,
@@ -128,25 +137,29 @@ type BaseImageCollection = {
 };
 
 type Props = {
-  baseImageCollection: BaseImageCollection;
+  baseImageCollectionRef: CreateBaseImage_BaseImageCollectionFragment$key;
   locale: string;
   isLoading?: boolean;
   onSubmit: (data: BaseImageData) => void;
 };
 
 const CreateBaseImageForm = ({
-  baseImageCollection,
+  baseImageCollectionRef,
   locale,
   isLoading = false,
   onSubmit,
 }: Props) => {
+  const baseImageCollectionData = useFragment(
+    CREATE_BASE_IMAGE_FRAGMENT,
+    baseImageCollectionRef,
+  );
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<FormData>({
     mode: "onTouched",
-    defaultValues: transformInputData(baseImageCollection),
+    defaultValues: transformInputData(baseImageCollectionData),
     resolver: yupResolver(baseImageSchema),
   });
 
@@ -156,7 +169,9 @@ const CreateBaseImageForm = ({
         ...data,
         file: data.file,
       };
-      onSubmit(transformOutputData(baseImageCollection, locale, baseImageData));
+      onSubmit(
+        transformOutputData(baseImageCollectionData, locale, baseImageData),
+      );
     }
   };
 

--- a/frontend/src/forms/CreateBaseImageCollection.tsx
+++ b/frontend/src/forms/CreateBaseImageCollection.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { baseImageCollectionHandleSchema, yup } from "forms";
+import { graphql, useFragment } from "react-relay";
+import type { CreateBaseImageCollection_SystemModelsFragment$key } from "api/__generated__/CreateBaseImageCollection_SystemModelsFragment.graphql";
+
+const CREATE_BASE_IMAGE_COLLECTION_FRAGMENT = graphql`
+  fragment CreateBaseImageCollection_SystemModelsFragment on SystemModel
+  @relay(plural: true) {
+    id
+    name
+  }
+`;
 
 const FormRow = ({
   id,
@@ -68,23 +78,22 @@ const initialData: BaseImageCollectionData = {
   systemModelId: "",
 };
 
-type SystemModelOption = {
-  id: string;
-  name: string;
-};
-
 type Props = {
-  systemModels: SystemModelOption[];
+  systemModelsRef: CreateBaseImageCollection_SystemModelsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: BaseImageCollectionData) => void;
 };
 
 const CreateBaseImageCollectionForm = ({
-  systemModels,
+  systemModelsRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
   const intl = useIntl();
+  const systemModelsData = useFragment(
+    CREATE_BASE_IMAGE_COLLECTION_FRAGMENT,
+    systemModelsRef,
+  );
   const {
     register,
     handleSubmit,
@@ -149,7 +158,7 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select a System Model",
               })}
             </option>
-            {systemModels.map((systemModelOption) => (
+            {systemModelsData.map((systemModelOption) => (
               <option key={systemModelOption.id} value={systemModelOption.id}>
                 {systemModelOption.name}
               </option>

--- a/frontend/src/forms/CreateBaseImageCollection.tsx
+++ b/frontend/src/forms/CreateBaseImageCollection.tsx
@@ -21,6 +21,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { FormattedMessage, useIntl } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
 import Button from "components/Button";
@@ -30,14 +31,15 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { baseImageCollectionHandleSchema, yup } from "forms";
-import { graphql, useFragment } from "react-relay";
-import type { CreateBaseImageCollection_SystemModelsFragment$key } from "api/__generated__/CreateBaseImageCollection_SystemModelsFragment.graphql";
+
+import type { CreateBaseImageCollection_OptionsFragment$key } from "api/__generated__/CreateBaseImageCollection_OptionsFragment.graphql";
 
 const CREATE_BASE_IMAGE_COLLECTION_FRAGMENT = graphql`
-  fragment CreateBaseImageCollection_SystemModelsFragment on SystemModel
-  @relay(plural: true) {
-    id
-    name
+  fragment CreateBaseImageCollection_OptionsFragment on RootQueryType {
+    systemModels {
+      id
+      name
+    }
   }
 `;
 
@@ -79,20 +81,20 @@ const initialData: BaseImageCollectionData = {
 };
 
 type Props = {
-  systemModelsRef: CreateBaseImageCollection_SystemModelsFragment$key;
+  optionsRef: CreateBaseImageCollection_OptionsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: BaseImageCollectionData) => void;
 };
 
 const CreateBaseImageCollectionForm = ({
-  systemModelsRef,
+  optionsRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
   const intl = useIntl();
-  const systemModelsData = useFragment(
+  const { systemModels } = useFragment(
     CREATE_BASE_IMAGE_COLLECTION_FRAGMENT,
-    systemModelsRef,
+    optionsRef,
   );
   const {
     register,
@@ -158,9 +160,9 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select a System Model",
               })}
             </option>
-            {systemModelsData.map((systemModelOption) => (
-              <option key={systemModelOption.id} value={systemModelOption.id}>
-                {systemModelOption.name}
+            {systemModels.map((systemModel) => (
+              <option key={systemModel.id} value={systemModel.id}>
+                {systemModel.name}
               </option>
             ))}
           </Form.Select>

--- a/frontend/src/forms/CreateSystemModel.tsx
+++ b/frontend/src/forms/CreateSystemModel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2023 SECO Mind Srl
+  Copyright 2021-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,6 +33,16 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { systemModelHandleSchema, messages, yup } from "forms";
+import { graphql, useFragment } from "react-relay/hooks";
+import type { CreateSystemModel_HardwareTypeFragment$key } from "api/__generated__/CreateSystemModel_HardwareTypeFragment.graphql";
+
+const CREATE_SYSTEM_MODEL_FRAGMENT = graphql`
+  fragment CreateSystemModel_HardwareTypeFragment on HardwareType
+  @relay(plural: true) {
+    id
+    name
+  }
+`;
 
 const FormRow = ({
   id,
@@ -135,25 +145,25 @@ const initialData: FormData = {
   partNumbers: [{ value: "" }],
 };
 
-type HardwareTypeOption = {
-  id: string;
-  name: string;
-};
-
 type Props = {
-  hardwareTypes: HardwareTypeOption[];
+  hardwareTypesRef: CreateSystemModel_HardwareTypeFragment$key;
   locale: string;
   isLoading?: boolean;
   onSubmit: (data: SystemModelChanges) => void;
 };
 
 const CreateSystemModelForm = ({
-  hardwareTypes,
+  hardwareTypesRef,
   locale,
   isLoading = false,
   onSubmit,
 }: Props) => {
   const intl = useIntl();
+  const hardwareTypesData = useFragment(
+    CREATE_SYSTEM_MODEL_FRAGMENT,
+    hardwareTypesRef,
+  );
+
   const {
     control,
     register,
@@ -291,7 +301,7 @@ const CreateSystemModelForm = ({
                       defaultMessage: "Select a Hardware Type",
                     })}
                   </option>
-                  {hardwareTypes.map((hardwareTypeOption) => (
+                  {hardwareTypesData.map((hardwareTypeOption) => (
                     <option
                       key={hardwareTypeOption.id}
                       value={hardwareTypeOption.id}

--- a/frontend/src/forms/CreateSystemModel.tsx
+++ b/frontend/src/forms/CreateSystemModel.tsx
@@ -21,6 +21,7 @@
 import React, { useCallback } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { FormattedMessage, useIntl } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
 import Button from "components/Button";
@@ -33,14 +34,18 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { systemModelHandleSchema, messages, yup } from "forms";
-import { graphql, useFragment } from "react-relay/hooks";
-import type { CreateSystemModel_HardwareTypeFragment$key } from "api/__generated__/CreateSystemModel_HardwareTypeFragment.graphql";
+
+import type { CreateSystemModel_OptionsFragment$key } from "api/__generated__/CreateSystemModel_OptionsFragment.graphql";
 
 const CREATE_SYSTEM_MODEL_FRAGMENT = graphql`
-  fragment CreateSystemModel_HardwareTypeFragment on HardwareType
-  @relay(plural: true) {
-    id
-    name
+  fragment CreateSystemModel_OptionsFragment on RootQueryType {
+    hardwareTypes {
+      id
+      name
+    }
+    tenantInfo {
+      defaultLocale
+    }
   }
 `;
 
@@ -146,23 +151,21 @@ const initialData: FormData = {
 };
 
 type Props = {
-  hardwareTypesRef: CreateSystemModel_HardwareTypeFragment$key;
-  locale: string;
+  optionsRef: CreateSystemModel_OptionsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: SystemModelChanges) => void;
 };
 
 const CreateSystemModelForm = ({
-  hardwareTypesRef,
-  locale,
+  optionsRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
   const intl = useIntl();
-  const hardwareTypesData = useFragment(
-    CREATE_SYSTEM_MODEL_FRAGMENT,
-    hardwareTypesRef,
-  );
+  const {
+    hardwareTypes,
+    tenantInfo: { defaultLocale: locale },
+  } = useFragment(CREATE_SYSTEM_MODEL_FRAGMENT, optionsRef);
 
   const {
     control,
@@ -301,12 +304,9 @@ const CreateSystemModelForm = ({
                       defaultMessage: "Select a Hardware Type",
                     })}
                   </option>
-                  {hardwareTypesData.map((hardwareTypeOption) => (
-                    <option
-                      key={hardwareTypeOption.id}
-                      value={hardwareTypeOption.id}
-                    >
-                      {hardwareTypeOption.name}
+                  {hardwareTypes.map((hardwareType) => (
+                    <option key={hardwareType.id} value={hardwareType.id}>
+                      {hardwareType.name}
                     </option>
                   ))}
                 </Form.Select>

--- a/frontend/src/forms/CreateUpdateChannel.tsx
+++ b/frontend/src/forms/CreateUpdateChannel.tsx
@@ -31,6 +31,19 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { updateChannelHandleSchema, yup, messages } from "forms";
+import { graphql, useFragment } from "react-relay/hooks";
+import type { CreateUpdateChannel_DeviceGroupFragment$key } from "api/__generated__/CreateUpdateChannel_DeviceGroupFragment.graphql";
+
+const CREATE_UPDATE_CHANNEL_FRAGMENT = graphql`
+  fragment CreateUpdateChannel_DeviceGroupFragment on DeviceGroup
+  @relay(plural: true) {
+    id
+    name
+    updateChannel {
+      name
+    }
+  }
+`;
 
 const FormRow = ({
   id,
@@ -116,16 +129,20 @@ const transformOutputData = ({
 });
 
 type Props = {
-  targetGroups: ReadonlyArray<TargetGroup>;
+  targetGroupsRef: CreateUpdateChannel_DeviceGroupFragment$key;
   isLoading?: boolean;
   onSubmit: (data: UpdateChannelData) => void;
 };
 
 const CreateUpdateChannel = ({
+  targetGroupsRef,
   isLoading = false,
-  targetGroups,
   onSubmit,
 }: Props) => {
+  const targetGroups = useFragment(
+    CREATE_UPDATE_CHANNEL_FRAGMENT,
+    targetGroupsRef,
+  );
   const {
     register,
     handleSubmit,

--- a/frontend/src/forms/CreateUpdateChannel.tsx
+++ b/frontend/src/forms/CreateUpdateChannel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,15 +32,16 @@ import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { updateChannelHandleSchema, yup, messages } from "forms";
 import { graphql, useFragment } from "react-relay/hooks";
-import type { CreateUpdateChannel_DeviceGroupFragment$key } from "api/__generated__/CreateUpdateChannel_DeviceGroupFragment.graphql";
+import type { CreateUpdateChannel_OptionsFragment$key } from "api/__generated__/CreateUpdateChannel_OptionsFragment.graphql";
 
-const CREATE_UPDATE_CHANNEL_FRAGMENT = graphql`
-  fragment CreateUpdateChannel_DeviceGroupFragment on DeviceGroup
-  @relay(plural: true) {
-    id
-    name
-    updateChannel {
+const CREATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT = graphql`
+  fragment CreateUpdateChannel_OptionsFragment on RootQueryType {
+    deviceGroups {
+      id
       name
+      updateChannel {
+        name
+      }
     }
   }
 `;
@@ -129,19 +130,19 @@ const transformOutputData = ({
 });
 
 type Props = {
-  targetGroupsRef: CreateUpdateChannel_DeviceGroupFragment$key;
+  queryRef: CreateUpdateChannel_OptionsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: UpdateChannelData) => void;
 };
 
 const CreateUpdateChannel = ({
-  targetGroupsRef,
+  queryRef,
   isLoading = false,
   onSubmit,
 }: Props) => {
-  const targetGroups = useFragment(
-    CREATE_UPDATE_CHANNEL_FRAGMENT,
-    targetGroupsRef,
+  const { deviceGroups: targetGroups } = useFragment(
+    CREATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT,
+    queryRef,
   );
   const {
     register,

--- a/frontend/src/forms/UpdateBaseImage.tsx
+++ b/frontend/src/forms/UpdateBaseImage.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,6 +30,22 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { baseImageStartingVersionRequirementSchema, yup } from "forms";
+import { graphql } from "relay-runtime";
+import { useFragment } from "react-relay";
+import type { UpdateBaseImage_BaseImageFragment$key } from "api/__generated__/UpdateBaseImage_BaseImageFragment.graphql";
+
+const UPDATE_BASE_IMAGE_FRAGMENT = graphql`
+  fragment UpdateBaseImage_BaseImageFragment on BaseImage {
+    version
+    url
+    startingVersionRequirement
+    releaseDisplayName
+    description
+    baseImageCollection {
+      name
+    }
+  }
+`;
 
 const FormRow = ({
   id,
@@ -48,16 +64,7 @@ const FormRow = ({
   </Form.Group>
 );
 
-type BaseImageData = {
-  baseImageCollection: {
-    name: string;
-  };
-  version: string;
-  url: string;
-  startingVersionRequirement: string | null;
-  releaseDisplayName: string | null;
-  description: string | null;
-};
+type BaseImageData = UpdateBaseImage_BaseImageFragment$key;
 
 type FormData = {
   baseImageCollection: string;
@@ -103,7 +110,7 @@ const transformOutputData = (
 });
 
 type UpdateBaseImageProps = {
-  baseImage: BaseImageData;
+  baseImageRef: BaseImageData;
   locale: string;
   isLoading?: boolean;
   onSubmit: (data: BaseImageChanges) => void;
@@ -111,21 +118,23 @@ type UpdateBaseImageProps = {
 };
 
 const UpdateBaseImage = ({
-  baseImage,
+  baseImageRef,
   locale,
   isLoading = false,
   onSubmit,
   onDelete,
 }: UpdateBaseImageProps) => {
+  const baseImageData = useFragment(UPDATE_BASE_IMAGE_FRAGMENT, baseImageRef);
   const defaultValues = useMemo(
     () => ({
-      baseImageCollection: baseImage.baseImageCollection.name,
-      version: baseImage.version,
-      startingVersionRequirement: baseImage.startingVersionRequirement || "",
-      releaseDisplayName: baseImage.releaseDisplayName || "",
-      description: baseImage.description || "",
+      baseImageCollection: baseImageData.baseImageCollection.name,
+      version: baseImageData.version,
+      startingVersionRequirement:
+        baseImageData.startingVersionRequirement || "",
+      releaseDisplayName: baseImageData.releaseDisplayName || "",
+      description: baseImageData.description || "",
     }),
-    [baseImage],
+    [baseImageData],
   );
 
   const {
@@ -180,11 +189,11 @@ const UpdateBaseImage = ({
             defaultMessage="<a>{baseImageName}</a>"
             values={{
               a: (chunks: React.ReactNode) => (
-                <a target="_blank" rel="noreferrer" href={baseImage.url}>
+                <a target="_blank" rel="noreferrer" href={baseImageData.url}>
                   {chunks}
                 </a>
               ),
-              baseImageName: baseImage.url.split("/").pop(),
+              baseImageName: baseImageData.url.split("/").pop(),
             }}
           />
         </FormRow>

--- a/frontend/src/forms/UpdateUpdateChannel.tsx
+++ b/frontend/src/forms/UpdateUpdateChannel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 import React, { useCallback, useMemo, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useIntl, FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
 import Button from "components/Button";
@@ -31,6 +32,44 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { updateChannelHandleSchema, yup, messages } from "forms";
+
+import type {
+  UpdateUpdateChannel_UpdateChannelFragment$key,
+  UpdateUpdateChannel_UpdateChannelFragment$data,
+} from "api/__generated__/UpdateUpdateChannel_UpdateChannelFragment.graphql";
+import type {
+  UpdateUpdateChannel_OptionsFragment$key,
+  UpdateUpdateChannel_OptionsFragment$data,
+} from "api/__generated__/UpdateUpdateChannel_OptionsFragment.graphql";
+
+const UPDATE_UPDATE_CHANNEL_FRAGMENT = graphql`
+  fragment UpdateUpdateChannel_UpdateChannelFragment on UpdateChannel {
+    id
+    name
+    handle
+    targetGroups {
+      id
+      name
+      updateChannel {
+        id
+        name
+      }
+    }
+  }
+`;
+
+const UPDATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT = graphql`
+  fragment UpdateUpdateChannel_OptionsFragment on RootQueryType {
+    deviceGroups {
+      id
+      name
+      updateChannel {
+        id
+        name
+      }
+    }
+  }
+`;
 
 const FormRow = ({
   id,
@@ -69,23 +108,14 @@ const TargetGroupsErrors = ({ errors }: { errors: unknown }) => {
   return null;
 };
 
-type TargetGroup = {
-  readonly id: string;
-  readonly name: string;
-  readonly updateChannel: {
-    readonly id: string;
-    readonly name: string;
-  } | null;
-};
+type UpdateChannel = Omit<
+  UpdateUpdateChannel_UpdateChannelFragment$data,
+  " $fragmentType"
+>;
+type TargetGroup =
+  UpdateUpdateChannel_OptionsFragment$data["deviceGroups"][number];
 
 const getTargetGroupValue = (targetGroup: TargetGroup) => targetGroup.id;
-
-type UpdateChannel = {
-  id: string;
-  name: string;
-  handle: string;
-  targetGroups: readonly TargetGroup[];
-};
 
 type UpdateChannelData = {
   name: string;
@@ -111,20 +141,30 @@ const transformOutputData = ({
 });
 
 type Props = {
-  updateChannel: UpdateChannel;
-  targetGroups: readonly TargetGroup[];
+  updateChannelRef: UpdateUpdateChannel_UpdateChannelFragment$key;
+  optionsRef: UpdateUpdateChannel_OptionsFragment$key;
   isLoading?: boolean;
   onSubmit: (data: UpdateChannelData) => void;
   onDelete: () => void;
 };
 
 const UpdateUpdateChannel = ({
-  updateChannel,
+  updateChannelRef,
+  optionsRef,
   isLoading = false,
-  targetGroups,
   onSubmit,
   onDelete,
 }: Props) => {
+  const updateChannel = useFragment(
+    UPDATE_UPDATE_CHANNEL_FRAGMENT,
+    updateChannelRef,
+  );
+
+  const { deviceGroups: targetGroups } = useFragment(
+    UPDATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT,
+    optionsRef,
+  );
+
   const {
     register,
     handleSubmit,
@@ -137,9 +177,7 @@ const UpdateUpdateChannel = ({
     resolver: yupResolver(updateChannelSchema),
   });
 
-  useEffect(() => {
-    reset(updateChannel);
-  }, [reset, updateChannel]);
+  useEffect(() => reset(updateChannel), [reset, updateChannel]);
 
   const intl = useIntl();
 

--- a/frontend/src/pages/BaseImage.tsx
+++ b/frontend/src/pages/BaseImage.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -51,14 +51,10 @@ const GET_BASE_IMAGE_QUERY = graphql`
     baseImage(id: $id) {
       id
       version
-      url
-      startingVersionRequirement
-      releaseDisplayName
-      description
       baseImageCollection {
         id
-        name
       }
+      ...UpdateBaseImage_BaseImageFragment
     }
     tenantInfo {
       defaultLocale
@@ -204,7 +200,7 @@ const BaseImageContent = ({ baseImage, locale }: BaseImageContentProps) => {
           {errorFeedback}
         </Alert>
         <UpdateBaseImageForm
-          baseImage={baseImage}
+          baseImageRef={baseImage}
           locale={locale}
           onSubmit={handleUpdateBaseImage}
           onDelete={handleShowDeleteModal}

--- a/frontend/src/pages/BaseImageCollection.tsx
+++ b/frontend/src/pages/BaseImageCollection.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import { FormattedMessage } from "react-intl";
-import _ from "lodash";
 
 import type {
   BaseImageCollection_getBaseImageCollection_Query,
@@ -55,9 +54,7 @@ const GET_BASE_IMAGE_COLLECTION_QUERY = graphql`
       id
       name
       handle
-      systemModel {
-        name
-      }
+      ...UpdateBaseImageCollection_SystemModelFragment
       ...BaseImagesTable_BaseImagesFragment
     }
   }
@@ -215,11 +212,7 @@ const BaseImageCollectionContent = ({
         </Alert>
         <div className="mb-3">
           <UpdateBaseImageCollectionForm
-            initialData={_.pick(baseImageCollection, [
-              "name",
-              "handle",
-              "systemModel",
-            ])}
+            baseImageCollectionRef={baseImageCollection}
             onSubmit={handleUpdateBaseImageCollection}
             onDelete={handleShowDeleteModal}
             isLoading={isUpdatingBaseImageCollection}

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -44,8 +44,7 @@ import { Link, Route, useNavigate } from "Navigation";
 const GET_SYSTEM_MODELS_QUERY = graphql`
   query BaseImageCollectionCreate_getSystemModels_Query {
     systemModels {
-      id
-      name
+      ...CreateBaseImageCollection_SystemModelsFragment
     }
   }
 `;
@@ -77,7 +76,7 @@ const BaseImageCollection = ({
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
 
-  const systemModelsData = usePreloadedQuery(
+  const { systemModels } = usePreloadedQuery(
     GET_SYSTEM_MODELS_QUERY,
     getSystemModelsQuery,
   );
@@ -88,13 +87,13 @@ const BaseImageCollection = ({
     );
 
   // TODO: handle readonly type without mapping to mutable type
-  const systemModels = useMemo(
-    () =>
-      systemModelsData.systemModels.map((systemModel) => ({
-        ...systemModel,
-      })),
-    [systemModelsData],
-  );
+  // const systemModels = useMemo(
+  //   () =>
+  //     systemModelsData.systemModels.map((systemModel) => ({
+  //       ...systemModel,
+  //     })),
+  //   [systemModelsData],
+  // );
 
   const handleCreateBaseImageCollection = useCallback(
     (baseImageCollection: BaseImageCollectionData) => {
@@ -195,7 +194,7 @@ const BaseImageCollection = ({
               {errorFeedback}
             </Alert>
             <CreateBaseImageCollectionForm
-              systemModels={systemModels}
+              systemModelsRef={systemModels}
               onSubmit={handleCreateBaseImageCollection}
               isLoading={isCreatingBaseImageCollection}
             />

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -29,7 +29,10 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
-import type { BaseImageCollectionCreate_getSystemModels_Query } from "api/__generated__/BaseImageCollectionCreate_getSystemModels_Query.graphql";
+import type {
+  BaseImageCollectionCreate_getOptions_Query,
+  BaseImageCollectionCreate_getOptions_Query$data,
+} from "api/__generated__/BaseImageCollectionCreate_getOptions_Query.graphql";
 import type { BaseImageCollectionCreate_createBaseImageCollection_Mutation } from "api/__generated__/BaseImageCollectionCreate_createBaseImageCollection_Mutation.graphql";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -41,11 +44,12 @@ import Result from "components/Result";
 import Spinner from "components/Spinner";
 import { Link, Route, useNavigate } from "Navigation";
 
-const GET_SYSTEM_MODELS_QUERY = graphql`
-  query BaseImageCollectionCreate_getSystemModels_Query {
+const CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY = graphql`
+  query BaseImageCollectionCreate_getOptions_Query {
     systemModels {
-      ...CreateBaseImageCollection_SystemModelsFragment
+      __typename
     }
+    ...CreateBaseImageCollection_OptionsFragment
   }
 `;
 
@@ -56,65 +60,44 @@ const CREATE_BASE_IMAGE_COLLECTION_MUTATION = graphql`
     createBaseImageCollection(input: $input) {
       baseImageCollection {
         id
-        name
-        handle
-        systemModel {
-          name
-        }
       }
     }
   }
 `;
 
 type BaseImageCollectionProps = {
-  getSystemModelsQuery: PreloadedQuery<BaseImageCollectionCreate_getSystemModels_Query>;
+  baseImageCollectionOptions: BaseImageCollectionCreate_getOptions_Query$data;
 };
 
 const BaseImageCollection = ({
-  getSystemModelsQuery,
+  baseImageCollectionOptions,
 }: BaseImageCollectionProps) => {
-  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
-
-  const { systemModels } = usePreloadedQuery(
-    GET_SYSTEM_MODELS_QUERY,
-    getSystemModelsQuery,
-  );
+  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
 
   const [createBaseImageCollection, isCreatingBaseImageCollection] =
     useMutation<BaseImageCollectionCreate_createBaseImageCollection_Mutation>(
       CREATE_BASE_IMAGE_COLLECTION_MUTATION,
     );
 
-  // TODO: handle readonly type without mapping to mutable type
-  // const systemModels = useMemo(
-  //   () =>
-  //     systemModelsData.systemModels.map((systemModel) => ({
-  //       ...systemModel,
-  //     })),
-  //   [systemModelsData],
-  // );
-
   const handleCreateBaseImageCollection = useCallback(
     (baseImageCollection: BaseImageCollectionData) => {
       createBaseImageCollection({
         variables: { input: baseImageCollection },
         onCompleted(data, errors) {
+          if (data.createBaseImageCollection) {
+            const baseImageCollectionId =
+              data.createBaseImageCollection.baseImageCollection.id;
+            return navigate({
+              route: Route.baseImageCollectionsEdit,
+              params: { baseImageCollectionId },
+            });
+          }
           if (errors) {
             const errorFeedback = errors
               .map((error) => error.message)
               .join(". \n");
             return setErrorFeedback(errorFeedback);
-          }
-          const baseImageCollectionId =
-            data.createBaseImageCollection?.baseImageCollection.id;
-          if (baseImageCollectionId) {
-            navigate({
-              route: Route.baseImageCollectionsEdit,
-              params: { baseImageCollectionId },
-            });
-          } else {
-            navigate({ route: Route.baseImageCollections });
           }
         },
         onError() {
@@ -151,67 +134,82 @@ const BaseImageCollection = ({
   );
 
   return (
-    <Page>
-      <Page.Header
-        title={
-          <FormattedMessage
-            id="pages.BaseImageCollectionCreate.title"
-            defaultMessage="Create Base Image Collection"
-          />
-        }
+    <>
+      <Alert
+        show={!!errorFeedback}
+        variant="danger"
+        onClose={() => setErrorFeedback(null)}
+        dismissible
+      >
+        {errorFeedback}
+      </Alert>
+      <CreateBaseImageCollectionForm
+        optionsRef={baseImageCollectionOptions}
+        onSubmit={handleCreateBaseImageCollection}
+        isLoading={isCreatingBaseImageCollection}
       />
-      <Page.Main>
-        {systemModels.length === 0 ? (
-          <Result.EmptyList
-            title={
-              <FormattedMessage
-                id="pages.BaseImageCollectionCreate.noSystemModels.title"
-                defaultMessage="You haven't created any System Model yet"
-              />
-            }
-          >
-            <p>
-              <FormattedMessage
-                id="pages.BaseImageCollectionCreate.noSystemModels.message"
-                defaultMessage="You need at least one System Model to create a Base Image Collection"
-              />
-            </p>
-            <Button as={Link} route={Route.systemModelsNew}>
-              <FormattedMessage
-                id="pages.BaseImageCollectionCreate.noSystemModels.createButton"
-                defaultMessage="Create System Model"
-              />
-            </Button>
-          </Result.EmptyList>
-        ) : (
-          <>
-            <Alert
-              show={!!errorFeedback}
-              variant="danger"
-              onClose={() => setErrorFeedback(null)}
-              dismissible
-            >
-              {errorFeedback}
-            </Alert>
-            <CreateBaseImageCollectionForm
-              systemModelsRef={systemModels}
-              onSubmit={handleCreateBaseImageCollection}
-              isLoading={isCreatingBaseImageCollection}
-            />
-          </>
-        )}
-      </Page.Main>
-    </Page>
+    </>
+  );
+};
+
+const NoSystemModels = () => (
+  <Result.EmptyList
+    title={
+      <FormattedMessage
+        id="pages.BaseImageCollectionCreate.noSystemModels.title"
+        defaultMessage="You haven't created any System Model yet"
+      />
+    }
+  >
+    <p>
+      <FormattedMessage
+        id="pages.BaseImageCollectionCreate.noSystemModels.message"
+        defaultMessage="You need at least one System Model to create a Base Image Collection"
+      />
+    </p>
+    <Button as={Link} route={Route.systemModelsNew}>
+      <FormattedMessage
+        id="pages.BaseImageCollectionCreate.noSystemModels.createButton"
+        defaultMessage="Create System Model"
+      />
+    </Button>
+  </Result.EmptyList>
+);
+
+type BaseImageCollectionWrapperProps = {
+  getBaseImageCollectionOptionsQuery: PreloadedQuery<BaseImageCollectionCreate_getOptions_Query>;
+};
+
+const BaseImageCollectionWrapper = ({
+  getBaseImageCollectionOptionsQuery,
+}: BaseImageCollectionWrapperProps) => {
+  const baseImageCollectionOptions = usePreloadedQuery(
+    CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY,
+    getBaseImageCollectionOptionsQuery,
+  );
+  const { systemModels } = baseImageCollectionOptions;
+  if (systemModels.length === 0) {
+    return <NoSystemModels />;
+  }
+  return (
+    <BaseImageCollection
+      baseImageCollectionOptions={baseImageCollectionOptions}
+    />
   );
 };
 
 const BaseImageCollectionCreatePage = () => {
-  const [getSystemModelsQuery, getSystemModels] =
-    useQueryLoader<BaseImageCollectionCreate_getSystemModels_Query>(
-      GET_SYSTEM_MODELS_QUERY,
+  const [getBaseImageCollectionOptionsQuery, getBaseImageCollectionOptions] =
+    useQueryLoader<BaseImageCollectionCreate_getOptions_Query>(
+      CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY,
     );
 
-  useEffect(() => getSystemModels({}), [getSystemModels]);
+  const fetchBaseImageCollectionOptions = useCallback(
+    () => getBaseImageCollectionOptions({}, { fetchPolicy: "network-only" }),
+    [getBaseImageCollectionOptions],
+  );
+
+  useEffect(fetchBaseImageCollectionOptions, [fetchBaseImageCollectionOptions]);
 
   return (
     <Suspense
@@ -227,10 +225,26 @@ const BaseImageCollectionCreatePage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getSystemModels({})}
+        onReset={fetchBaseImageCollectionOptions}
       >
-        {getSystemModelsQuery && (
-          <BaseImageCollection getSystemModelsQuery={getSystemModelsQuery} />
+        {getBaseImageCollectionOptionsQuery && (
+          <Page>
+            <Page.Header
+              title={
+                <FormattedMessage
+                  id="pages.BaseImageCollectionCreate.title"
+                  defaultMessage="Create Base Image Collection"
+                />
+              }
+            />
+            <Page.Main>
+              <BaseImageCollectionWrapper
+                getBaseImageCollectionOptionsQuery={
+                  getBaseImageCollectionOptionsQuery
+                }
+              />
+            </Page.Main>
+          </Page>
         )}
       </ErrorBoundary>
     </Suspense>

--- a/frontend/src/pages/BaseImageCollections.tsx
+++ b/frontend/src/pages/BaseImageCollections.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -84,7 +84,12 @@ const BaseImageCollectionsPage = () => {
       GET_BASE_IMAGE_COLLECTIONS_QUERY,
     );
 
-  useEffect(() => getBaseImageCollections({}), [getBaseImageCollections]);
+  const fetchBaseImageCollections = useCallback(
+    () => getBaseImageCollections({}, { fetchPolicy: "store-and-network" }),
+    [getBaseImageCollections],
+  );
+
+  useEffect(fetchBaseImageCollections, [fetchBaseImageCollections]);
 
   return (
     <Suspense
@@ -100,7 +105,7 @@ const BaseImageCollectionsPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getBaseImageCollections({})}
+        onReset={fetchBaseImageCollections}
       >
         {getBaseImageCollectionsQuery && (
           <BaseImageCollectionsContent

--- a/frontend/src/pages/BaseImageCreate.tsx
+++ b/frontend/src/pages/BaseImageCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -47,8 +47,7 @@ import { Link, Route, useNavigate } from "Navigation";
 const GET_BASE_IMAGE_COLLECTION_QUERY = graphql`
   query BaseImageCreate_getBaseImageCollection_Query($id: ID!) {
     baseImageCollection(id: $id) {
-      id
-      name
+      ...CreateBaseImage_BaseImageCollectionFragment
     }
     tenantInfo {
       defaultLocale
@@ -152,7 +151,7 @@ const BaseImageCreateContent = ({
           {errorFeedback}
         </Alert>
         <CreateBaseImageForm
-          baseImageCollection={baseImageCollection}
+          baseImageCollectionRef={baseImageCollection}
           locale={locale}
           onSubmit={handleCreateBaseImage}
           isLoading={isCreatingBaseImage}

--- a/frontend/src/pages/BaseImageCreate.tsx
+++ b/frontend/src/pages/BaseImageCreate.tsx
@@ -31,9 +31,9 @@ import {
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type {
-  BaseImageCreate_getBaseImageCollection_Query,
-  BaseImageCreate_getBaseImageCollection_Query$data,
-} from "api/__generated__/BaseImageCreate_getBaseImageCollection_Query.graphql";
+  BaseImageCreate_getOptions_Query,
+  BaseImageCreate_getOptions_Query$data,
+} from "api/__generated__/BaseImageCreate_getOptions_Query.graphql";
 import type { BaseImageCreate_createBaseImage_Mutation } from "api/__generated__/BaseImageCreate_createBaseImage_Mutation.graphql";
 import Alert from "components/Alert";
 import Center from "components/Center";
@@ -45,13 +45,12 @@ import type { BaseImageData } from "forms/CreateBaseImage";
 import { Link, Route, useNavigate } from "Navigation";
 
 const GET_BASE_IMAGE_COLLECTION_QUERY = graphql`
-  query BaseImageCreate_getBaseImageCollection_Query($id: ID!) {
-    baseImageCollection(id: $id) {
+  query BaseImageCreate_getOptions_Query($baseImageCollectionId: ID!) {
+    baseImageCollection(id: $baseImageCollectionId) {
+      id
       ...CreateBaseImage_BaseImageCollectionFragment
     }
-    tenantInfo {
-      defaultLocale
-    }
+    ...CreateBaseImage_OptionsFragment
   }
 `;
 
@@ -61,7 +60,7 @@ const CREATE_BASE_IMAGE_MUTATION = graphql`
   ) {
     createBaseImage(input: $input) {
       baseImage {
-        __typename
+        id
       }
     }
   }
@@ -69,17 +68,19 @@ const CREATE_BASE_IMAGE_MUTATION = graphql`
 
 type BaseImageCreateContentProps = {
   baseImageCollection: NonNullable<
-    BaseImageCreate_getBaseImageCollection_Query$data["baseImageCollection"]
+    BaseImageCreate_getOptions_Query$data["baseImageCollection"]
   >;
-  locale: BaseImageCreate_getBaseImageCollection_Query$data["tenantInfo"]["defaultLocale"];
+  queryRef: BaseImageCreate_getOptions_Query$data;
 };
 
 const BaseImageCreateContent = ({
   baseImageCollection,
-  locale,
+  queryRef,
 }: BaseImageCreateContentProps) => {
-  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
+
+  const baseImageCollectionId = baseImageCollection.id;
+  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
 
   const [createBaseImage, isCreatingBaseImage] =
     useMutation<BaseImageCreate_createBaseImage_Mutation>(
@@ -94,9 +95,7 @@ const BaseImageCreateContent = ({
           if (data.createBaseImage) {
             return navigate({
               route: Route.baseImageCollectionsEdit,
-              params: {
-                baseImageCollectionId: baseImage.baseImageCollectionId,
-              },
+              params: { baseImageCollectionId },
             });
           }
 
@@ -119,16 +118,27 @@ const BaseImageCreateContent = ({
           if (!data.createBaseImage) {
             return;
           }
-          store
+
+          const baseImage = store
+            .getRootField("createBaseImage")
+            .getLinkedRecord("baseImage");
+          const baseImageCollection = store
             .getRoot()
             .getLinkedRecord("baseImageCollection", {
-              id: baseImage.baseImageCollectionId,
-            })
-            ?.invalidateRecord();
+              id: baseImageCollectionId,
+            });
+          const baseImages =
+            baseImageCollection?.getLinkedRecords("baseImages");
+          if (baseImageCollection && baseImages) {
+            baseImageCollection.setLinkedRecords(
+              [...baseImages, baseImage],
+              "baseImages",
+            );
+          }
         },
       });
     },
-    [createBaseImage, navigate],
+    [createBaseImage, navigate, baseImageCollectionId],
   );
 
   return (
@@ -152,7 +162,7 @@ const BaseImageCreateContent = ({
         </Alert>
         <CreateBaseImageForm
           baseImageCollectionRef={baseImageCollection}
-          locale={locale}
+          optionsRef={queryRef}
           onSubmit={handleCreateBaseImage}
           isLoading={isCreatingBaseImage}
         />
@@ -162,18 +172,18 @@ const BaseImageCreateContent = ({
 };
 
 type BaseImageCreateWrapperProps = {
-  getBaseImageCollectionQuery: PreloadedQuery<BaseImageCreate_getBaseImageCollection_Query>;
+  getBaseImageCollectionQuery: PreloadedQuery<BaseImageCreate_getOptions_Query>;
 };
 
 const BaseImageCreateWrapper = ({
   getBaseImageCollectionQuery,
 }: BaseImageCreateWrapperProps) => {
-  const { baseImageCollection, tenantInfo } = usePreloadedQuery(
+  const queryData = usePreloadedQuery(
     GET_BASE_IMAGE_COLLECTION_QUERY,
     getBaseImageCollectionQuery,
   );
 
-  if (!baseImageCollection) {
+  if (!queryData.baseImageCollection) {
     return (
       <Result.NotFound
         title={
@@ -195,8 +205,8 @@ const BaseImageCreateWrapper = ({
 
   return (
     <BaseImageCreateContent
-      baseImageCollection={baseImageCollection}
-      locale={tenantInfo.defaultLocale}
+      baseImageCollection={queryData.baseImageCollection}
+      queryRef={queryData}
     />
   );
 };
@@ -205,16 +215,18 @@ const BaseImageCreatePage = () => {
   const { baseImageCollectionId = "" } = useParams();
 
   const [getBaseImageCollectionQuery, getBaseImageCollection] =
-    useQueryLoader<BaseImageCreate_getBaseImageCollection_Query>(
+    useQueryLoader<BaseImageCreate_getOptions_Query>(
       GET_BASE_IMAGE_COLLECTION_QUERY,
     );
 
-  const fetchBaseImageCollection = useCallback(() => {
-    getBaseImageCollection(
-      { id: baseImageCollectionId },
-      { fetchPolicy: "network-only" },
-    );
-  }, [getBaseImageCollection, baseImageCollectionId]);
+  const fetchBaseImageCollection = useCallback(
+    () =>
+      getBaseImageCollection(
+        { baseImageCollectionId },
+        { fetchPolicy: "network-only" },
+      ),
+    [getBaseImageCollection, baseImageCollectionId],
+  );
 
   useEffect(fetchBaseImageCollection, [fetchBaseImageCollection]);
 

--- a/frontend/src/pages/DeviceGroupCreate.tsx
+++ b/frontend/src/pages/DeviceGroupCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022-2023 SECO Mind Srl
+  Copyright 2022-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,9 +36,6 @@ const CREATE_DEVICE_GROUP_MUTATION = graphql`
     createDeviceGroup(input: $input) {
       deviceGroup {
         id
-        name
-        handle
-        selector
         devices {
           id
         }
@@ -61,20 +58,18 @@ const DeviceGroupCreatePage = () => {
       createDeviceGroup({
         variables: { input: deviceGroup },
         onCompleted(data, errors) {
+          if (data.createDeviceGroup) {
+            const deviceGroupId = data.createDeviceGroup.deviceGroup.id;
+            return navigate({
+              route: Route.deviceGroupsEdit,
+              params: { deviceGroupId },
+            });
+          }
           if (errors) {
             const errorFeedback = errors
               .map((error) => error.message)
               .join(". \n");
             return setErrorFeedback(errorFeedback);
-          }
-          const deviceGroupId = data.createDeviceGroup?.deviceGroup.id;
-          if (deviceGroupId) {
-            navigate({
-              route: Route.deviceGroupsEdit,
-              params: { deviceGroupId },
-            });
-          } else {
-            navigate({ route: Route.deviceGroups });
           }
         },
         onError() {

--- a/frontend/src/pages/DeviceGroups.tsx
+++ b/frontend/src/pages/DeviceGroups.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022-2023 SECO Mind Srl
+  Copyright 2022-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -80,7 +80,12 @@ const DevicesPage = () => {
   const [getDeviceGroupsQuery, getDeviceGroups] =
     useQueryLoader<DeviceGroups_getDeviceGroups_Query>(GET_DEVICE_GROUPS_QUERY);
 
-  useEffect(() => getDeviceGroups({}), [getDeviceGroups]);
+  const fetchDeviceGroups = useCallback(
+    () => getDeviceGroups({}, { fetchPolicy: "store-and-network" }),
+    [getDeviceGroups],
+  );
+
+  useEffect(fetchDeviceGroups, [fetchDeviceGroups]);
 
   return (
     <Suspense
@@ -96,7 +101,7 @@ const DevicesPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getDeviceGroups({})}
+        onReset={fetchDeviceGroups}
       >
         {getDeviceGroupsQuery && (
           <DeviceGroupsContent getDeviceGroupsQuery={getDeviceGroupsQuery} />

--- a/frontend/src/pages/HardwareTypes.tsx
+++ b/frontend/src/pages/HardwareTypes.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2023 SECO Mind Srl
+  Copyright 2021-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -99,7 +99,12 @@ const HardwareTypesPage = () => {
       GET_HARDWARE_TYPES_QUERY,
     );
 
-  useEffect(() => getHardwareTypes({}), [getHardwareTypes]);
+  const fetchHardwareTypes = useCallback(
+    () => getHardwareTypes({}, { fetchPolicy: "store-and-network" }),
+    [getHardwareTypes],
+  );
+
+  useEffect(fetchHardwareTypes, [fetchHardwareTypes]);
 
   return (
     <Suspense
@@ -115,7 +120,7 @@ const HardwareTypesPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getHardwareTypes({})}
+        onReset={fetchHardwareTypes}
       >
         {getHardwareTypesQuery && (
           <HardwareTypesContent getHardwareTypesQuery={getHardwareTypesQuery} />

--- a/frontend/src/pages/SystemModelCreate.tsx
+++ b/frontend/src/pages/SystemModelCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2023 SECO Mind Srl
+  Copyright 2021-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ const GET_HARDWARE_TYPES_QUERY = graphql`
   query SystemModelCreate_getHardwareTypes_Query {
     hardwareTypes {
       id
-      name
+      ...CreateSystemModel_HardwareTypeFragment
     }
   }
 `;
@@ -91,7 +91,7 @@ const SystemModelContent = ({
 }: SystemModelContentProps) => {
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
-  const hardwareTypesData = usePreloadedQuery(
+  const { hardwareTypes } = usePreloadedQuery(
     GET_HARDWARE_TYPES_QUERY,
     getHardwareTypesQuery,
   );
@@ -105,14 +105,6 @@ const SystemModelContent = ({
       CREATE_SYSTEM_MODEL_MUTATION,
     );
 
-  // TODO: handle readonly type without mapping to mutable type
-  const hardwareTypes = useMemo(
-    () =>
-      hardwareTypesData.hardwareTypes.map((hardwareType) => ({
-        ...hardwareType,
-      })),
-    [hardwareTypesData],
-  );
   const locale = useMemo(
     () => defaultLocaleData.tenantInfo.defaultLocale,
     [defaultLocaleData],
@@ -220,7 +212,7 @@ const SystemModelContent = ({
               {errorFeedback}
             </Alert>
             <CreateSystemModelForm
-              hardwareTypes={hardwareTypes}
+              hardwareTypesRef={hardwareTypes}
               locale={locale}
               onSubmit={handleCreateSystemModel}
               isLoading={isCreatingSystemModel}

--- a/frontend/src/pages/SystemModels.tsx
+++ b/frontend/src/pages/SystemModels.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2023 SECO Mind Srl
+  Copyright 2021-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
  */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -97,7 +97,12 @@ const SystemModelsPage = () => {
   const [getSystemModelsQuery, getSystemModels] =
     useQueryLoader<SystemModels_getSystemModels_Query>(GET_SYSTEM_MODELS_QUERY);
 
-  useEffect(() => getSystemModels({}), [getSystemModels]);
+  const fetchSystemModels = useCallback(
+    () => getSystemModels({}, { fetchPolicy: "store-and-network" }),
+    [getSystemModels],
+  );
+
+  useEffect(fetchSystemModels, [fetchSystemModels]);
 
   return (
     <Suspense
@@ -113,7 +118,7 @@ const SystemModelsPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getSystemModels({})}
+        onReset={fetchSystemModels}
       >
         {getSystemModelsQuery && (
           <SystemModelsContent getSystemModelsQuery={getSystemModelsQuery} />

--- a/frontend/src/pages/UpdateCampaigns.tsx
+++ b/frontend/src/pages/UpdateCampaigns.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -82,7 +82,12 @@ const UpdateCampaignsPage = () => {
       GET_UPDATE_CAMPAIGNS_QUERY,
     );
 
-  useEffect(() => getUpdateCampaigns({}), [getUpdateCampaigns]);
+  const fetchUpdateCampaigns = useCallback(
+    () => getUpdateCampaigns({}, { fetchPolicy: "store-and-network" }),
+    [getUpdateCampaigns],
+  );
+
+  useEffect(fetchUpdateCampaigns, [fetchUpdateCampaigns]);
 
   return (
     <Suspense
@@ -98,7 +103,7 @@ const UpdateCampaignsPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getUpdateCampaigns({})}
+        onReset={fetchUpdateCampaigns}
       >
         {getUpdateCampaignsQuery && (
           <UpdateCampaignsContent

--- a/frontend/src/pages/UpdateChannelCreate.tsx
+++ b/frontend/src/pages/UpdateChannelCreate.tsx
@@ -42,11 +42,7 @@ import { Route, useNavigate } from "Navigation";
 const GET_DEVICE_GROUPS_QUERY = graphql`
   query UpdateChannelCreate_getDeviceGroups_Query {
     deviceGroups {
-      id
-      name
-      updateChannel {
-        name
-      }
+      ...CreateUpdateChannel_DeviceGroupFragment
     }
   }
 `;
@@ -157,7 +153,7 @@ const UpdateChannel = ({ getDeviceGroupsQuery }: UpdateChannelProps) => {
           {errorFeedback}
         </Alert>
         <CreateUpdateChannelForm
-          targetGroups={deviceGroups}
+          targetGroupsRef={deviceGroups}
           onSubmit={handleCreateUpdateChannel}
           isLoading={isCreatingUpdateChannel}
         />

--- a/frontend/src/pages/UpdateChannelCreate.tsx
+++ b/frontend/src/pages/UpdateChannelCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -39,11 +39,9 @@ import Page from "components/Page";
 import Spinner from "components/Spinner";
 import { Route, useNavigate } from "Navigation";
 
-const GET_DEVICE_GROUPS_QUERY = graphql`
+const GET_CREATE_UPDATE_CHANNEL_OPTIONS_QUERY = graphql`
   query UpdateChannelCreate_getDeviceGroups_Query {
-    deviceGroups {
-      ...CreateUpdateChannel_DeviceGroupFragment
-    }
+    ...CreateUpdateChannel_OptionsFragment
   }
 `;
 
@@ -54,28 +52,24 @@ const CREATE_UPDATE_CHANNEL_MUTATION = graphql`
     createUpdateChannel(input: $input) {
       updateChannel {
         id
-        name
-        handle
-        targetGroups {
-          id
-          name
-        }
       }
     }
   }
 `;
 
 type UpdateChannelProps = {
-  getDeviceGroupsQuery: PreloadedQuery<UpdateChannelCreate_getDeviceGroups_Query>;
+  getCreateUpdateChannelOptionsQuery: PreloadedQuery<UpdateChannelCreate_getDeviceGroups_Query>;
 };
 
-const UpdateChannel = ({ getDeviceGroupsQuery }: UpdateChannelProps) => {
+const UpdateChannel = ({
+  getCreateUpdateChannelOptionsQuery,
+}: UpdateChannelProps) => {
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
   const navigate = useNavigate();
 
-  const { deviceGroups } = usePreloadedQuery(
-    GET_DEVICE_GROUPS_QUERY,
-    getDeviceGroupsQuery,
+  const updateChannelCreateData = usePreloadedQuery(
+    GET_CREATE_UPDATE_CHANNEL_OPTIONS_QUERY,
+    getCreateUpdateChannelOptionsQuery,
   );
 
   const [createUpdateChannel, isCreatingUpdateChannel] =
@@ -153,7 +147,7 @@ const UpdateChannel = ({ getDeviceGroupsQuery }: UpdateChannelProps) => {
           {errorFeedback}
         </Alert>
         <CreateUpdateChannelForm
-          targetGroupsRef={deviceGroups}
+          queryRef={updateChannelCreateData}
           onSubmit={handleCreateUpdateChannel}
           isLoading={isCreatingUpdateChannel}
         />
@@ -163,15 +157,17 @@ const UpdateChannel = ({ getDeviceGroupsQuery }: UpdateChannelProps) => {
 };
 
 const UpdateChannelCreatePage = () => {
-  const [getDeviceGroupsQuery, getDeviceGroups] =
+  const [getCreateUpdateChannelOptionsQuery, getCreateUpdateChannelOptions] =
     useQueryLoader<UpdateChannelCreate_getDeviceGroups_Query>(
-      GET_DEVICE_GROUPS_QUERY,
+      GET_CREATE_UPDATE_CHANNEL_OPTIONS_QUERY,
     );
 
-  useEffect(
-    () => getDeviceGroups({}, { fetchPolicy: "network-only" }),
-    [getDeviceGroups],
+  const fetchCreateUpdateChannelOptions = useCallback(
+    () => getCreateUpdateChannelOptions({}, { fetchPolicy: "network-only" }),
+    [getCreateUpdateChannelOptions],
   );
+
+  useEffect(fetchCreateUpdateChannelOptions, [fetchCreateUpdateChannelOptions]);
 
   return (
     <Suspense
@@ -187,10 +183,14 @@ const UpdateChannelCreatePage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getDeviceGroups({}, { fetchPolicy: "network-only" })}
+        onReset={fetchCreateUpdateChannelOptions}
       >
-        {getDeviceGroupsQuery && (
-          <UpdateChannel getDeviceGroupsQuery={getDeviceGroupsQuery} />
+        {getCreateUpdateChannelOptionsQuery && (
+          <UpdateChannel
+            getCreateUpdateChannelOptionsQuery={
+              getCreateUpdateChannelOptionsQuery
+            }
+          />
         )}
       </ErrorBoundary>
     </Suspense>

--- a/frontend/src/pages/UpdateChannels.tsx
+++ b/frontend/src/pages/UpdateChannels.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { ErrorBoundary } from "react-error-boundary";
 import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
@@ -82,7 +82,12 @@ const UpdateChannelsPage = () => {
       GET_UPDATE_CHANNELS_QUERY,
     );
 
-  useEffect(() => getUpdateChannels({}), [getUpdateChannels]);
+  const fetchUpdateChannels = useCallback(
+    () => getUpdateChannels({}, { fetchPolicy: "store-and-network" }),
+    [getUpdateChannels],
+  );
+
+  useEffect(fetchUpdateChannels, [fetchUpdateChannels]);
 
   return (
     <Suspense
@@ -98,7 +103,7 @@ const UpdateChannelsPage = () => {
             <Page.LoadingError onRetry={props.resetErrorBoundary} />
           </Center>
         )}
-        onReset={() => getUpdateChannels({})}
+        onReset={fetchUpdateChannels}
       >
         {getUpdateChannelsQuery && (
           <UpdateChannelsContent


### PR DESCRIPTION
[Specify Relay data requirements for a components (create/update forms) with fragments](https://relay.dev/docs/principles-and-architecture/thinking-in-relay/#specifying-the-data-requirements-of-a-component). 
Fetch for latest entity data on view/update pages before rendering form.
Use locally cached list of entity data on list pages (if present) on first page render and fetch for latest data meanwhile.
Refactor queries on create/update pages to fetch entity data and form options in one query.

