### PR TITLE
Remove unused `device_fixture/2` function

### DIFF
--- a/backend/test/support/fixtures/devices_fixtures.ex
+++ b/backend/test/support/fixtures/devices_fixtures.ex
@@ -156,8 +156,4 @@ defmodule Edgehog.DevicesFixtures do
     |> Ash.Changeset.for_update(:add_tags, %{tags: tags})
     |> Ash.update!()
   end
-
-  # Needed to avoid legacy tests compilation errors
-  # TODO: remove when Ash porting is complete
-  def device_fixture(_, _), do: nil
 end


### PR DESCRIPTION
The function's stub was left to support compiling the app, including legacy code and tests.
Now that all tests were ported to Ash, the function is not needed and can be removed.

Closes #267

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
