### PR TITLE
base_image: correctly scope upload to the BaseImageCollection bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+### Fixed
+- Correctly scope Base Image uploads to their Base Image Collection bucket.
+
 ## [0.9.0-rc.1] - 2024-07-10
 ### Fixed
 - Wrong input params used in GraphQL mutation when creating a base image, leading to a rejected operation ([#574](https://github.com/edgehog-device-manager/edgehog/pull/574)).

--- a/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
+++ b/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
@@ -46,9 +46,12 @@ defmodule Edgehog.BaseImages.BaseImage.Changes.HandleFileUpload do
   end
 
   defp upload_file(changeset, file) do
-    {:ok, base_image} = Ash.Changeset.apply_attributes(changeset)
+    tenant_id = changeset.to_tenant
 
-    case @storage_module.store(base_image, file) do
+    {:ok, base_image_collection_id} =
+      Ash.Changeset.fetch_argument(changeset, :base_image_collection_id)
+
+    case @storage_module.store(tenant_id, base_image_collection_id, file) do
       {:ok, file_url} ->
         changeset
         |> Ash.Changeset.force_change_attribute(:url, file_url)

--- a/backend/lib/edgehog/base_images/bucket_storage.ex
+++ b/backend/lib/edgehog/base_images/bucket_storage.ex
@@ -27,7 +27,9 @@ defmodule Edgehog.BaseImages.BucketStorage do
   alias Edgehog.BaseImages.Uploaders
 
   @impl Storage
-  def store(%BaseImage{} = scope, %Plug.Upload{} = upload) do
+  def store(tenant_id, base_image_collection_id, %Plug.Upload{} = upload) do
+    scope = %{tenant_id: tenant_id, base_image_collection_id: base_image_collection_id}
+
     with {:ok, file_name} <- Uploaders.BaseImage.store({upload, scope}) do
       # TODO: investigate URL signing instead of public access
       file_url = Uploaders.BaseImage.url({file_name, scope})

--- a/backend/lib/edgehog/base_images/storage.ex
+++ b/backend/lib/edgehog/base_images/storage.ex
@@ -24,7 +24,11 @@ defmodule Edgehog.BaseImages.Storage do
 
   @type upload :: %Plug.Upload{}
 
-  @callback store(scope :: %BaseImage{}, file :: upload()) ::
+  @callback store(
+              tenant_id :: String.t() | integer(),
+              base_image_id :: String.t() | integer(),
+              file :: upload()
+            ) ::
               {:ok, file_url :: String.t()} | {:error, reason :: any}
 
   @callback delete(base_image :: %BaseImage{}) ::


### PR DESCRIPTION
The extracted base_image_collection_id was nil in the current implementation, leading to the image being put in the wrong bucket directory. This makes the storage module behaviour more explicit in its requirement (instead of having to pass the whole BaseImage) and adds a test to verify that the base_image_collection_id received by the storage module actually matches the one from the Base Image Collection.

Close #586

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
