### PR TITLE
feat(containers): add support fot available deployments interface

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -54,6 +54,10 @@ config :edgehog,
        :astarte_available_containers_module,
        Edgehog.Astarte.Device.AvailableContainersMock
 
+config :edgehog,
+       :astarte_available_deployments_module,
+       Edgehog.Astarte.Device.AvailableDeploymentsMock
+
 config :edgehog, :astarte_available_images_module, Edgehog.Astarte.Device.AvailableImagesMock
 config :edgehog, :astarte_base_image_module, Edgehog.Astarte.Device.BaseImageMock
 config :edgehog, :astarte_battery_status_module, Edgehog.Astarte.Device.BatteryStatusMock

--- a/backend/lib/edgehog/astarte/device/available_deployments.ex
+++ b/backend/lib/edgehog/astarte/device/available_deployments.ex
@@ -1,0 +1,55 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.AvailableDeployments do
+  @moduledoc false
+
+  @behaviour Edgehog.Astarte.Device.AvailableDeployments.Behaviour
+
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.AvailableDeployments.DeploymentStatus
+
+  @interface "io.edgehog.devicemanager.apps.AvailableDeployments"
+
+  def get(%AppEngine{} = client, device_id) do
+    with {:ok, %{"data" => data}} <-
+           AppEngine.Devices.get_datastream_data(client, device_id, @interface) do
+      deployments = Enum.map(data, &parse_available_deployment/1)
+
+      {:ok, deployments}
+    end
+  end
+
+  defp parse_available_deployment({deployment_id, parameters}) do
+    status =
+      case parameters["status"] do
+        "Idle" -> :idle
+        "Starting" -> :starting
+        "Stopping" -> :stopping
+        "Stopped" -> :stopped
+        "Error" -> :error
+      end
+
+    %DeploymentStatus{
+      id: deployment_id,
+      status: status
+    }
+  end
+end

--- a/backend/lib/edgehog/astarte/device/available_deployments/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/available_deployments/behaviour.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.AvailableDeployments.Behaviour do
+  @moduledoc false
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.AvailableDeployments.DeploymentStatus
+
+  @callback get(client :: AppEngine.t(), device_id :: String.t()) ::
+              {:ok, list(DeploymentStatus.t())} | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/device/available_deployments/deployment_status.ex
+++ b/backend/lib/edgehog/astarte/device/available_deployments/deployment_status.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.AvailableDeployments.DeploymentStatus do
+  @moduledoc false
+
+  @enforce_keys [:id, :status]
+  defstruct [
+    :id,
+    :status
+  ]
+
+  @type t() :: %__MODULE__{
+          id: String.t(),
+          status: atom()
+        }
+end

--- a/backend/lib/edgehog/devices/device/calculations/astarte_interface_value.ex
+++ b/backend/lib/edgehog/devices/device/calculations/astarte_interface_value.ex
@@ -56,6 +56,11 @@ defmodule Edgehog.Devices.Device.Calculations.AstarteInterfaceValue do
                       :astarte_available_images_module,
                       Edgehog.Astarte.Device.AvailableImages
                     )
+  @available_deployments Application.compile_env(
+                           :edgehog,
+                           :astarte_available_deployments_module,
+                           Edgehog.Astarte.Device.AvailableDeployments
+                         )
 
   @base_image Application.compile_env(
                 :edgehog,
@@ -106,6 +111,7 @@ defmodule Edgehog.Devices.Device.Calculations.AstarteInterfaceValue do
                     )
 
   defp value_id_to_fetch_fun(:available_containers), do: &@available_containers.get/2
+  defp value_id_to_fetch_fun(:available_deployments), do: &@available_deployments.get/2
   defp value_id_to_fetch_fun(:available_images), do: &@available_images.get/2
   defp value_id_to_fetch_fun(:base_image_info), do: &@base_image.get/2
   defp value_id_to_fetch_fun(:hardware_info), do: &@hardware_info.get/2

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -332,6 +332,11 @@ defmodule Edgehog.Devices.Device do
       calculation Calculations.CellularConnection
     end
 
+    calculate :available_deployments, {:array, Types.DeploymentStatus} do
+      public? true
+      calculation {Calculations.AstarteInterfaceValue, value_id: :available_deployments}
+    end
+
     calculate :base_image, Types.BaseImage do
       public? true
       calculation {Calculations.AstarteInterfaceValue, value_id: :base_image_info}

