### PR TITLE
Port tests on OTA operations to Ash

### DIFF
--- a/backend/lib/edgehog/os_management/ota_operation/changes/handle_ephemeral_image_deletion.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/changes/handle_ephemeral_image_deletion.ex
@@ -1,0 +1,51 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.OSManagement.OTAOperation.Changes.HandleEphemeralImageDeletion do
+  use Ash.Resource.Change
+
+  alias Edgehog.OSManagement.EphemeralImage
+
+  @ephemeral_image_module Application.compile_env(
+                            :edgehog,
+                            :os_management_ephemeral_image_module,
+                            EphemeralImage
+                          )
+
+  @impl true
+  def change(%Ash.Changeset{valid?: false} = changeset, _opts, _context), do: changeset
+
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_transaction(changeset, &cleanup_base_image_url/2)
+  end
+
+  defp cleanup_base_image_url(changeset, {:ok, ota_operation} = result) do
+    tenant_id = changeset.to_tenant
+
+    # We do our best to clean up
+    _ = @ephemeral_image_module.delete(tenant_id, ota_operation.id, ota_operation.base_image_url)
+
+    result
+  end
+
+  defp cleanup_base_image_url(_changeset, result) do
+    result
+  end
+end

--- a/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
@@ -30,6 +30,8 @@ defmodule Edgehog.OSManagement.OTAOperation do
   alias Edgehog.OSManagement.OTAOperation.Status
   alias Edgehog.OSManagement.OTAOperation.StatusCode
 
+  @terminal_statuses [:success, :failure]
+
   resource do
     description """
     An OTA update operation
@@ -101,25 +103,29 @@ defmodule Edgehog.OSManagement.OTAOperation do
     end
 
     update :mark_as_timed_out do
-      # Needed because Edgehog.Changes.PublishNotification is not atomic
+      # Needed because PublishNotification and HandleEphemeralImageDeletion are not atomic
       require_atomic? false
 
       change set_attribute(:status, :failure)
       change set_attribute(:status_code, :request_timeout)
       change {Edgehog.Changes.PublishNotification, event_type: :ota_operation_updated}
 
-      # TODO: cleanup base image for manual operations
+      change Changes.HandleEphemeralImageDeletion do
+        where attribute_equals(:manual?, true)
+      end
     end
 
     update :update_status do
       accept [:status, :status_progress, :status_code, :message]
 
-      # Needed because Edgehog.Changes.PublishNotification is not atomic
+      # Needed because PublishNotification and HandleEphemeralImageDeletion are not atomic
       require_atomic? false
 
       change {Edgehog.Changes.PublishNotification, event_type: :ota_operation_updated}
 
-      # TODO: cleanup base image for manual operations reaching a terminal status
+      change Changes.HandleEphemeralImageDeletion do
+        where [attribute_equals(:manual?, true), attribute_in(:status, @terminal_statuses)]
+      end
     end
 
     action :send_update_request do

--- a/backend/test/support/data_case.ex
+++ b/backend/test/support/data_case.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,8 +44,13 @@ defmodule Edgehog.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import Edgehog.DataCase
+      import Mox
     end
   end
+
+  import Mox
+
+  setup :verify_on_exit!
 
   setup tags do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])


### PR DESCRIPTION
The PR converts the old tests that were run on the function of the OSManagement context and run them on the available Ash actions.

It also adds a missing piece of logic on OTA operations before porting the relative tests: cleaning up the ephemeral image of manual OTA operation once they reach a terminal status and the rollout is ended. 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
