### PR TITLE
Fix intended path behaviour in `.env` variables

### DIFF
--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -31,6 +31,7 @@ default_var =
       # paths in the .env are relative to ../
       defaults
       |> Map.fetch!(var)
+      |> String.replace_prefix("../", "../../")
       |> String.replace_prefix("./", "../")
     end
   else


### PR DESCRIPTION
Prior to this fix variables in `.env` file were not correctly resolved: paths starting with `../` were not translated to `../../`

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
