### PR TITLE
chore(container): set up deployment event interface handling

### DIFF
--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -31,6 +31,7 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
   alias Edgehog.Triggers.IncomingData
   alias Edgehog.Triggers.TriggerPayload
 
+  @deployment_event "io.edgehog.devicemanager.apps.DeploymentEvent"
   @ota_event "io.edgehog.devicemanager.OTAEvent"
   @ota_response "io.edgehog.devicemanager.OTAResponse"
   @system_info "io.edgehog.devicemanager.SystemInfo"
@@ -101,6 +102,21 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
     Device
     |> Ash.Changeset.for_create(:from_part_number_event, params)
     |> Ash.create(tenant: tenant)
+  end
+
+  defp handle_event(%IncomingData{interface: @deployment_event} = event, tenant, _realm_id, _device_id, _timestamp) do
+    "/" <> deployment_id = event.path
+    status = event.value["status"]
+    message = event.value["message"]
+
+    status_attrs = %{status: status, mesage: message}
+
+    # TODO: update deployment status
+    _ = deployment_id
+    _ = status_attrs
+    _ = tenant
+
+    {:ok, nil}
   end
 
   defp handle_event(

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.DeploymentEvent.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.DeploymentEvent.json
@@ -1,0 +1,25 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.DeploymentEvent",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "mappings": [
+    {
+      "endpoint": "/%{release_id}/status",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "Deployment status",
+      "doc": "Possible values: [Idle, Starting, Started, Stopping, Stopped, Error]"
+    },
+    {
+      "endpoint": "/%{release_id}/message",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "Optional message for the event"
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-deployment-event.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-deployment-event.json.eex
@@ -1,0 +1,19 @@
+{
+    "name": "edgehog-deployment-event",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "ignore_ssl_errors": false,
+        "http_method": "post",
+        "http_static_headers": {}
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.DeploymentEvent",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+}


### PR DESCRIPTION
initialize infrastructure for the DeploymentEvent interface, similarly to OTAEvent.

the actual handling of the state change will be done at a later date, once the actual deployment process is implemented.