### PR TITLE
feat(containers): init container capability

### DIFF
--- a/backend/lib/edgehog/capabilities.ex
+++ b/backend/lib/edgehog/capabilities.ex
@@ -66,6 +66,73 @@ defmodule Edgehog.Capabilities do
         minor: 1
       }
     ],
+    container_management: [
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableContainers",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableDeployments",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableImages",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableNetworks",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableVolumes",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateContainerRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateDeploymentRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateImageRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateNetworkRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateVolumeRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.DeploymentCommand",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.DeploymentEvent",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.DeploymentUpdate",
+        major: 0,
+        minor: 1
+      }
+    ],
     hardware_info: [
       %Astarte.InterfaceID{
         name: "io.edgehog.devicemanager.HardwareInfo",

--- a/backend/lib/edgehog/devices/device/types/capability.ex
+++ b/backend/lib/edgehog/devices/device/types/capability.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Devices.Device.Types.Capability do
       battery_status: "The device provides information about its battery status.",
       cellular_connection: "The device provides information about its cellular connection.",
       commands: "The device supports commands, for example the rebooting command.",
+      container_management: "The device supports running applications using containers.",
       geolocation: "The device can be geolocated.",
       hardware_info: "The device provides information about its hardware.",
       led_behaviors: "The device can be asked to blink its LED in a specific pattern.",

--- a/backend/test/edgehog/capabilities_test.exs
+++ b/backend/test/edgehog/capabilities_test.exs
@@ -57,7 +57,41 @@ defmodule Edgehog.CapabilitiesTest do
         "io.edgehog.devicemanager.SystemInfo" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.SystemStatus" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.config.Telemetry" => %InterfaceVersion{major: 0, minor: 1},
-        "io.edgehog.devicemanager.WiFiScanResults" => %InterfaceVersion{major: 0, minor: 1}
+        "io.edgehog.devicemanager.WiFiScanResults" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableContainers" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableDeployments" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableImages" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentEvent" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.CreateContainerRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeploymentRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateImageRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.DeploymentCommand" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentUpdate" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableNetworks" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableVolumes" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.CreateNetworkRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateVolumeRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        }
       }
 
       expected_capabilities = [
@@ -65,6 +99,7 @@ defmodule Edgehog.CapabilitiesTest do
         :battery_status,
         :cellular_connection,
         :commands,
+        :container_management,
         :geolocation,
         :hardware_info,
         :led_behaviors,


### PR DESCRIPTION
adds the capability `container_management` if a device supports all the required interfaces.

closes #615 
~drafted because we don't currently support all required interfaces~