### PR TITLE
Move code interfaces from resources to domains

### DIFF
--- a/backend/lib/edgehog/astarte/astarte.ex
+++ b/backend/lib/edgehog/astarte/astarte.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,14 @@ defmodule Edgehog.Astarte do
   use Ash.Domain
 
   resources do
-    resource Edgehog.Astarte.Cluster
-    resource Edgehog.Astarte.Realm
+    resource Edgehog.Astarte.Cluster do
+      define :create_cluster, action: :create
+    end
+
+    resource Edgehog.Astarte.Realm do
+      define :fetch_realm_by_name, action: :by_name, args: [:name]
+      define :create_realm, action: :create
+      define :destroy_realm, action: :destroy
+    end
   end
 end

--- a/backend/lib/edgehog/astarte/astarte.ex
+++ b/backend/lib/edgehog/astarte/astarte.ex
@@ -27,7 +27,7 @@ defmodule Edgehog.Astarte do
     end
 
     resource Edgehog.Astarte.Realm do
-      define :fetch_realm_by_name, action: :by_name, args: [:name]
+      define :fetch_realm_by_name, action: :read, get_by: :name, not_found_error?: true
       define :create_realm, action: :create
       define :destroy_realm, action: :destroy
     end

--- a/backend/lib/edgehog/astarte/cluster/cluster.ex
+++ b/backend/lib/edgehog/astarte/cluster/cluster.ex
@@ -25,10 +25,6 @@ defmodule Edgehog.Astarte.Cluster do
 
   alias Edgehog.Astarte.Cluster
 
-  code_interface do
-    define :create
-  end
-
   actions do
     defaults [:read, :destroy]
 

--- a/backend/lib/edgehog/astarte/realm/realm.ex
+++ b/backend/lib/edgehog/astarte/realm/realm.ex
@@ -32,10 +32,6 @@ defmodule Edgehog.Astarte.Realm do
       multitenancy :allow_global
     end
 
-    read :by_name do
-      get_by :name
-    end
-
     create :create do
       primary? true
       accept [:name, :private_key, :cluster_id]

--- a/backend/lib/edgehog/astarte/realm/realm.ex
+++ b/backend/lib/edgehog/astarte/realm/realm.ex
@@ -25,12 +25,6 @@ defmodule Edgehog.Astarte.Realm do
   alias Edgehog.Astarte.Realm
   alias Edgehog.Validations
 
-  code_interface do
-    define :fetch_by_name, action: :by_name, args: [:name]
-    define :create
-    define :destroy
-  end
-
   actions do
     defaults [:read, :destroy]
 

--- a/backend/lib/edgehog/tenants/tenant/changes/provision_astarte_resources.ex
+++ b/backend/lib/edgehog/tenants/tenant/changes/provision_astarte_resources.ex
@@ -37,7 +37,7 @@ defmodule Edgehog.Tenants.Tenant.Changes.ProvisionAstarteResources do
   end
 
   defp create_cluster(astarte_config) do
-    case Astarte.Cluster.create(%{base_api_url: astarte_config.base_api_url}) do
+    case Astarte.create_cluster(%{base_api_url: astarte_config.base_api_url}) do
       {:ok, cluster} ->
         {:ok, cluster}
 
@@ -53,7 +53,7 @@ defmodule Edgehog.Tenants.Tenant.Changes.ProvisionAstarteResources do
       private_key: astarte_config.realm_private_key
     }
 
-    case Astarte.Realm.create(attrs, tenant: tenant) do
+    case Astarte.create_realm(attrs, tenant: tenant) do
       {:ok, realm} ->
         {:ok, realm}
 

--- a/backend/lib/edgehog/tenants/tenant/changes/trigger_reconciliation.ex
+++ b/backend/lib/edgehog/tenants/tenant/changes/trigger_reconciliation.ex
@@ -27,7 +27,7 @@ defmodule Edgehog.Tenants.Tenant.Changes.TriggerReconciliation do
   def change(changeset, _opts, _ctx) do
     Ash.Changeset.after_action(changeset, fn _changeset, tenant ->
       # TODO: this can probably be done with Ash notifiers, investigate that
-      Tenants.Tenant.reconcile(tenant)
+      Tenants.reconcile_tenant(tenant)
 
       {:ok, tenant}
     end)

--- a/backend/lib/edgehog/tenants/tenant/tenant.ex
+++ b/backend/lib/edgehog/tenants/tenant/tenant.ex
@@ -65,8 +65,6 @@ defmodule Edgehog.Tenants.Tenant do
       accept [:name, :slug, :public_key, :default_locale]
     end
 
