### PR TITLE
Fix Credo warnings

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -85,7 +85,7 @@ jobs:
       run: mix format --check-formatted
 
     - name: Run Credo code analysis
-      run: mix credo
+      run: mix credo --strict
 
     - name: Check for unused dependencies
       run: mix do deps.get, deps.unlock --check-unused

--- a/backend/lib/edgehog/application.ex
+++ b/backend/lib/edgehog/application.ex
@@ -28,6 +28,8 @@ defmodule Edgehog.Application do
   use Application
   require Logger
   alias Edgehog.Config
+  alias EdgehogWeb.Endpoint
+  alias EdgehogWeb.Router
 
   @impl true
   def start(_type, _args) do
@@ -37,7 +39,7 @@ defmodule Edgehog.Application do
 
     # We inject this here so that the non-web part of the application doesn't depend on the web part
     tenant_to_trigger_url_fun = fn %Edgehog.Tenants.Tenant{slug: slug} ->
-      EdgehogWeb.Router.Helpers.astarte_trigger_url(EdgehogWeb.Endpoint, :process_event, slug)
+      Router.Helpers.astarte_trigger_url(Endpoint, :process_event, slug)
     end
 
     children = [
@@ -57,7 +59,7 @@ defmodule Edgehog.Application do
       {Edgehog.Tenants.Reconciler.Supervisor,
        tenant_to_trigger_url_fun: tenant_to_trigger_url_fun},
       # Start the Endpoint (http/https)
-      EdgehogWeb.Endpoint
+      Endpoint
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/backend/lib/edgehog/astarte/realm/calculations/realm_management_client.ex
+++ b/backend/lib/edgehog/astarte/realm/calculations/realm_management_client.ex
@@ -21,6 +21,8 @@
 defmodule Edgehog.Astarte.Realm.Calculations.RealmManagementClient do
   use Ash.Resource.Calculation
 
+  alias Astarte.Client.RealmManagement
+
   @impl true
   def load(_query, _opts, _context) do
     [cluster: [:base_api_url]]
@@ -37,7 +39,7 @@ defmodule Edgehog.Astarte.Realm.Calculations.RealmManagementClient do
         }
       } = realm
 
-      case Astarte.Client.RealmManagement.new(base_api_url, realm_name, private_key: private_key) do
+      case RealmManagement.new(base_api_url, realm_name, private_key: private_key) do
         {:ok, client} -> client
         _error -> nil
       end

--- a/backend/lib/edgehog/devices/device/calculations/appengine_client.ex
+++ b/backend/lib/edgehog/devices/device/calculations/appengine_client.ex
@@ -21,6 +21,8 @@
 defmodule Edgehog.Devices.Device.Calculations.AppEngineClient do
   use Ash.Resource.Calculation
 
+  alias Astarte.Client.AppEngine
+
   @impl true
   def load(_query, _opts, _context) do
     [realm: [:name, :private_key, cluster: [:base_api_url]]]
@@ -40,7 +42,7 @@ defmodule Edgehog.Devices.Device.Calculations.AppEngineClient do
       } = device
 
       # TODO: scope client claims to the device
-      case Astarte.Client.AppEngine.new(base_api_url, realm_name, private_key: private_key) do
+      case AppEngine.new(base_api_url, realm_name, private_key: private_key) do
         {:ok, client} -> client
         _error -> nil
       end

--- a/backend/lib/edgehog/devices/system_model/system_model.ex
+++ b/backend/lib/edgehog/devices/system_model/system_model.ex
@@ -25,9 +25,9 @@ defmodule Edgehog.Devices.SystemModel do
       AshGraphql.Resource
     ]
 
-  alias Edgehog.Localization
   alias Edgehog.Devices.SystemModel.Changes
   alias Edgehog.Devices.SystemModel.Validations
