### PR TITLE
Prefer default `read` action over `list` and `get`

### DIFF
--- a/backend/lib/edgehog/base_images/base_image/base_image.ex
+++ b/backend/lib/edgehog/base_images/base_image/base_image.ex
@@ -42,6 +42,8 @@ defmodule Edgehog.BaseImages.BaseImage do
   end
 
   actions do
+    defaults [:read]
+
     create :create do
       description "Create a new base image in a base image collection."
       primary? true
@@ -101,16 +103,6 @@ defmodule Edgehog.BaseImages.BaseImage do
       change {Localization.Changes.UpsertLocalizedAttribute,
               input_argument: :localized_release_display_names,
               target_attribute: :release_display_name}
-    end
-
-    read :get do
-      description "Returns a single base image."
-      get? true
-    end
-
-    read :list do
-      description "Returns a list of base images."
-      primary? true
     end
 
     update :update do

--- a/backend/lib/edgehog/base_images/base_image_collection.ex
+++ b/backend/lib/edgehog/base_images/base_image_collection.ex
@@ -41,6 +41,8 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
   end
 
   actions do
+    defaults [:read]
+
     create :create do
       description "Creates a new base image collection."
       primary? true
@@ -53,16 +55,6 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
       end
 
       change manage_relationship(:system_model_id, :system_model, type: :append)
-    end
-
-    read :get do
-      description "Returns a single base image."
-      get? true
-    end
-
-    read :list do
-      description "Returns a list of base images."
-      primary? true
     end
 
     update :update do

--- a/backend/lib/edgehog/base_images/base_images.ex
+++ b/backend/lib/edgehog/base_images/base_images.ex
@@ -32,9 +32,18 @@ defmodule Edgehog.BaseImages do
     root_level_errors? true
 
     queries do
-      get Edgehog.BaseImages.BaseImage, :base_image, :get
-      get Edgehog.BaseImages.BaseImageCollection, :base_image_collection, :get
-      list Edgehog.BaseImages.BaseImageCollection, :base_image_collections, :list
+      get Edgehog.BaseImages.BaseImage, :base_image, :read do
+        description "Returns a single base image."
+      end
+
+      get Edgehog.BaseImages.BaseImageCollection, :base_image_collection, :read do
+        description "Returns a single base image collection."
+      end
+
+      list Edgehog.BaseImages.BaseImageCollection, :base_image_collections, :read do
+        description "Returns a list of base image collections."
+        paginate_with nil
+      end
     end
 
     mutations do

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -51,7 +51,7 @@ defmodule Edgehog.Devices.Device do
   end
 
   actions do
-    defaults [:destroy]
+    defaults [:read, :destroy]
 
     create :create do
       primary? true
@@ -162,16 +162,6 @@ defmodule Edgehog.Devices.Device do
       # We also set the device to online since it sent some data. This helps resynchronizing the
       # online state for long-running devices if a device connected trigger is missed
       change set_attribute(:online, true)
-    end
-
-    read :get do
-      description "Returns a single device."
-      get? true
-    end
-
-    read :list do
-      description "Returns a list of devices."
-      primary? true
     end
 
     update :update do

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -32,12 +32,32 @@ defmodule Edgehog.Devices do
     root_level_errors? true
 
     queries do
-      get Edgehog.Devices.Device, :device, :get
-      list Edgehog.Devices.Device, :devices, :list
-      get Edgehog.Devices.HardwareType, :hardware_type, :get
-      list Edgehog.Devices.HardwareType, :hardware_types, :list
-      get Edgehog.Devices.SystemModel, :system_model, :get
-      list Edgehog.Devices.SystemModel, :system_models, :list
+      get Edgehog.Devices.Device, :device, :read do
+        description "Returns a single device."
+      end
+
+      list Edgehog.Devices.Device, :devices, :read do
+        description "Returns a list of devices."
+        paginate_with nil
+      end
+
+      get Edgehog.Devices.HardwareType, :hardware_type, :read do
+        description "Returns a single hardware type."
+      end
+
+      list Edgehog.Devices.HardwareType, :hardware_types, :read do
+        description "Returns a list of hardware types."
+        paginate_with nil
+      end
+
+      get Edgehog.Devices.SystemModel, :system_model, :read do
+        description "Returns a single system model."
+      end
+
+      list Edgehog.Devices.SystemModel, :system_models, :read do
+        description "Returns a list of system models."
+        paginate_with nil
+      end
     end
 
     mutations do