-    read :by_slug, get_by: :slug
-
     read :current_tenant do
       description "Retrieves the current tenant."
       get? true

--- a/backend/lib/edgehog/tenants/tenant/tenant.ex
+++ b/backend/lib/edgehog/tenants/tenant/tenant.ex
@@ -57,14 +57,6 @@ defmodule Edgehog.Tenants.Tenant do
     end
   end
 
-  code_interface do
-    define :create
-    define :provision
-    define :fetch_by_slug, action: :by_slug, args: [:slug]
-    define :reconcile, args: [:tenant]
-    define :destroy
-  end
-
   actions do
     defaults [:read, :destroy]
 

--- a/backend/lib/edgehog/tenants/tenants.ex
+++ b/backend/lib/edgehog/tenants/tenants.ex
@@ -39,7 +39,7 @@ defmodule Edgehog.Tenants do
     resource Edgehog.Tenants.Tenant do
       define :create_tenant, action: :create
       define :provision_tenant, action: :provision
-      define :fetch_tenant_by_slug, action: :by_slug, args: [:slug]
+      define :fetch_tenant_by_slug, action: :read, get_by: :slug, not_found_error?: true
       define :reconcile_tenant, action: :reconcile, args: [:tenant]
       define :destroy_tenant, action: :destroy
     end

--- a/backend/lib/edgehog/tenants/tenants.ex
+++ b/backend/lib/edgehog/tenants/tenants.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,12 @@ defmodule Edgehog.Tenants do
   end
 
   resources do
-    resource Edgehog.Tenants.Tenant
+    resource Edgehog.Tenants.Tenant do
+      define :create_tenant, action: :create
+      define :provision_tenant, action: :provision
+      define :fetch_tenant_by_slug, action: :by_slug, args: [:slug]
+      define :reconcile_tenant, action: :reconcile, args: [:tenant]
+      define :destroy_tenant, action: :destroy
+    end
   end
 end

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -21,6 +21,7 @@
 defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
   use Ash.Resource.Actions.Implementation
 
+  alias Edgehog.Astarte
   alias Edgehog.Astarte.Realm
   alias Edgehog.Devices.Device
   alias Edgehog.OSManagement
@@ -50,7 +51,8 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
       |> Ash.Query.select([:id])
       |> Ash.Query.load(tenant: [:tenant_id])
 
-    with {:ok, realm} <- Realm.fetch_by_name(realm_name, query: read_query, tenant: tenant),
+    with {:ok, realm} <-
+           Astarte.fetch_realm_by_name(realm_name, query: read_query, tenant: tenant),
          {:ok, _} <- handle_event(event, realm.tenant, realm.id, device_id, timestamp) do
       :ok
     end

--- a/backend/lib/edgehog_web/populate_tenant.ex
+++ b/backend/lib/edgehog_web/populate_tenant.ex
@@ -30,7 +30,7 @@ defmodule EdgehogWeb.PopulateTenant do
   def call(conn, _opts) do
     tenant_slug = conn.path_params["tenant_slug"]
 
-    case Tenants.Tenant.fetch_by_slug(tenant_slug) do
+    case Tenants.fetch_tenant_by_slug(tenant_slug) do
       {:ok, tenant} ->
         Ash.PlugHelpers.set_tenant(conn, tenant)
 

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -104,7 +104,7 @@ cluster =
     name: "Test Cluster",
     base_api_url: read_env_var.("SEEDS_ASTARTE_BASE_API_URL")
   }
-  |> Astarte.Cluster.create!()
+  |> Astarte.create_cluster!()
 
 {status, private_key} =
   read_key!.("SEEDS_TENANT_PRIVATE_KEY_FILE", "SEEDS_TENANT_ORIGINAL_FILE", "tenant_private")
@@ -129,7 +129,7 @@ tenant =
     slug: "acme-inc",
     public_key: public_key
   }
-  |> Tenants.Tenant.create!()
+  |> Tenants.create_tenant!()
 
 {status, realm_pk} =
   read_key!.("SEEDS_REALM_PRIVATE_KEY_FILE", "SEEDS_REALM_ORIGINAL_FILE", "realm_private")
@@ -149,6 +149,6 @@ realm =
     name: read_env_var.("SEEDS_REALM"),
     private_key: realm_pk
   }
-  |> Astarte.Realm.create!(tenant: tenant)
+  |> Astarte.create_realm!(tenant: tenant)
 
 :ok

