### PR TITLE
[frontend] standardize the structure of update forms

### DIFF
--- a/frontend/src/forms/UpdateSystemModel.tsx
+++ b/frontend/src/forms/UpdateSystemModel.tsx
@@ -217,6 +217,8 @@ const UpdateSystemModelForm = ({
 
   const onFormSubmit = (data: FormData) =>
     onSubmit(transformOutputData(systemModel, locale, data));
+  const canSubmit = !isLoading && isDirty;
+  const canReset = isDirty && !isLoading;
 
   const handleAddPartNumber = useCallback(() => {
     partNumbers.append({ value: "" });
@@ -275,7 +277,7 @@ const UpdateSystemModelForm = ({
                 id="system-model-form-name"
                 label={
                   <FormattedMessage
-                    id="components.UpdateSystemModelForm.nameLabel"
+                    id="forms.UpdateSystemModel.nameLabel"
                     defaultMessage="Name"
                   />
                 }
@@ -291,7 +293,7 @@ const UpdateSystemModelForm = ({
                 id="system-model-form-handle"
                 label={
                   <FormattedMessage
-                    id="components.UpdateSystemModelForm.handleLabel"
+                    id="forms.UpdateSystemModel.handleLabel"
                     defaultMessage="Handle"
                   />
                 }
@@ -311,7 +313,7 @@ const UpdateSystemModelForm = ({
                 label={
                   <>
                     <FormattedMessage
-                      id="components.CreateSystemModelForm.descriptionLabel"
+                      id="forms.UpdateSystemModel.descriptionLabel"
                       defaultMessage="Description"
                     />
                     <span className="small text-muted"> ({locale})</span>
@@ -324,7 +326,7 @@ const UpdateSystemModelForm = ({
                 id="system-model-form-hardware-type"
                 label={
                   <FormattedMessage
-                    id="components.UpdateSystemModelForm.hardwareTypeLabel"
+                    id="forms.UpdateSystemModel.hardwareTypeLabel"
                     defaultMessage="Hardware Type"
                   />
                 }
@@ -339,7 +341,7 @@ const UpdateSystemModelForm = ({
                 id="system-model-form-part-numbers"
                 label={
                   <FormattedMessage
-                    id="components.UpdateSystemModelForm.partNumbersLabel"
+                    id="forms.UpdateSystemModel.partNumbersLabel"
                     defaultMessage="Part Numbers"
                   />
                 }
@@ -363,6 +365,7 @@ const UpdateSystemModelForm = ({
                       <Button
                         className="mb-auto"
                         variant="danger"
+                        disabled={isLoading}
                         onClick={() => handleDeletePartNumber(index)}
                       >
                         <Icon icon="delete" />
@@ -372,10 +375,11 @@ const UpdateSystemModelForm = ({
                   <Button
                     className="me-auto"
                     variant="secondary"
+                    disabled={isLoading}
                     onClick={handleAddPartNumber}
                   >
                     <FormattedMessage
-                      id="components.UpdateSystemModelForm.addPartNumberButton"
+                      id="forms.UpdateSystemModel.addPartNumberButton"
                       defaultMessage="Add part number"
                     />
                   </Button>
@@ -384,33 +388,35 @@ const UpdateSystemModelForm = ({
             </Stack>
           </Col>
         </Row>
-        <div className="d-flex justify-content-end align-items-center">
-          <Stack direction="horizontal" gap={3}>
-            <Button
-              disabled={!isDirty}
-              variant="secondary"
-              onClick={() => reset()}
-            >
-              <FormattedMessage
-                id="components.UpdateSystemModelForm.resetButton"
-                defaultMessage="Reset"
-              />
-            </Button>
-            <Button variant="primary" type="submit" disabled={isLoading}>
-              {isLoading && <Spinner size="sm" className="me-2" />}
-              <FormattedMessage
-                id="components.UpdateSystemModelForm.submitButton"
-                defaultMessage="Update"
-              />
-            </Button>
-            <Button variant="danger" onClick={onDelete}>
-              <FormattedMessage
-                id="components.UpdateSystemModelForm.deleteButton"
-                defaultMessage="Delete"
-              />
-            </Button>
-          </Stack>
-        </div>
+        <Stack
+          direction="horizontal"
+          gap={3}
+          className="justify-content-end align-items-center"
+        >
+          <Button variant="primary" type="submit" disabled={!canSubmit}>
+            {isLoading && <Spinner size="sm" className="me-2" />}
+            <FormattedMessage
+              id="forms.UpdateSystemModel.submitButton"
+              defaultMessage="Update"
+            />
+          </Button>
+          <Button
+            disabled={!canReset}
+            variant="secondary"
+            onClick={() => reset()}
+          >
+            <FormattedMessage
+              id="forms.UpdateSystemModel.resetButton"
+              defaultMessage="Reset"
+            />
+          </Button>
+          <Button variant="danger" onClick={onDelete}>
+            <FormattedMessage
+              id="forms.UpdateSystemModel.deleteButton"
+              defaultMessage="Delete"
+            />
+          </Button>
+        </Stack>
       </Stack>
     </form>
   );

--- a/frontend/src/forms/UpdateUpdateChannel.tsx
+++ b/frontend/src/forms/UpdateUpdateChannel.tsx
@@ -234,6 +234,7 @@ const UpdateUpdateChannel = ({
     onSubmit(transformOutputData(data));
 
   const canSubmit = !isLoading && isDirty;
+  const canReset = isDirty && !isLoading;
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
@@ -304,12 +305,26 @@ const UpdateUpdateChannel = ({
             )}
           </Form.Control.Feedback>
         </FormRow>
-        <div className="d-flex justify-content-end align-items-center gap-2">
+        <Stack
+          direction="horizontal"
+          gap={3}
+          className="justify-content-end align-items-center"
+        >
           <Button variant="primary" type="submit" disabled={!canSubmit}>
             {isLoading && <Spinner size="sm" className="me-2" />}
             <FormattedMessage
               id="forms.UpdateUpdateChannel.submitButton"
               defaultMessage="Update"
+            />
+          </Button>
+          <Button
+            variant="secondary"
+            disabled={!canReset}
+            onClick={() => reset()}
+          >
+            <FormattedMessage
+              id="forms.UpdateUpdateChannel.resetButton"
+              defaultMessage="Reset"
             />
           </Button>
           <Button variant="danger" onClick={onDelete}>
@@ -318,7 +333,7 @@ const UpdateUpdateChannel = ({
               defaultMessage="Delete"
             />
           </Button>
-        </div>
+        </Stack>
       </Stack>
     </form>
   );

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -464,21 +464,6 @@
   "components.Topbar.userMenu.logoutLabel": {
     "defaultMessage": "Logout"
   },
-  "components.UpdateBaseImageCollection.deleteButton": {
-    "defaultMessage": "Delete"
-  },
-  "components.UpdateBaseImageCollection.handleLabel": {
-    "defaultMessage": "Handle"
-  },
-  "components.UpdateBaseImageCollection.nameLabel": {
-    "defaultMessage": "Name"
-  },
-  "components.UpdateBaseImageCollection.submitButton": {
-    "defaultMessage": "Update"
-  },
-  "components.UpdateBaseImageCollection.systemModelLabel": {
-    "defaultMessage": "System Model"
-  },
   "components.UpdateCampaignOutcome.Failure": {
     "defaultMessage": "Failure"
   },
@@ -527,63 +512,6 @@
   "components.UpdateChannelsTable.targetGroupsTitle": {
     "defaultMessage": "Target Groups",
     "description": "Title for the Target Groups column of the update channels table"
-  },
-  "components.UpdateDeviceGroupForm.deleteButton": {
-    "defaultMessage": "Delete"
-  },
-  "components.UpdateDeviceGroupForm.handleLabel": {
-    "defaultMessage": "Handle"
-  },
-  "components.UpdateDeviceGroupForm.nameLabel": {
-    "defaultMessage": "Name"
-  },
-  "components.UpdateDeviceGroupForm.selectorLabel": {
-    "defaultMessage": "Selector"
-  },
-  "components.UpdateDeviceGroupForm.submitButton": {
-    "defaultMessage": "Update"
-  },
-  "components.UpdateHardwareTypeForm.addPartNumberButton": {
-    "defaultMessage": "Add Part Number"
-  },
-  "components.UpdateHardwareTypeForm.deleteButton": {
-    "defaultMessage": "Delete"
-  },
-  "components.UpdateHardwareTypeForm.handleLabel": {
-    "defaultMessage": "Handle"
-  },
-  "components.UpdateHardwareTypeForm.nameLabel": {
-    "defaultMessage": "Name"
-  },
-  "components.UpdateHardwareTypeForm.partNumbersLabel": {
-    "defaultMessage": "Part Numbers"
-  },
-  "components.UpdateHardwareTypeForm.submitButton": {
-    "defaultMessage": "Update"
-  },
-  "components.UpdateSystemModelForm.addPartNumberButton": {
-    "defaultMessage": "Add part number"
-  },
-  "components.UpdateSystemModelForm.deleteButton": {
-    "defaultMessage": "Delete"
-  },
-  "components.UpdateSystemModelForm.handleLabel": {
-    "defaultMessage": "Handle"
-  },
-  "components.UpdateSystemModelForm.hardwareTypeLabel": {
-    "defaultMessage": "Hardware Type"
-  },
-  "components.UpdateSystemModelForm.nameLabel": {
-    "defaultMessage": "Name"
-  },
-  "components.UpdateSystemModelForm.partNumbersLabel": {
-    "defaultMessage": "Part Numbers"
-  },
-  "components.UpdateSystemModelForm.resetButton": {
-    "defaultMessage": "Reset"
-  },
-  "components.UpdateSystemModelForm.submitButton": {
-    "defaultMessage": "Update"
   },
   "components.UpdateTargetsTable.completionTimestampTitle": {
     "defaultMessage": "Completed at",
@@ -793,6 +721,9 @@
   "forms.UpdateBaseImage.releaseDisplayNameLabel": {
     "defaultMessage": "Release Display Name"
   },
+  "forms.UpdateBaseImage.resetButton": {
+    "defaultMessage": "Reset"
+  },
   "forms.UpdateBaseImage.starting-version-requirementLabel": {
     "defaultMessage": "Supported starting versions"
   },
@@ -801,6 +732,24 @@
   },
   "forms.UpdateBaseImage.versionLabel": {
     "defaultMessage": "Version"
+  },
+  "forms.UpdateBaseImageCollection.deleteButton": {
+    "defaultMessage": "Delete"
+  },
+  "forms.UpdateBaseImageCollection.handleLabel": {
+    "defaultMessage": "Handle"
+  },
+  "forms.UpdateBaseImageCollection.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "forms.UpdateBaseImageCollection.resetButton": {
+    "defaultMessage": "Reset"
+  },
+  "forms.UpdateBaseImageCollection.submitButton": {
+    "defaultMessage": "Update"
+  },
+  "forms.UpdateBaseImageCollection.systemModelLabel": {
+    "defaultMessage": "System Model"
   },
   "forms.UpdateCampaignForm.baseImageCollectionLabel": {
     "defaultMessage": "Base Image Collection"
@@ -832,6 +781,72 @@
   "forms.UpdateCampaignForm.updateChannelLabel": {
     "defaultMessage": "Update Channel"
   },
+  "forms.UpdateDeviceGroup.deleteButton": {
+    "defaultMessage": "Delete"
+  },
+  "forms.UpdateDeviceGroup.handleLabel": {
+    "defaultMessage": "Handle"
+  },
+  "forms.UpdateDeviceGroup.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "forms.UpdateDeviceGroup.resetButton": {
+    "defaultMessage": "Reset"
+  },
+  "forms.UpdateDeviceGroup.selectorLabel": {
+    "defaultMessage": "Selector"
+  },
+  "forms.UpdateDeviceGroup.submitButton": {
+    "defaultMessage": "Update"
+  },
+  "forms.UpdateHardwareType.addPartNumberButton": {
+    "defaultMessage": "Add Part Number"
+  },
+  "forms.UpdateHardwareType.deleteButton": {
+    "defaultMessage": "Delete"
+  },
+  "forms.UpdateHardwareType.handleLabel": {
+    "defaultMessage": "Handle"
+  },
+  "forms.UpdateHardwareType.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "forms.UpdateHardwareType.partNumbersLabel": {
+    "defaultMessage": "Part Numbers"
+  },
+  "forms.UpdateHardwareType.resetButton": {
+    "defaultMessage": "Reset"
+  },
+  "forms.UpdateHardwareType.submitButton": {
+    "defaultMessage": "Update"
+  },
+  "forms.UpdateSystemModel.addPartNumberButton": {
+    "defaultMessage": "Add part number"
+  },
+  "forms.UpdateSystemModel.deleteButton": {
+    "defaultMessage": "Delete"
+  },
+  "forms.UpdateSystemModel.descriptionLabel": {
+    "defaultMessage": "Description"
+  },
+  "forms.UpdateSystemModel.handleLabel": {
+    "defaultMessage": "Handle"
+  },
+  "forms.UpdateSystemModel.hardwareTypeLabel": {
+    "defaultMessage": "Hardware Type"
+  },
+  "forms.UpdateSystemModel.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "forms.UpdateSystemModel.partNumbersLabel": {
+    "defaultMessage": "Part Numbers"
+  },
+  "forms.UpdateSystemModel.resetButton": {
+    "defaultMessage": "Reset"
+  },
+  "forms.UpdateSystemModel.submitButton": {
+    "defaultMessage": "Update"
+  },
   "forms.UpdateUpdateChannel.deleteButton": {
     "defaultMessage": "Delete"
   },
@@ -840,6 +855,9 @@
   },
   "forms.UpdateUpdateChannel.nameLabel": {
     "defaultMessage": "Name"
+  },
+  "forms.UpdateUpdateChannel.resetButton": {
+    "defaultMessage": "Reset"
   },
   "forms.UpdateUpdateChannel.submitButton": {
     "defaultMessage": "Update"


### PR DESCRIPTION
- add missing action buttons and sort them in order of: `Update`, `Reset`, `Delete` 
- track field changes and enable/disable action buttons (`Update` and `Reset` buttons are enabled when form has changes and mutation is not in progress, disabled otherwise)
- fix: do not reset form on first render

First render, `Update` and `Reset` buttons are disabled.
![HardwareType_first-render](https://github.com/edgehog-device-manager/edgehog/assets/26611935/0ef1dbcf-de04-4149-8ab5-20ba5751b36c)

Form has changes, buttons are active
![HardwareType_buttons-active](https://github.com/edgehog-device-manager/edgehog/assets/26611935/ccbf8c56-0d41-4642-aedb-a579232c8fe8)

Update request in progress
![HardwareTypes_update-in-progress](https://github.com/edgehog-device-manager/edgehog/assets/26611935/44a60c9b-c01f-4bdb-a254-b6705dbf7686)

