### PR TITLE
feat(containers): implemented create image request interface

### DIFF
--- a/backend/lib/edgehog/astarte/device/create_image_request.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.CreateImageRequest do
+  @moduledoc false
+  @behaviour Edgehog.Astarte.Device.CreateImageRequest.Behaviour
+
+  alias Astarte.Client.AppEngine
+
+  @interface "io.edgehog.devicemanager.apps.CreateImageRequest"
+
+  @impl Edgehog.Astarte.Device.CreateImageRequest.Behaviour
+  def send_create_image_request(%AppEngine{} = client, device_id, request_data) do
+    AppEngine.Devices.send_datastream(
+      client,
+      device_id,
+      @interface,
+      "/image",
+      request_data
+    )
+  end
+end

--- a/backend/lib/edgehog/astarte/device/create_image_request/behaviour.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request/behaviour.ex
@@ -1,0 +1,31 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.CreateImageRequest.Behaviour do
+  @moduledoc false
+  alias Astarte.Client.AppEngine
+  alias Edgehog.Astarte.Device.CreateImageRequest.RequestData
+
+  @callback send_create_image_request(
+              client :: AppEngine.t(),
+              device_id :: String.t(),
+              request_data :: RequestData.t()
+            ) :: :ok | {:error, term()}
+end

--- a/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
@@ -1,0 +1,35 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Astarte.Device.CreateImageRequest.RequestData do
+  @moduledoc false
+
+  defstruct [
+    :image_id,
+    :reference,
+    :registry_auth
+  ]
+
+  @type t() :: %__MODULE__{
+          image_id: String.t(),
+          reference: String.t(),
+          registry_auth: String.t()
+        }
+end

--- a/backend/lib/edgehog/containers/image_credentials.ex
+++ b/backend/lib/edgehog/containers/image_credentials.ex
@@ -75,6 +75,10 @@ defmodule Edgehog.Containers.ImageCredentials do
     has_many :images, Edgehog.Containers.Image
   end
 
+  calculations do
+    calculate :base64_json, :string, Base64JsonEncoding
+  end
+
   identities do
     identity :name, [:name]
   end

--- a/backend/lib/edgehog/containers/image_credentials/base64_json_encoding.ex
+++ b/backend/lib/edgehog/containers/image_credentials/base64_json_encoding.ex
@@ -1,0 +1,35 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.ImageCredentials.Base64JsonEncoding do
+  @moduledoc false
+  use Ash.Resource.Calculation
+
+  alias AshGraphql.Types.JSONString
+
+  @impl Ash.Resource.Calculation
+  def calculate(records, _opts, _context) do
+    for record <- records do
+      %{username: record.username, password: record.password}
+      |> JSONString.encode()
+      |> Base.encode64()
+    end
+  end
+end

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -27,6 +27,8 @@ defmodule Edgehog.Devices.Device do
     ]
 
   alias Edgehog.Changes.NormalizeTagName
+  alias Edgehog.Containers.Image
+  alias Edgehog.Containers.ImageCredentials
   alias Edgehog.Devices.Device.BatterySlot
   alias Edgehog.Devices.Device.Calculations
   alias Edgehog.Devices.Device.Changes
@@ -223,6 +225,24 @@ defmodule Edgehog.Devices.Device do
       description "Sets led behavior."
       argument :behavior, LedBehavior, description: "The led behavior.", allow_nil?: false
       manual ManualActions.SetLedBehavior
+    end
+
+    update :send_create_image do
+      description "Sends a create image request to the device."
+
+      argument :image, :struct do
+        constraints instance_of: Image
+        description "The image the device will pull."
+        allow_nil? false
+      end
+
+      argument :credentials, :struct do
+        constraints instance_of: ImageCredentials
+        description "The credentials to use."
+        allow_nil? true
+      end
+
+      manual ManualActions.SendCreateImageRequest
     end
   end
 

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
@@ -1,0 +1,54 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Devices.Device.ManualActions.SendCreateImageRequest do
+  @moduledoc false
+  use Ash.Resource.ManualUpdate
+
+  require Ash.Query
+
+  @send_create_image_request_behaviour Application.compile_env(
+                                         :edgehog,
+                                         :astarte_create_image_request_module,
+                                         Edgehog.Astarte.Device.CreateImageRequest
+                                       )
+
+  @impl Ash.Resource.ManualUpdate
+  def update(changeset, _opts, _context) do
+    device = changeset.data
+
+    image = changeset.arguments.image
+    credentials = changeset.arguments.credentials
+
+    data = %{
+      image_id: image.id,
+      reference: image.reference,
+      credentials: credentials.base64_json
+    }
+
+    with {:ok, device} <- Ash.load(device, :appengine_client) do
+      @send_create_image_request_behaviour.send_create_image_request(
+        device.appengine_client,
+        device.device_id,
+        data
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes #630

- Implemented the `create_image` behaviour
- Implemented the `base64_json` calculation in the `image_credentials` resource
- Implemented the manual action `send_create_image_request` in the `device` resource. This is inteded to be internally called with an `Image` and an optional `ImageCredentials` struct to send the appropriate astarte call to the device.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