+  alias Edgehog.Localization
 
   resource do
     description """

--- a/backend/lib/edgehog/forwarder/session/manual_actions/request_session.ex
+++ b/backend/lib/edgehog/forwarder/session/manual_actions/request_session.ex
@@ -22,6 +22,7 @@ defmodule Edgehog.Forwarder.Session.ManualActions.RequestSession do
   use Ash.Resource.Actions.Implementation
 
   alias Edgehog.Devices.Device
+  alias Edgehog.Forwarder
 
   @forwarder_session_module Application.compile_env(
                               :edgehog,
@@ -69,8 +70,8 @@ defmodule Edgehog.Forwarder.Session.ManualActions.RequestSession do
     end
   end
 
-  defp fetch_forwarder_config() do
-    Ash.read_one(Edgehog.Forwarder.Config, not_found_error?: true)
+  defp fetch_forwarder_config do
+    Ash.read_one(Forwarder.Config, not_found_error?: true)
   end
 
   defp validate_device_connected(%Device{online: true}) do

--- a/backend/lib/edgehog/forwarder/session/manual_actions/request_session.ex
+++ b/backend/lib/edgehog/forwarder/session/manual_actions/request_session.ex
@@ -21,6 +21,7 @@
 defmodule Edgehog.Forwarder.Session.ManualActions.RequestSession do
   use Ash.Resource.Actions.Implementation
 
+  alias Ash.Error.Changes.InvalidArgument
   alias Edgehog.Devices.Device
   alias Edgehog.Forwarder
 
@@ -80,7 +81,7 @@ defmodule Edgehog.Forwarder.Session.ManualActions.RequestSession do
 
   defp validate_device_connected(%Device{online: false}) do
     {:error,
-     Ash.Error.Changes.InvalidArgument.exception(
+     InvalidArgument.exception(
        field: :device_id,
        message: "device is disconnected"
      )}

--- a/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
+++ b/backend/lib/edgehog/geolocation/providers/google_geolocation.ex
@@ -22,8 +22,8 @@ defmodule Edgehog.Geolocation.Providers.GoogleGeolocation do
   @behaviour Edgehog.Geolocation.GeolocationProvider
 
   alias Edgehog.Astarte.Device.WiFiScanResult
-  alias Edgehog.Devices.Device
   alias Edgehog.Config
+  alias Edgehog.Devices.Device
   alias Edgehog.Geolocation.Position
 
   use Tesla

--- a/backend/lib/edgehog/os_management/ota_operation/manual_actions/send_update_request.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/manual_actions/send_update_request.ex
@@ -22,6 +22,7 @@ defmodule Edgehog.OSManagement.OTAOperation.ManualActions.SendUpdateRequest do
   use Ash.Resource.Actions.Implementation
 
   alias Edgehog.Astarte.Device.OTARequest
+  alias Edgehog.Error.AstarteAPIError
 
   @ota_request_v1_module Application.compile_env(
                            :edgehog,
@@ -48,7 +49,7 @@ defmodule Edgehog.OSManagement.OTAOperation.ManualActions.SendUpdateRequest do
     with {:error, %Astarte.Client.APIError{} = api_error} <-
            @ota_request_v1_module.update(client, device_id, ota_operation_id, base_image_url) do
       reason =
-        Edgehog.Error.AstarteAPIError.exception(
+        AstarteAPIError.exception(
           status: api_error.status,
           response: api_error.response
         )

--- a/backend/lib/edgehog/selector/ast/binary_op.ex
+++ b/backend/lib/edgehog/selector/ast/binary_op.ex
@@ -23,10 +23,12 @@ defmodule Edgehog.Selector.AST.BinaryOp do
 
   import Ash.Expr
 
-  defimpl Edgehog.Selector.Filter do
+  alias Edgehog.Selector
+
+  defimpl Selector.Filter do
     def to_ash_expr(binary_op) do
-      lhs = Edgehog.Selector.Filter.to_ash_expr(binary_op.lhs)
-      rhs = Edgehog.Selector.Filter.to_ash_expr(binary_op.rhs)
+      lhs = Selector.Filter.to_ash_expr(binary_op.lhs)
+      rhs = Selector.Filter.to_ash_expr(binary_op.rhs)
 
       case binary_op.operator do
         :and -> expr(^lhs and ^rhs)

--- a/backend/lib/edgehog/tenants/reconciler.ex
+++ b/backend/lib/edgehog/tenants/reconciler.ex
@@ -22,9 +22,9 @@ defmodule Edgehog.Tenants.Reconciler do
   @behaviour Edgehog.Tenants.Reconciler.Behaviour
   use GenServer
 
-  alias Edgehog.Tenants.Tenant
   alias Edgehog.Tenants.Reconciler.Core
   alias Edgehog.Tenants.Reconciler.TaskSupervisor
+  alias Edgehog.Tenants.Tenant
 
   @reconcile_interval :timer.minutes(10)
 

--- a/backend/lib/edgehog/tenants/tenant/tenant.ex
+++ b/backend/lib/edgehog/tenants/tenant/tenant.ex
@@ -27,6 +27,7 @@ defmodule Edgehog.Tenants.Tenant do
       AshJsonApi.Resource
     ]
 
+  alias Ash.Error.Invalid.TenantRequired
   alias Edgehog.Tenants.AstarteConfig
   alias Edgehog.Tenants.Tenant
   alias Edgehog.Validations
@@ -75,7 +76,7 @@ defmodule Edgehog.Tenants.Tenant do
         else
           Ash.Query.add_error(
             query,
-            Ash.Error.Invalid.TenantRequired.exception(resource: query.resource)
+            TenantRequired.exception(resource: query.resource)
           )
         end
       end

--- a/backend/lib/edgehog/update_campaigns/update_channel/changes/relate_target_groups.ex
+++ b/backend/lib/edgehog/update_campaigns/update_channel/changes/relate_target_groups.ex
@@ -21,6 +21,7 @@
 defmodule Edgehog.UpdateCampaigns.UpdateChannel.Changes.RelateTargetGroups do
   use Ash.Resource.Change
 
+  alias Ash.Error.Changes.InvalidArgument
   alias Edgehog.Groups.DeviceGroup
 
   @impl true
@@ -48,7 +49,7 @@ defmodule Edgehog.UpdateCampaigns.UpdateChannel.Changes.RelateTargetGroups do
       {:ok, update_channel}
     else
       {:error,
-       Ash.Error.Changes.InvalidArgument.exception(
+       InvalidArgument.exception(
          field: :target_group_ids,
          message:
            "some target groups were not found or are already associated with an update channel"

--- a/backend/test/edgehog/config/jwt_public_key_pem_type_test.exs
+++ b/backend/test/edgehog/config/jwt_public_key_pem_type_test.exs
@@ -21,8 +21,8 @@
 defmodule Edgehog.Config.JWTPublicKeyPEMTypeTest do
   use ExUnit.Case, async: true
 
-  alias JOSE.JWK
   alias Edgehog.Config.JWTPublicKeyPEMType
+  alias JOSE.JWK
 
   @public_key_path "admin_public_key.pem"
 

--- a/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
@@ -21,6 +21,7 @@
 defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
   use Edgehog.DataCase, async: true
 
+  alias Ecto.Adapters.SQL
   alias Edgehog.OSManagement
   alias Edgehog.OSManagement.OTAOperation
   alias Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Core
@@ -801,7 +802,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
     Enum.each(@executor_allowed_mocks, &Mox.allow(&1, self(), pid))
 
     # Also allow the pid to use SQL Sandbox
-    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+    SQL.Sandbox.allow(Repo, self(), pid)
 
     pid
   end

--- a/backend/test/edgehog/update_campaigns/resumer/core_test.exs
+++ b/backend/test/edgehog/update_campaigns/resumer/core_test.exs
@@ -24,8 +24,8 @@ defmodule Edgehog.UpdateCampaigns.Resumer.CoreTest do
   import Edgehog.TenantsFixtures
   import Edgehog.UpdateCampaignsFixtures
 
-  alias Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout
   alias Edgehog.UpdateCampaigns.Resumer.Core
+  alias Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout
   alias Edgehog.UpdateCampaigns.UpdateCampaign
 
   describe "stream_resumable_update_campaigns/0" do

--- a/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
@@ -21,8 +21,8 @@
 defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
   use EdgehogWeb.GraphqlCase
 
-  alias Edgehog.PubSub
   alias Edgehog.OSManagement.OTAOperation
+  alias Edgehog.PubSub
 
   import Edgehog.DevicesFixtures
 

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -626,8 +626,8 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
   end
 
   describe "device location/position" do
-    alias Edgehog.Geolocation.GeolocationProviderMock
     alias Edgehog.Geolocation.GeocodingProviderMock
+    alias Edgehog.Geolocation.GeolocationProviderMock
     alias Edgehog.Geolocation.Location
     alias Edgehog.Geolocation.Position
 

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -474,6 +474,8 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
   end
 
   describe "capabilities" do
+    alias Edgehog.Tenants.Reconciler.AstarteResources
+
     setup %{tenant: tenant} do
       fixture = device_fixture(tenant: tenant)
       device_id = fixture.device_id
@@ -487,7 +489,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
       %{tenant: tenant, id: id, device_id: device_id} = ctx
 
       all_interfaces_introspection =
-        Edgehog.Tenants.Reconciler.AstarteResources.load_interfaces()
+        AstarteResources.load_interfaces()
         |> Map.new(fn
           %{
             "interface_name" => name,

--- a/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
+++ b/backend/test/edgehog_web/schema/query/forwarder_config_test.exs
@@ -69,7 +69,7 @@ defmodule EdgehogWeb.Schema.Query.ForwarderConfigTest do
     original_config
   end
 
-  defp mock_unconfigured_forwarder() do
+  defp mock_unconfigured_forwarder do
     original_config = Application.fetch_env!(:edgehog, :edgehog_forwarder)
 
     Application.put_env(:edgehog, :edgehog_forwarder, %{

--- a/backend/test/support/admin_api/conn_case.ex
+++ b/backend/test/support/admin_api/conn_case.ex
@@ -52,9 +52,12 @@ defmodule EdgehogWeb.AdminAPI.ConnCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
+  alias EdgehogWeb.Auth.Token
+
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
 
     conn =
       Phoenix.ConnTest.build_conn()
@@ -104,7 +107,7 @@ defmodule EdgehogWeb.AdminAPI.ConnCase do
 
     # Generate the JWT
     {:ok, jwt, _claims} =
-      EdgehogWeb.Auth.Token.encode_and_sign("dontcare", claims,
+      Token.encode_and_sign("dontcare", claims,
         secret: jwk,
         allowed_algos: ["ES256"]
       )

--- a/backend/test/support/channel_case.ex
+++ b/backend/test/support/channel_case.ex
@@ -48,9 +48,11 @@ defmodule EdgehogWeb.ChannelCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
+
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
     :ok
   end
 end

--- a/backend/test/support/conn_case.ex
+++ b/backend/test/support/conn_case.ex
@@ -55,9 +55,12 @@ defmodule EdgehogWeb.ConnCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
+  alias EdgehogWeb.Auth.Token
+
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
 
     conn = Phoenix.ConnTest.build_conn()
 
@@ -92,7 +95,7 @@ defmodule EdgehogWeb.ConnCase do
 
     # Generate the JWT
     {:ok, jwt, _claims} =
-      EdgehogWeb.Auth.Token.encode_and_sign("dontcare", claims,
+      Token.encode_and_sign("dontcare", claims,
         secret: jwk,
         allowed_algos: ["ES256"]
       )

--- a/backend/test/support/data_case.ex
+++ b/backend/test/support/data_case.ex
@@ -48,13 +48,15 @@ defmodule Edgehog.DataCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
+
   import Mox
 
   setup :verify_on_exit!
 
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
   end
 
   @doc """

--- a/backend/test/support/graphql_case.ex
+++ b/backend/test/support/graphql_case.ex
@@ -28,13 +28,15 @@ defmodule EdgehogWeb.GraphqlCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
+
   import Mox
 
   setup :verify_on_exit!
 
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Edgehog.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
 
     %{tenant: Edgehog.TenantsFixtures.tenant_fixture()}
   end


### PR DESCRIPTION
The PR fixes all relevant warnings yielded when running Credo strict checks: `mix credo --strict`.
It then changes the CI workflow to run Credo with the `--strict` flag.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
