### PR TITLE
Format error `fields` when setting device led behavior

### DIFF
--- a/frontend/src/components/LedBehaviorDropdown.tsx
+++ b/frontend/src/components/LedBehaviorDropdown.tsx
@@ -124,7 +124,9 @@ const LedBehaviorDropdown = ({ deviceId, disabled, onError }: Props) => {
         onCompleted(data, errors) {
           if (errors) {
             const errorFeedback = errors
-              .map((error) => error.message)
+              .map(({ fields, message }) =>
+                fields.length ? `${fields.join(" ")} ${message}` : message,
+              )
               .join(". \n");
             return onError(errorFeedback);
           }


### PR DESCRIPTION
Change formatting for the errors encountered when trying to set the led behavior for a device: as already done in other GraphQL mutations, format the `fields` property of each error when available to display futher details about the error.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
