### PR TITLE
Define an Enum type to model the status of a Forwarder session

### DIFF
--- a/backend/lib/edgehog/forwarder/session/session.ex
+++ b/backend/lib/edgehog/forwarder/session/session.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Forwarder.Session do
     ]
 
   alias Edgehog.Forwarder.Session.ManualActions
+  alias Edgehog.Forwarder.Session.Status
 
   resource do
     description "The details of a forwarder session."
@@ -81,11 +82,10 @@ defmodule Edgehog.Forwarder.Session do
       allow_nil? false
     end
 
-    attribute :status, :atom do
+    attribute :status, Status do
       description "The status of the session."
       public? true
       allow_nil? false
-      constraints one_of: [:connected, :connecting]
     end
 
     attribute :forwarder_hostname, :string do

--- a/backend/lib/edgehog/forwarder/session/status.ex
+++ b/backend/lib/edgehog/forwarder/session/status.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Forwarder.Session.Status do
+  use Ash.Type.Enum,
+    values: [
+      connected: "The device is connected to the forwarder.",
+      connecting: "The device is connecting to the forwarder."
+    ]
+
+  def graphql_type(_), do: :forwarder_session_status
+end

--- a/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_session_test.exs
@@ -57,8 +57,7 @@ defmodule EdgehogWeb.Schema.Query.ForwarderSessionTest do
 
       assert %{
                "token" => "session_token",
-               # TODO: Ash leaves atoms lowercase?
-               "status" => "connected",
+               "status" => "CONNECTED",
                "forwarderHostname" => "localhost",
                "forwarderPort" => 4001
              } = extract_result!(result)


### PR DESCRIPTION
Instead of using a free-form field with some constraints, use an Ash.Type.Enum to precisely describe the possible values of the status field.
This also generates a more informative and readable GraphQL schema.
