### PR TITLE
Use better input for Google Geolocation

### DIFF
--- a/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
@@ -48,7 +48,7 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeolocation do
     latest_wifi_scan_results =
       Enum.filter(
         wifi_scan_results,
-        &(DateTime.diff(latest_scan.timestamp, &1.timestamp, :second) < 1)
+        &(DateTime.diff(latest_scan.timestamp, &1.timestamp, :second) < 5)
       )
 
     {:ok, latest_wifi_scan_results}

--- a/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
@@ -61,10 +61,14 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeolocation do
   defp geolocate_wifi([%WiFiScanResult{} | _] = wifi_scan_results) do
     wifi_access_points =
       Enum.map(wifi_scan_results, fn wifi ->
+        age =
+          wifi.timestamp && DateTime.diff(DateTime.now!("Etc/UTC"), wifi.timestamp, :millisecond)
+
         %{
           macAddress: wifi.mac_address,
           signalStrength: wifi.rssi,
-          channel: wifi.channel
+          channel: wifi.channel,
+          age: age
         }
       end)
 


### PR DESCRIPTION
The PR performs a couple of tweaks on the module that queries Google Geolocation APIs for retrieving a position from WiFi scans.

1. Consider the age of WiFi scans.
To improve the accuracy of results, the additional `age` field is specified for each provided WiFi scan: i.e. the number of milliseconds since the access point was detected.
For reference: https://developers.google.com/maps/documentation/geolocation/requests-geolocation#wifi_access_point_object
2. Consider the last 5 seconds of WiFi scans instead of 1.
Low-end devices might take a while to perform WiFi scanning routines. To retain more information, the last 5 seconds of scans are considered instead of keeping only the last 1 second, which might be too short as time window.