### PR TITLE
Fix container image not available for linux/amd64 architecture

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 #
 ARG ELIXIR_VERSION=1.16.2
 ARG OTP_VERSION=26.2.3
-ARG DEBIAN_VERSION=bookworm-20240408-slim
+ARG DEBIAN_VERSION=bookworm-20240311-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
The tag `1.16.2-erlang-26.2.3-debian-bookworm-20240408-slim` of the `docker.io/hexpm/elixir` image is only available for the `linux/arm64/v8` platform.
The PR targets instead the image `1.16.2-erlang-26.2.3-debian-bookworm-20240311-slim` which supports the `amd64 platform`.