--- a/backend/test/edgehog/astarte/cluster_test.exs
+++ b/backend/test/edgehog/astarte/cluster_test.exs
@@ -23,6 +23,7 @@ defmodule Edgehog.Astarte.ClusterTest do
 
   @moduletag :ported_to_ash
 
+  alias Edgehog.Astarte
   alias Edgehog.Astarte.Cluster
 
   import Edgehog.AstarteFixtures
@@ -34,7 +35,7 @@ defmodule Edgehog.Astarte.ClusterTest do
     test "with valid data creates a cluster" do
       %{base_api_url: url, name: name} = @valid_attrs
 
-      assert {:ok, %Cluster{} = cluster} = Cluster.create(@valid_attrs)
+      assert {:ok, %Cluster{} = cluster} = Astarte.create_cluster(@valid_attrs)
       assert cluster.base_api_url == url
       assert cluster.name == name
     end
@@ -42,7 +43,7 @@ defmodule Edgehog.Astarte.ClusterTest do
     test "creates cluster without name" do
       %{base_api_url: url} = @valid_attrs
 
-      assert {:ok, %Cluster{} = cluster} = Cluster.create(%{base_api_url: url})
+      assert {:ok, %Cluster{} = cluster} = Astarte.create_cluster(%{base_api_url: url})
       assert cluster.base_api_url == url
       assert cluster.name == nil
     end
@@ -50,7 +51,7 @@ defmodule Edgehog.Astarte.ClusterTest do
     test "strips trailing slash from base_api_url" do
       attrs = %{base_api_url: "https://api.test.astarte.example/foo/", name: "test-trailing"}
 
-      assert {:ok, %Cluster{} = cluster} = Cluster.create(attrs)
+      assert {:ok, %Cluster{} = cluster} = Astarte.create_cluster(attrs)
       assert cluster.base_api_url == "https://api.test.astarte.example/foo"
     end
 
@@ -66,7 +67,7 @@ defmodule Edgehog.Astarte.ClusterTest do
       ]
 
       invalid_attrs_list
-      |> Enum.map(&Cluster.create/1)
+      |> Enum.map(&Astarte.create_cluster/1)
       |> Enum.each(fn result -> assert {:error, %Ash.Error.Invalid{}} = result end)
     end
 
@@ -79,7 +80,7 @@ defmodule Edgehog.Astarte.ClusterTest do
       invalid_schemas
       |> Enum.map(fn schema -> schema <> valid_host_name end)
       |> Enum.map(fn url -> %{base_api_url: url, name: valid_name} end)
-      |> Enum.map(&Cluster.create/1)
+      |> Enum.map(&Astarte.create_cluster/1)
       |> Enum.each(fn result -> assert {:error, %Ash.Error.Invalid{}} = result end)
     end
 
@@ -91,7 +92,7 @@ defmodule Edgehog.Astarte.ClusterTest do
       invalid_hosts
       |> Enum.map(fn host -> valid_schema <> host end)
       |> Enum.map(fn url -> %{base_api_url: url, name: valid_name} end)
-      |> Enum.map(&Cluster.create/1)
+      |> Enum.map(&Astarte.create_cluster/1)
       |> Enum.each(fn result -> assert {:error, %Ash.Error.Invalid{}} = result end)
     end
 
@@ -99,7 +100,7 @@ defmodule Edgehog.Astarte.ClusterTest do
       cluster = cluster_fixture()
 
       assert {:ok, upserted_cluster} =
-               Cluster.create(%{base_api_url: cluster.base_api_url, name: cluster.name})
+               Astarte.create_cluster(%{base_api_url: cluster.base_api_url, name: cluster.name})
 
       assert upserted_cluster.name == cluster.name
       assert upserted_cluster.base_api_url == cluster.base_api_url
@@ -109,7 +110,7 @@ defmodule Edgehog.Astarte.ClusterTest do
       cluster = cluster_fixture()
 
       assert {:ok, upserted_cluster} =
-               Cluster.create(%{base_api_url: cluster.base_api_url, name: "other"})
+               Astarte.create_cluster(%{base_api_url: cluster.base_api_url, name: "other"})
 
       assert upserted_cluster.name == cluster.name
     end

--- a/backend/test/edgehog/astarte/realm_test.exs
+++ b/backend/test/edgehog/astarte/realm_test.exs
@@ -37,7 +37,7 @@ defmodule Edgehog.Astarte.RealmTest do
       tenant = tenant_fixture()
       valid_attrs = %{cluster_id: cluster.id, name: "somename", private_key: @valid_private_key}
 