--- a/backend/lib/edgehog/devices/device/types/deployment_status.ex
+++ b/backend/lib/edgehog/devices/device/types/deployment_status.ex
@@ -1,0 +1,26 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Devices.Device.Types.DeploymentStatus do
+  @moduledoc false
+  use Edgehog.Devices.Device.Types.AstarteInterfaceValue,
+    value_id: :deployment_status,
+    value_struct: Edgehog.Astarte.Device.AvailableDeployments.DeploymentStatus
+end

--- a/backend/lib/edgehog_web/schema/astarte_types.ex
+++ b/backend/lib/edgehog_web/schema/astarte_types.ex
@@ -159,4 +159,13 @@ defmodule EdgehogWeb.Schema.AstarteTypes do
     @desc "Wether the container is pulled or not."
     field :pulled, :boolean
   end
+
+  @desc "Describes the status of a deployment on a device."
+  object :deployment_status do
+    @desc "The deployment id."
+    field :id, :string
+
+    @desc "The deployment status, can be :idle, :starting, :started, :stopping, :stopped or :error"
+    field :status, :string
+  end
 end

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.AvailableDeployments.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.AvailableDeployments.json
@@ -1,0 +1,16 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.AvailableDeployments",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "mappings": [
+    {
+      "allow_unset": true,
+      "endpoint": "/%{release_id}/status",
+      "type": "string",
+      "description": "Status of the deployment",
+      "doc": "Possible values: [Idle, Starting, Started, Stopping, Stopped, Error]"
+    }
+  ]
+}

--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -533,6 +533,34 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
       assert first_image["pulled"]
       refute second_image["pulled"]
     end
+
+    test "can read available deployments on the device", %{
+      tenant: tenant,
+      id: id,
+      device_id: device_id
+    } do
+      expect(Edgehog.Astarte.Device.AvailableDeploymentsMock, :get, fn _client, ^device_id ->
+        {:ok, available_deployments_fixture()}
+      end)
+
+      document = """
+      query ($id: ID!) {
+        device(id: $id) {
+          availableDeployments {
+            id
+            status
+          }
+        }
+      }
+      """
+
+      assert %{"availableDeployments" => [deployment]} =
+               [document: document, tenant: tenant, id: id]
+               |> device_query()
+               |> extract_result!()
+
+      assert deployment["status"] == "Idle"
+    end
   end
 
   describe "capabilities" do

--- a/backend/test/support/astarte_mock_case.ex
+++ b/backend/test/support/astarte_mock_case.ex
@@ -128,6 +128,11 @@ defmodule Edgehog.AstarteMockCase do
       Edgehog.Mocks.Astarte.Device.AvailableImages
     )
 
+    Mox.stub_with(
+      Edgehog.Astarte.Device.AvailableDeploymentsMock,
+      Edgehog.Mocks.Astarte.Device.AvailableDeployments
+    )
+
     :ok
   end
 end

--- a/backend/test/support/fixtures/astarte_fixtures.ex
+++ b/backend/test/support/fixtures/astarte_fixtures.ex
@@ -164,6 +164,18 @@ defmodule Edgehog.AstarteFixtures do
     ]
   end
 
+  def available_deployments_fixture(opts \\ []) do
+    [
+      struct!(
+        %Edgehog.Astarte.Device.AvailableDeployments.DeploymentStatus{
+          id: "1",
+          status: "Idle"
+        },
+        opts
+      )
+    ]
+  end
+
   def base_image_info_fixture(opts \\ []) do
     struct!(
       %Edgehog.Astarte.Device.BaseImage{

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -103,3 +103,7 @@ Mox.defmock(Edgehog.Tenants.ReconcilerMock, for: Edgehog.Tenants.Reconciler.Beha
 Mox.defmock(Edgehog.Astarte.Device.AvailableImagesMock,
   for: Edgehog.Astarte.Device.AvailableImages.Behaviour
 )
+
+Mox.defmock(Edgehog.Astarte.Device.AvailableDeploymentsMock,
+  for: Edgehog.Astarte.Device.AvailableDeployments.Behaviour
+)


### PR DESCRIPTION
Closes #625. Implements the astarte interface
`io.edgehog.devicemanager.apps.AvailableDeployments` between a device and edgehog

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
