### PR TITLE
executor_test: make expectations order-independent

### DIFF
--- a/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
@@ -168,13 +168,10 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       base_image_url = update_campaign.base_image.url
       target_device_ids = Enum.map(update_campaign.update_targets, & &1.device.device_id)
 
-      # Set an expectation for each target on the OTARequest mock and send back a message
-      # to wait for all devices
-      Enum.each(target_device_ids, fn device_id ->
-        expect(OTARequestV1Mock, :update, fn _client, ^device_id, _uuid, ^base_image_url ->
-          send_sync(parent, {ref, device_id})
-          :ok
-        end)
+      # Expect target_count update calls and send back a message for each device
+      expect(OTARequestV1Mock, :update, target_count, fn _client, device_id, _uuid, ^base_image_url ->
+        send_sync(parent, {ref, device_id})
+        :ok
       end)
 
       pid = start_executor!(update_campaign)


### PR DESCRIPTION
The previous version was causing flakyness in tests since it assumed a specific order for the devices, which is not guaranteed. The new version removes that assumption. The presence of each and every target device is verified by the `send_sync` mechanism anyway.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
