### PR TITLE
Fix: OTA operation success event not being handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Wrong input params used in GraphQL mutation when creating a base image, leading to a rejected operation ([#574](https://github.com/edgehog-device-manager/edgehog/pull/574)).
 - Fix docker-compose local build.
+- Fix OTA operation events not being handled, leading to a successful OTA operation while the device was still pending.
 
 ## [0.9.0-rc.0] - 2024-07-08
 ### Added

--- a/backend/lib/edgehog/update_campaigns/rollout_mechanism/push_rollout/executor.ex
+++ b/backend/lib/edgehog/update_campaigns/rollout_mechanism/push_rollout/executor.ex
@@ -398,6 +398,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
           [internal_event({:ota_operation_failure, ota_operation})]
 
         Core.ota_operation_acknowledged?(ota_operation) ->
+          ota_operation = Ash.load!(ota_operation, :device)
           # Handle this explicitly so we log a message
           Logger.info("Device #{ota_operation.device.device_id} acknowledged the update")
           []
@@ -416,6 +417,8 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   end
 
   def handle_event(:internal, {:ota_operation_success, ota_operation}, _state, data) do
+    ota_operation = Ash.load!(ota_operation, :device)
+
     Logger.info("Device #{ota_operation.device.device_id} updated successfully")
 
     _ =
@@ -430,6 +433,8 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   end
 
   def handle_event(:internal, {:ota_operation_failure, ota_operation}, state, data) do
+    ota_operation = Ash.load!(ota_operation, :device)
+
     Logger.notice("Device #{ota_operation.device.device_id} failed to update: #{ota_operation.status_code}")
 
     _ =


### PR DESCRIPTION
The code crashed in accessing the `device` field of the OTA operation while trying to handle the event about the OTA operation.

The change fixes the issue by ensuring that the device field is preloaded on the OTA operation resource before trying to access it.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
