### PR TITLE
Fix: add padding in Sidebar since Bootstrap does not apply it

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -48,7 +48,7 @@ const SidebarItem = ({
   return (
     <NavLink
       as={Link}
-      className={`w-100 d-flex align-items-center ${
+      className={`px-3 py-2 w-100 d-flex align-items-center ${
         isActive ? "text-light bg-primary" : "text-dark"
       }`}
       {...linkProps}


### PR DESCRIPTION
Recent versions of Bootstrap were subject to refactoring to use CSS variables as a way to define the CSS values used in components.
This change results in the `.nav-link` class not applying the correct padding anymore to the component, so this commit manually adds the padding back to keep the sidebar usable.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
