### PR TITLE
Chore: fix code wrongly formatted by Styler

### DIFF
--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -59,6 +59,16 @@ config :edgehog, EdgehogWeb.Endpoint,
 # The `http:` config above can be replaced with:
 #
 #     https: [
+#       port: 4001,
+#       cipher_suite: :strong,
+#       keyfile: "priv/cert/selfsigned_key.pem",
+#       certfile: "priv/cert/selfsigned.pem"
+#     ],
+#
+# If desired, both `http:` and `https:` keys can be
+# configured to run both http and https servers on
+# different ports.
+
 config :ex_aws, :s3,
   scheme: "http://",
   host: "localhost",
@@ -72,23 +82,13 @@ config :goth,
   disabled: true
 
 # Do not include timestamps in development logs
-#       port: 4001,
-#       cipher_suite: :strong,
-#       keyfile: "priv/cert/selfsigned_key.pem",
-#       certfile: "priv/cert/selfsigned.pem"
 config :logger, :console, format: "[$level] $message $metadata\n"
 
 # Initialize plugs at runtime for faster development compilation
-#     ],
-#
-# If desired, both `http:` and `https:` keys can be
 config :phoenix, :plug_init_mode, :runtime
 
 # Set a higher stacktrace during development. Avoid configuring such
-# configured to run both http and https servers on
 # in production as building large stacktraces may be expensive.
-# different ports.
-
 config :phoenix, :stacktrace_depth, 20
 
 config :waffle,

--- a/backend/config/prod.exs
+++ b/backend/config/prod.exs
@@ -31,12 +31,11 @@ import Config
 # before starting your production server.
 config :edgehog, EdgehogWeb.Endpoint, url: [host: "example.com", port: 80]
 
+# Configure Logfmt
 config :logger, :console, format: {PrettyLog.LogfmtFormatter, :format}
 
 # Do not print debug messages in production
 config :logger, level: :info
-
-# Configure Logfmt
 
 # ## SSL Support
 #

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -47,7 +47,7 @@ config :edgehog, EdgehogWeb.Endpoint,
   secret_key_base: "cJMfZ0TGL4Dy0e4kzSn5SrODWbgzWJ7E0rfWMKWvrtdiUjuYDrOQstMY/36V2ccd",
   server: false
 
-# Storage mocks for tests
+# Mocks for tests
 config :edgehog, :assets_system_model_picture_module, Edgehog.Assets.SystemModelPictureMock
 config :edgehog, :astarte_base_image_module, Edgehog.Astarte.Device.BaseImageMock
 config :edgehog, :astarte_battery_status_module, Edgehog.Astarte.Device.BatteryStatusMock
@@ -56,7 +56,6 @@ config :edgehog,
        :astarte_cellular_connection_module,
        Edgehog.Astarte.Device.CellularConnectionMock
 
-# Astarte mocks for tests
 config :edgehog, :astarte_device_status_module, Edgehog.Astarte.Device.DeviceStatusMock
 config :edgehog, :astarte_forwarder_session_module, Edgehog.Astarte.Device.ForwarderSessionMock
 config :edgehog, :astarte_geolocation_module, Edgehog.Astarte.Device.GeolocationMock
@@ -80,9 +79,10 @@ config :edgehog, :reconciler_module, Edgehog.Tenants.ReconcilerMock
 
 # Enable s3 storage since we're using mocks for it
 config :edgehog, enable_s3_storage?: true
+
+# Geolocation mocks for tests
 config :edgehog, google_geocoding_api_key: "test_api_key"
 config :edgehog, google_geolocation_api_key: "test_api_key"
-# Geolocation mocks for tests
 config :edgehog, ipbase_api_key: "test_api_key"
 
 config :edgehog,

--- a/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
@@ -260,11 +260,11 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       parent = self()
 
       expect(OTARequestV1Mock, :update, max_updates, fn _client, _device_id, ota_operation_id, _url ->
+        # Since we don't know _which_ target will receive the request, we send it back from here
         send(parent, {:updated_target, ota_operation_id})
         :ok
       end)
 
-      # Since we don't know _which_ target will receive the request, we send it back from here
       pid = start_executor!(update_campaign)
 
       # Wait for the Executor to arrive at :wait_for_available_slot
@@ -398,10 +398,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       } = ctx
 
       expect(BaseImageMock, :get, target_count, fn _client, _device_id ->
+        # Reply like the target already has the correct base image version
         {:ok, astarte_base_image_with_version(base_image_version)}
       end)
 
-      # Reply like the target already has the correct base image version
       start_execution(pid)
 
       assert_normal_exit(pid, ref)
@@ -419,10 +419,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       } = ctx
 
       expect(BaseImageMock, :get, target_count, fn _client, _device_id ->
+        # Reply like the target already has an higher version
         {:ok, astarte_base_image_with_version(higher_base_image_version)}
       end)
 
-      # Reply like the target already has an higher version
       start_execution(pid)
 
       # Wait for the Executor to arrive at :wait_for_campaign_completion
@@ -498,10 +498,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
 
       # Stub BaseImage with a compatible base image by default
       stub(BaseImageMock, :get, fn _client, _device_id ->
+        # Reply like the target already has an incompatible version
         {:ok, astarte_base_image_with_version("2.0.0")}
       end)
 
-      # Reply like the target already has an incompatible version
       update_campaign =
         update_campaign_with_targets_fixture(target_count,
           base_image_id: base_image.id,
@@ -608,10 +608,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       } = ctx
 
       expect(BaseImageMock, :get, failing_target_count, fn _client, _device_id ->
+        # Reply like the target already has an higher version
         {:ok, astarte_base_image_with_version(higher_base_image_version)}
       end)
 
-      # Reply like the target already has an higher version
       start_execution(pid)
 
       assert_normal_exit(pid, ref)
@@ -629,10 +629,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       } = ctx
 
       expect(BaseImageMock, :get, failing_target_count, fn _client, _device_id ->
+        # Reply like the target already has an incompatible version
         {:ok, astarte_base_image_with_version(incompatible_base_image_version)}
       end)
 
-      # Reply like the target already has an incompatible version
       start_execution(pid)
 
       assert_normal_exit(pid, ref)
@@ -649,10 +649,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       } = ctx
 
       expect(BaseImageMock, :get, failing_target_count, fn _client, _device_id ->
+        # Reply like the target already has an incompatible version
         {:ok, astarte_base_image_with_version(nil)}
       end)
 
-      # Reply like the target already has an incompatible version
       start_execution(pid)
 
       assert_normal_exit(pid, ref)
@@ -836,11 +836,11 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
 
     # Expect count calls to the mock
     expect(OTARequestV1Mock, :update, count, fn _client, _device_id, _uuid, _url ->
+      # Send the sync
       send_sync(parent, ref)
       :ok
     end)
 
-    # Send the sync
     ref
   end
 


### PR DESCRIPTION
When the first formatting job was run with Styler in PR #557, the latter misplaced some code and comments.
This change fixes the issue by moving back the comments near the appropriate code.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
