### PR TITLE
Specify `require_atomic? false` on non-atomic Ash actions

### DIFF
--- a/backend/lib/edgehog/base_images/base_image/base_image.ex
+++ b/backend/lib/edgehog/base_images/base_image/base_image.ex
@@ -156,6 +156,9 @@ defmodule Edgehog.BaseImages.BaseImage do
       description "Deletes a base image."
       primary? true
 
+      # Needed because HandleFileDeletion is not atomic
+      require_atomic? false
+
       change Changes.HandleFileDeletion
     end
 

--- a/backend/lib/edgehog/devices/system_model/system_model.ex
+++ b/backend/lib/edgehog/devices/system_model/system_model.ex
@@ -157,6 +157,9 @@ defmodule Edgehog.Devices.SystemModel do
       description "Deletes a system model."
       primary? true
 
+      # Needed because HandlePictureDeletion is not atomic
+      require_atomic? false
+
       change {Changes.HandlePictureDeletion, force?: true}
     end
   end


### PR DESCRIPTION
Add `require_atomic? false` directive to express that the relative actions are not atomic.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
