### PR TITLE
BaseImage: prefer Ash.Changeset.fetch_change/2 to apply_attributes/1

### DIFF
--- a/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
+++ b/backend/lib/edgehog/base_images/base_image/changes/handle_file_upload.ex
@@ -48,12 +48,12 @@ defmodule Edgehog.BaseImages.BaseImage.Changes.HandleFileUpload do
   defp upload_file(changeset, file) do
     tenant_id = changeset.to_tenant
 
-    {:ok, base_image} = Ash.Changeset.apply_attributes(changeset)
+    {:ok, base_image_version} = Ash.Changeset.fetch_change(changeset, :version)
 
     {:ok, base_image_collection_id} =
       Ash.Changeset.fetch_argument(changeset, :base_image_collection_id)
 
-    case @storage_module.store(tenant_id, base_image_collection_id, base_image.version, file) do
+    case @storage_module.store(tenant_id, base_image_collection_id, base_image_version, file) do
       {:ok, file_url} ->
         changeset
         |> Ash.Changeset.force_change_attribute(:url, file_url)


### PR DESCRIPTION
When trying to upload the file of a base image during its creation, prefer using `Ash.Changeset.fetch_change/2` to retrieve just the version of the base image, instead of resorting to `Ash.Changeset.apply_attributes/1` to fetch all attributes.