--- a/backend/lib/edgehog/devices/hardware_type.ex
+++ b/backend/lib/edgehog/devices/hardware_type.ex
@@ -43,15 +43,7 @@ defmodule Edgehog.Devices.HardwareType do
   end
 
   actions do
-    read :get do
-      description "Returns a hardware type."
-      get? true
-    end
-
-    read :list do
-      description "Returns a list of hardware types."
-      primary? true
-    end
+    defaults [:read]
 
     create :create do
       description "Creates a hardware type."

--- a/backend/lib/edgehog/devices/system_model/system_model.ex
+++ b/backend/lib/edgehog/devices/system_model/system_model.ex
@@ -43,15 +43,7 @@ defmodule Edgehog.Devices.SystemModel do
   end
 
   actions do
-    read :get do
-      description "Returns a system model."
-      get? true
-    end
-
-    read :list do
-      description "Returns a list of system models."
-      primary? true
-    end
+    defaults [:read]
 
     create :create do
       description "Creates a system model."

--- a/backend/lib/edgehog/groups/device_group/device_group.ex
+++ b/backend/lib/edgehog/groups/device_group/device_group.ex
@@ -32,21 +32,13 @@ defmodule Edgehog.Groups.DeviceGroup do
   end
 
   actions do
+    defaults [:read]
+
     create :create do
       description "Creates a new device group."
       primary? true
 
       accept [:name, :handle, :selector]
-    end
-
-    read :get do
-      description "Returns a single device group."
-      get? true
-    end
-
-    read :list do
-      description "Returns the list of all device groups."
-      primary? true
     end
 
     update :update do

--- a/backend/lib/edgehog/groups/groups.ex
+++ b/backend/lib/edgehog/groups/groups.ex
@@ -29,8 +29,14 @@ defmodule Edgehog.Groups do
     root_level_errors? true
 
     queries do
-      get Edgehog.Groups.DeviceGroup, :device_group, :get
-      list Edgehog.Groups.DeviceGroup, :device_groups, :list
+      get Edgehog.Groups.DeviceGroup, :device_group, :read do
+        description "Returns a single device group."
+      end
+
+      list Edgehog.Groups.DeviceGroup, :device_groups, :read do
+        description "Returns a list of device groups."
+        paginate_with nil
+      end
     end
 
     mutations do

--- a/backend/lib/edgehog/labeling/labeling.ex
+++ b/backend/lib/edgehog/labeling/labeling.ex
@@ -29,7 +29,9 @@ defmodule Edgehog.Labeling do
     root_level_errors? true
 
     queries do
-      list Edgehog.Labeling.Tag, :existing_device_tags, :assigned_to_devices
+      list Edgehog.Labeling.Tag, :existing_device_tags, :read_assigned_to_devices do
+        paginate_with nil
+      end
     end
   end
 

--- a/backend/lib/edgehog/labeling/tag.ex
+++ b/backend/lib/edgehog/labeling/tag.ex
@@ -48,7 +48,7 @@ defmodule Edgehog.Labeling.Tag do
       change {Edgehog.Changes.NormalizeTagName, attribute: :name}
     end
 
-    read :assigned_to_devices do
+    read :read_assigned_to_devices do
       description "Returns Tags currently assigned to some device."
       prepare build(filter: expr(exists(device_tags, true)))
     end


### PR DESCRIPTION
The default `read` action is preferred as the backing bone to support queries in GraphQL APIs.
This change removes the distinction of "get" and "list" actions on the resource: this distinction only becomes relevant in code interfaces or GraphQL APIs.

Close #522

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