-      assert {:ok, %Realm{} = realm} = Realm.create(valid_attrs, tenant: tenant)
+      assert {:ok, %Realm{} = realm} = Astarte.create_realm(valid_attrs, tenant: tenant)
       assert realm.name == "somename"
       assert realm.private_key == @valid_private_key
       assert realm.tenant_id == tenant.tenant_id
@@ -91,21 +91,22 @@ defmodule Edgehog.Astarte.RealmTest do
       tenant = tenant_fixture()
       realm = realm_fixture(tenant: tenant)
 
-      assert {:ok, realm} = Realm.fetch_by_name(realm.name, tenant: tenant, load: [:cluster])
+      assert {:ok, realm} =
+               Astarte.fetch_realm_by_name(realm.name, tenant: tenant, load: [:cluster])
     end
 
     test "returns error for non-existing realm" do
       tenant = tenant_fixture()
 
       assert {:error, %Ash.Error.Query.NotFound{}} =
-               Realm.fetch_by_name("nonexisting", tenant: tenant)
+               Astarte.fetch_realm_by_name("nonexisting", tenant: tenant)
     end
   end
 
   test "destroy/1 deletes the realm" do
     tenant = tenant_fixture()
     realm = realm_fixture(tenant: tenant)
-    assert :ok = Realm.destroy(realm)
+    assert :ok = Astarte.destroy_realm(realm)
 
     assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
              Astarte.get(Realm, realm.id, tenant: tenant)
@@ -123,6 +124,6 @@ defmodule Edgehog.Astarte.RealmTest do
       name: unique_realm_name(),
       private_key: @valid_private_key
     })
-    |> Edgehog.Astarte.Realm.create(tenant: tenant)
+    |> Astarte.create_realm(tenant: tenant)
   end
 end

--- a/backend/test/edgehog/tenants_test.exs
+++ b/backend/test/edgehog/tenants_test.exs
@@ -41,7 +41,7 @@ defmodule Edgehog.TenantsTest do
                          |> X509.PrivateKey.to_pem()
                          |> String.trim()
 
-  describe "Tenant.create/1" do
+  describe "Tenants.create_tenant/1" do
     @describetag :ported_to_ash
 
     test "with valid data creates a tenant" do
@@ -52,7 +52,7 @@ defmodule Edgehog.TenantsTest do
 
       attrs = %{name: name, slug: slug, public_key: public_key, default_locale: default_locale}
 
-      assert {:ok, tenant} = Tenant.create(attrs)
+      assert {:ok, tenant} = Tenants.create_tenant(attrs)
 
       assert %Tenant{
                name: ^name,
@@ -69,7 +69,7 @@ defmodule Edgehog.TenantsTest do
         public_key: @valid_pem_public_key
       }
 
-      assert {:ok, %Tenant{} = tenant} = Tenant.create(attrs)
+      assert {:ok, %Tenant{} = tenant} = Tenants.create_tenant(attrs)
       assert tenant.default_locale == "en-US"
     end
 
@@ -128,7 +128,7 @@ defmodule Edgehog.TenantsTest do
     end
   end
 
-  describe "Tenant.reconcile/1" do
+  describe "Tenants.reconcile_tenant/1" do
     test "triggers tenant reconciliation" do
       Edgehog.Tenants.ReconcilerMock
       |> expect(:reconcile_tenant, fn %Tenant{} = tenant ->
@@ -138,11 +138,11 @@ defmodule Edgehog.TenantsTest do
       end)
 
       tenant = tenant_fixture()
-      assert :ok = Tenant.reconcile!(tenant)
+      assert :ok = Tenants.reconcile_tenants!(tenant)
     end
   end
 
-  describe "Tenant.provision/1" do
+  describe "Tenants.provision_tenant/1" do
     @describetag :ported_to_ash
 
     test "with valid attrs creates the tenant, cluster and realm" do
@@ -166,7 +166,7 @@ defmodule Edgehog.TenantsTest do
         }
       }
 
-      assert {:ok, tenant} = Tenant.provision(attrs)
+      assert {:ok, tenant} = Tenants.provision_tenant(attrs)
 
       assert %Tenant{
                name: ^tenant_name,
@@ -194,7 +194,7 @@ defmodule Edgehog.TenantsTest do
         }
       }
 
-      assert {:ok, %Tenant{} = tenant} = Tenant.provision(attrs)
+      assert {:ok, %Tenant{} = tenant} = Tenants.provision_tenant(attrs)
       assert tenant.default_locale == "en-US"
     end
 
