### PR TITLE
Fix: wrong input values used when creating a base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-dev] - Unreleased
+
 ## [0.9.0-rc.0] - 2024-07-08
 ### Added
 - Allow generating admin JWT using `gen-edgehog-jwt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.9.0-dev] - Unreleased
+### Fixed
+- Wrong input params used in GraphQL mutation when creating a base image, leading to a rejected operation ([#574](https://github.com/edgehog-device-manager/edgehog/pull/574)).
 
 ## [0.9.0-rc.0] - 2024-07-08
 ### Added

--- a/frontend/src/forms/CreateBaseImage.tsx
+++ b/frontend/src/forms/CreateBaseImage.tsx
@@ -80,14 +80,14 @@ type BaseImageData = {
   file: File;
   version: string;
   startingVersionRequirement: string;
-  releaseDisplayName: {
-    locale: string;
-    text: string;
-  };
-  description: {
-    locale: string;
-    text: string;
-  };
+  localizedReleaseDisplayNames?: {
+    languageTag: string;
+    value: string;
+  }[];
+  localizedDescriptions?: {
+    languageTag: string;
+    value: string;
+  }[];
 };
 
 type FormData = {
@@ -129,20 +129,34 @@ const transformOutputData = (
   baseImageCollection: CreateBaseImage_BaseImageCollectionFragment$data,
   locale: string,
   data: FormOutput,
-): BaseImageData => ({
-  baseImageCollectionId: baseImageCollection.id,
-  file: data.file[0],
-  version: data.version,
-  startingVersionRequirement: data.startingVersionRequirement,
-  releaseDisplayName: {
-    locale,
-    text: data.releaseDisplayName,
-  },
-  description: {
-    locale,
-    text: data.description,
-  },
-});
+): BaseImageData => {
+  const baseImage: BaseImageData = {
+    baseImageCollectionId: baseImageCollection.id,
+    file: data.file[0],
+    version: data.version,
+    startingVersionRequirement: data.startingVersionRequirement,
+  };
+
+  if (data.releaseDisplayName) {
+    baseImage.localizedReleaseDisplayNames = [
+      {
+        languageTag: locale,
+        value: data.releaseDisplayName,
+      },
+    ];
+  }
+
+  if (data.description) {
+    baseImage.localizedDescriptions = [
+      {
+        languageTag: locale,
+        value: data.description,
+      },
+    ];
+  }
+
+  return baseImage;
+};
 
 type Props = {
   baseImageCollectionRef: CreateBaseImage_BaseImageCollectionFragment$key;


### PR DESCRIPTION
Some input fields were not updated during the migration to the newest version of the GraphQL API.
This change fixes how localized fields are provided in the mutation when creating a base image.

Fixes #574

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
