### PR TITLE
BaseImage: fix missing 'version' when uploading an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - Unreleased
 ### Fixed
 - Correctly support automatic login attempts on the frontend regardless of existing auth sessions ([#596](https://github.com/edgehog-device-manager/edgehog/pull/596)).
+- Fix file upload for creating base images that was failing due to a regression that left out the `version` parameter, needed for uploading the file ([#600](https://github.com/edgehog-device-manager/edgehog/pull/600)).
 
 ## [0.9.0-rc.2] - 2024-09-11
 ### Fixed

--- a/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
+++ b/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
@@ -48,10 +48,12 @@ defmodule Edgehog.BaseImages.BaseImage.Changes.HandleFileUpload do
   defp upload_file(changeset, file) do
     tenant_id = changeset.to_tenant
 
+    {:ok, base_image} = Ash.Changeset.apply_attributes(changeset)
+
     {:ok, base_image_collection_id} =
       Ash.Changeset.fetch_argument(changeset, :base_image_collection_id)
 
-    case @storage_module.store(tenant_id, base_image_collection_id, file) do
+    case @storage_module.store(tenant_id, base_image_collection_id, base_image.version, file) do
       {:ok, file_url} ->
         changeset
         |> Ash.Changeset.force_change_attribute(:url, file_url)

--- a/backend/lib/edgehog/base_images/bucket_storage.ex
+++ b/backend/lib/edgehog/base_images/bucket_storage.ex
@@ -27,8 +27,12 @@ defmodule Edgehog.BaseImages.BucketStorage do
   alias Edgehog.BaseImages.Uploaders
 
   @impl Storage
-  def store(tenant_id, base_image_collection_id, %Plug.Upload{} = upload) do
-    scope = %{tenant_id: tenant_id, base_image_collection_id: base_image_collection_id}
+  def store(tenant_id, base_image_collection_id, base_image_version, %Plug.Upload{} = upload) do
+    scope = %{
+      tenant_id: tenant_id,
+      base_image_collection_id: base_image_collection_id,
+      base_image_version: base_image_version
+    }
 
     with {:ok, file_name} <- Uploaders.BaseImage.store({upload, scope}) do
       # TODO: investigate URL signing instead of public access

--- a/backend/lib/edgehog/base_images/storage.ex
+++ b/backend/lib/edgehog/base_images/storage.ex
@@ -26,7 +26,8 @@ defmodule Edgehog.BaseImages.Storage do
 
   @callback store(
               tenant_id :: String.t() | integer(),
-              base_image_id :: String.t() | integer(),
+              base_image_collection_id :: String.t() | integer(),
+              base_image_version :: String.t(),
               file :: upload()
             ) ::
               {:ok, file_url :: String.t()} | {:error, reason :: any}

--- a/backend/lib/edgehog/base_images/uploaders/base_image.ex
+++ b/backend/lib/edgehog/base_images/uploaders/base_image.ex
@@ -45,6 +45,6 @@ defmodule Edgehog.BaseImages.Uploaders.BaseImage do
   end
 
   def filename(_version, {_file, scope}) do
-    scope.version
+    scope.base_image_version
   end
 end


### PR DESCRIPTION
Commit 0e4d17b refactored how the scope gets passed to the BaseImages.Storage behaviour, but in doing so the base image's version was not provided anymore and thus the upload logic failed for a missing 'version' field, which is used to determine the filename for the uploaded file.

This change adds the base image's version between the required parameters by the upload logic.

Closes #600.
