### PR TITLE
Handle incoming triggers for OTA operations

### DIFF
--- a/backend/lib/edgehog/os_management/ota_operation/status_code.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/status_code.ex
@@ -37,14 +37,14 @@ defmodule Edgehog.OSManagement.OTAOperation.StatusCode do
   # Ash.Type.Enum expects snake case input and lowercases everything
   # This works even with PascalCase inputs if they are a single word, but we
   # need to match explicitly multiword status codes
-  def match("RequestTimeout"), do: :request_timeout
-  def match("InvalidRequest"), do: :invalid_request
-  def match("UpdateAlreadyInProgress"), do: :update_already_in_progress
-  def match("NetworkError"), do: :network_error
-  def match("IOError"), do: :io_error
-  def match("InternalError"), do: :internal_error
-  def match("InvalidBaseImage"), do: :invalid_base_image
-  def match("SystemRollback"), do: :system_rollback
+  def match("RequestTimeout"), do: {:ok, :request_timeout}
+  def match("InvalidRequest"), do: {:ok, :invalid_request}
+  def match("UpdateAlreadyInProgress"), do: {:ok, :update_already_in_progress}
+  def match("NetworkError"), do: {:ok, :network_error}
+  def match("IOError"), do: {:ok, :io_error}
+  def match("InternalError"), do: {:ok, :internal_error}
+  def match("InvalidBaseImage"), do: {:ok, :invalid_base_image}
+  def match("SystemRollback"), do: {:ok, :system_rollback}
   # Fallback to the default (overriden) `match/1` implementation so we still accept
   # atom inputs etc
   def match(term), do: super(term)


### PR DESCRIPTION
This PR implements the handling of incoming HTTP events triggered on the Astarte interfaces `io.edgehog.devicemanager.OTAEvent` and `io.edgehog.devicemanager.OTAResponse` by recording the progress and the
status change of OTA operations.

This change completes the porting of update campaign management to Ash.

Closes #497

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