@@ -278,7 +278,7 @@ defmodule Edgehog.TenantsTest do
     end
   end
 
-  describe "Tenant.destroy/1" do
+  describe "Tenants.destroy_tenant/1" do
     import Edgehog.AstarteFixtures
     import Edgehog.BaseImagesFixtures
     import Edgehog.DevicesFixtures
@@ -294,8 +294,8 @@ defmodule Edgehog.TenantsTest do
 
     @tag :ported_to_ash
     test "deletes the tenant", %{tenant: tenant} do
-      assert :ok = Tenant.destroy(tenant)
-      assert_raise Ash.Error.Query.NotFound, fn -> Tenant.fetch_by_slug!(tenant.slug) end
+      assert :ok = Tenants.destroy_tenant(tenant)
+      assert_raise Ash.Error.Query.NotFound, fn -> Tenants.fetch_tenant_by_slug!(tenant.slug) end
     end
 
     test "cascading deletes associated realm", %{tenant: tenant} do
@@ -304,7 +304,7 @@ defmodule Edgehog.TenantsTest do
       realm = realm_fixture(cluster)
 
       assert {:ok, ^realm} = Astarte.fetch_realm_by_name(realm.name)
-      assert :ok = Tenant.destroy(tenant)
+      assert :ok = Tenants.destroy_tenant(tenant)
       {:error, :realm_not_found} = Astarte.fetch_realm_by_name(realm.name)
     end
 
@@ -328,7 +328,7 @@ defmodule Edgehog.TenantsTest do
       update_campaign = update_campaign_fixture()
       update_target = target_fixture()
 
-      assert :ok = Tenant.destroy(tenant)
+      assert :ok = Tenants.destroy_tenant(tenant)
 
       refute entry_exists?(Edgehog.Devices.HardwareType, hardware_type.id)
       refute entry_exists?(Edgehog.Devices.SystemModel, system_model.id)
@@ -367,7 +367,7 @@ defmodule Edgehog.TenantsTest do
         astarte_config: astarte_config
       })
 
-    Tenant.provision(attrs)
+    Tenants.provision_tenant(attrs)
   end
 
   defp create_tenant(opts) do
@@ -384,7 +384,7 @@ defmodule Edgehog.TenantsTest do
       slug: unique_tenant_slug(),
       public_key: public_key
     })
-    |> Tenant.create()
+    |> Tenants.create_tenant()
   end
 
   defp entry_exists?(schema, id) do

--- a/backend/test/edgehog_web/admin_api/tenants/tenant_test.exs
+++ b/backend/test/edgehog_web/admin_api/tenants/tenant_test.exs
@@ -76,7 +76,7 @@ defmodule EdgehogWeb.AdminAPI.Tenants.TenantTest do
 
       assert response(conn, :created)
 
-      assert tenant = Tenants.Tenant.fetch_by_slug!(tenant_slug)
+      assert tenant = Tenants.fetch_tenant_by_slug!(tenant_slug)
 
       assert %Tenants.Tenant{
                name: ^tenant_name,
@@ -118,7 +118,7 @@ defmodule EdgehogWeb.AdminAPI.Tenants.TenantTest do
 
       assert response(conn, :created)
 
-      assert tenant = Tenants.Tenant.fetch_by_slug!(tenant_slug)
+      assert tenant = Tenants.fetch_tenant_by_slug!(tenant_slug)
 
       assert tenant.default_locale == "en-US"
     end

--- a/backend/test/support/fixtures/astarte_fixtures.ex
+++ b/backend/test/support/fixtures/astarte_fixtures.ex
@@ -49,7 +49,7 @@ defmodule Edgehog.AstarteFixtures do
       base_api_url: unique_cluster_base_api_url(),
       name: unique_cluster_name()
     })
-    |> Edgehog.Astarte.Cluster.create!()
+    |> Edgehog.Astarte.create_cluster!()
   end
 
   @private_key X509.PrivateKey.new_ec(:secp256r1) |> X509.PrivateKey.to_pem()
@@ -69,7 +69,7 @@ defmodule Edgehog.AstarteFixtures do
       name: unique_realm_name(),
       private_key: @private_key
     })
-    |> Edgehog.Astarte.Realm.create!(tenant: tenant.tenant_id)
+    |> Edgehog.Astarte.create_realm!(tenant: tenant.tenant_id)
   end
 
   @doc """


### PR DESCRIPTION
Use Ash domains as the default module to define code interfaces

Closes #509
