### PR TITLE
Specify Postgres version requirement in docs

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -125,10 +125,13 @@ jobs:
 
   test-coverage:
     name: Build and Test
+    strategy:
+      matrix:
+        postgres: [13, 14, 15, 16]
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:14
+        image: postgres:${{ matrix.postgres }}
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@
 erlang 27.0
 elixir 1.17.2-otp-27
 nodejs 22.4.0
+postgres 16.3

--- a/doc/pages/admin/deploying_with_kubernetes.md
+++ b/doc/pages/admin/deploying_with_kubernetes.md
@@ -20,7 +20,7 @@ below in the guide.*
 - An Ingress Controller deployed in the cluster (the guide contains examples for the NGINX Ingress
   Controller)
 - An Astarte instance, with an existing realm and its private key
-- A PostgreSQL database
+- A PostgreSQL v13+ database
 - S3-compatible storage with its credentials
 - The `jq` utility installed in the system
 - (Optional) A Google Geolocation API Key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 version: "3.8"
 services:
   postgresql:
-    image: postgres:14.0
+    image: postgres:16.3
     environment:
       POSTGRES_USER: edgehog
       POSTGRES_PASSWORD: edgehog


### PR DESCRIPTION
- When detailing the prerequisites for deploying an Edgehog instance on the documentation, specify that only Postgres v13+ is supported.
- Update development tooling to use the latest Postgres version, v16, and update the CI workflows to test all supported and advertised versions for production environments.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
