### PR TITLE
feat(containers): release deployment mechanism

### DIFF
--- a/backend/lib/edgehog/astarte/device/create_container_request.ex
+++ b/backend/lib/edgehog/astarte/device/create_container_request.ex
@@ -29,7 +29,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest do
 
   @impl Edgehog.Astarte.Device.CreateContainerRequest.Behaviour
   def send_create_container_request(%AppEngine{} = client, device_id, request_data) do
-    request_data_map = Map.from_struct(request_data)
+    request_data = Map.from_struct(request_data)
 
     api_call =
       AppEngine.Devices.send_datastream(
@@ -37,7 +37,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest do
         device_id,
         @interface,
         "/container",
-        request_data_map
+        request_data
       )
 
     with {:error, api_error} <- api_call do

--- a/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
@@ -20,31 +20,35 @@
 
 defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
   @moduledoc false
+
+  # TODO the interface for now has the :image key, this is a device
+  # problem, once solved it should be removed
+
   defstruct [
-    :container_id,
-    :image_id,
-    :networks_ids,
-    :volume_ids,
+    :id,
+    :imageId,
+    :networkIds,
+    :volumeIds,
     :hostname,
-    :restart_policy,
+    :restartPolicy,
     :env,
     :binds,
     :networks,
-    :port_bindings,
+    :portBindings,
     :privileged
   ]
 
   @type t() :: %__MODULE__{
-          container_id: String.t(),
-          image_id: String.t(),
-          networks_ids: list(String.t()),
-          volume_ids: list(String.t()),
+          id: String.t(),
+          imageId: String.t(),
+          networkIds: list(String.t()),
+          volumeIds: list(String.t()),
           hostname: String.t(),
-          restart_policy: String.t(),
+          restartPolicy: String.t(),
           env: list(tuple()),
           binds: list(String.t()),
           networks: list(String.t()),
-          port_bindings: list(String.t()),
+          portBindings: list(String.t()),
           privileged: String.t()
         }
 end

--- a/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
@@ -27,6 +27,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
   defstruct [
     :id,
     :imageId,
+    :image,
     :networkIds,
     :volumeIds,
     :hostname,
@@ -41,6 +42,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
   @type t() :: %__MODULE__{
           id: String.t(),
           imageId: String.t(),
+          image: String.t(),
           networkIds: list(String.t()),
           volumeIds: list(String.t()),
           hostname: String.t(),

--- a/backend/lib/edgehog/astarte/device/create_deployment_request.ex
+++ b/backend/lib/edgehog/astarte/device/create_deployment_request.ex
@@ -36,7 +36,7 @@ defmodule Edgehog.Astarte.Device.CreateDeploymentRequest do
         client,
         device_id,
         @interface,
-        "/release",
+        "/deployment",
         request_data
       )
 

--- a/backend/lib/edgehog/astarte/device/create_deployment_request.ex
+++ b/backend/lib/edgehog/astarte/device/create_deployment_request.ex
@@ -29,6 +29,8 @@ defmodule Edgehog.Astarte.Device.CreateDeploymentRequest do
 
   @impl Edgehog.Astarte.Device.CreateDeploymentRequest.Behaviour
   def send_create_deployment_request(%AppEngine{} = client, device_id, request_data) do
+    request_data = Map.from_struct(request_data)
+
     api_call =
       AppEngine.Devices.send_datastream(
         client,

--- a/backend/lib/edgehog/astarte/device/create_image_request.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request.ex
@@ -28,6 +28,8 @@ defmodule Edgehog.Astarte.Device.CreateImageRequest do
 
   @impl Edgehog.Astarte.Device.CreateImageRequest.Behaviour
   def send_create_image_request(%AppEngine{} = client, device_id, request_data) do
+    request_data = Map.from_struct(request_data)
+
     AppEngine.Devices.send_datastream(
       client,
       device_id,

--- a/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
@@ -22,14 +22,14 @@ defmodule Edgehog.Astarte.Device.CreateImageRequest.RequestData do
   @moduledoc false
 
   defstruct [
-    :image_id,
+    :id,
     :reference,
-    :registry_auth
+    :registryAuth
   ]
 
   @type t() :: %__MODULE__{
-          image_id: String.t(),
+          id: String.t(),
           reference: String.t(),
-          registry_auth: String.t()
+          registryAuth: String.t()
         }
 end

--- a/backend/lib/edgehog/containers/container.ex
+++ b/backend/lib/edgehog/containers/container.ex
@@ -31,8 +31,8 @@ defmodule Edgehog.Containers.Container do
     defaults [
       :read,
       :destroy,
-      create: [:restart_policy, :hostname, :env, :privileged],
-      update: [:restart_policy, :hostname, :env, :privileged]
+      create: [:restart_policy, :hostname, :env, :privileged, :image_id],
+      update: [:restart_policy, :hostname, :env, :privileged, :image_id]
     ]
   end
 

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -52,11 +52,26 @@ defmodule Edgehog.Containers do
 
   resources do
     resource Edgehog.Containers.Application
-    resource Edgehog.Containers.Container
-    resource Edgehog.Containers.Deployment
-    resource Edgehog.Containers.Image
+
+    resource Edgehog.Containers.Container do
+      define :fetch_container, action: :read, get_by: [:id]
+    end
+
+    resource Edgehog.Containers.Deployment do
+      define :deploy, action: :deploy, args: [:release_id, :device_id]
+      define :send_deploy_request, action: :send_deploy_request, args: [:deployment]
+    end
+
+    resource Edgehog.Containers.Image do
+      define :fetch_image, action: :read, get_by: [:id]
+    end
+
     resource Edgehog.Containers.ImageCredentials
-    resource Edgehog.Containers.Release
+
+    resource Edgehog.Containers.Release do
+      define :fetch_release, action: :read, get_by: [:id]
+    end
+
     resource Edgehog.Containers.ReleaseContainers
   end
 end

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -25,6 +25,7 @@ defmodule Edgehog.Containers.Deployment do
     extensions: [AshGraphql.Resource]
 
   alias Edgehog.Containers.Deployment.Changes
+  alias Edgehog.Containers.ManualActions
   alias Edgehog.Containers.Release
 
   graphql do
@@ -50,6 +51,8 @@ defmodule Edgehog.Containers.Deployment do
         constraints instance_of: __MODULE__
         allow_nil? false
       end
+
+      run ManualActions.SendDeployRequest
     end
   end
 

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -24,12 +24,33 @@ defmodule Edgehog.Containers.Deployment do
     domain: Edgehog.Containers,
     extensions: [AshGraphql.Resource]
 
+  alias Edgehog.Containers.Deployment.Changes
+  alias Edgehog.Containers.Release
+
   graphql do
     type :deployment
   end
 
   actions do
     defaults [:read, :destroy, create: [:device_id, :release_id]]
+
+    create :deploy do
+      description """
+      Starts the deployment of a release on a device.
+      It starts an Executor, handling the communication with the device.
+      """
+
+      accept [:release_id, :device_id]
+
+      change Changes.CreateDeploymentOnDevice
+    end
+
+    action :send_deploy_request do
+      argument :deployment, :struct do
+        constraints instance_of: __MODULE__
+        allow_nil? false
+      end
+    end
   end
 
   attributes do
@@ -43,7 +64,7 @@ defmodule Edgehog.Containers.Deployment do
       public? true
     end
 
-    belongs_to :release, Edgehog.Containers.Release do
+    belongs_to :release, Release do
       attribute_type :uuid
       public? true
     end

--- a/backend/lib/edgehog/containers/deployment/changes/create_deployment_on_device.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/create_deployment_on_device.ex
@@ -1,0 +1,38 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.CreateDeploymentOnDevice do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  alias Edgehog.Containers
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    # After the transaction has been executed, i.e. all checks have passed
+    # and the deployment is in the data layer, start the deployment with
+    # the result.
+    Ash.Changeset.after_action(changeset, fn _changeset, deployment ->
+      with :ok <- Containers.send_deploy_request(deployment) do
+        {:ok, deployment}
+      end
+    end)
+  end
+end

--- a/backend/lib/edgehog/containers/manual_actions/send_deploy_request.ex
+++ b/backend/lib/edgehog/containers/manual_actions/send_deploy_request.ex
@@ -37,8 +37,9 @@ defmodule Edgehog.Containers.ManualActions.SendDeployRequest do
       images = containers |> Enum.map(& &1.image) |> Enum.uniq()
 
       with :ok <- send_create_image_requests(device, images),
-           :ok <- send_create_container_requests(device, containers) do
-        Devices.send_create_deployment_request(device, deployment)
+           :ok <- send_create_container_requests(device, containers),
+           {:ok, _device} <- Devices.send_create_deployment_request(device, deployment) do
+        {:ok, deployment}
       end
     end
   end
@@ -46,7 +47,7 @@ defmodule Edgehog.Containers.ManualActions.SendDeployRequest do
   defp send_create_image_requests(device, images) do
     Enum.reduce_while(images, :ok, fn image, _acc ->
       case Devices.send_create_image_request(device, image) do
-        {:ok, _image} -> {:cont, :ok}
+        {:ok, _device} -> {:cont, :ok}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
@@ -55,7 +56,7 @@ defmodule Edgehog.Containers.ManualActions.SendDeployRequest do
   defp send_create_container_requests(device, containers) do
     Enum.reduce_while(containers, :ok, fn container, _acc ->
       case Devices.send_create_container_request(device, container) do
-        {:ok, _container} -> {:cont, :ok}
+        {:ok, _device} -> {:cont, :ok}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)

--- a/backend/lib/edgehog/containers/manual_actions/send_deploy_request.ex
+++ b/backend/lib/edgehog/containers/manual_actions/send_deploy_request.ex
@@ -1,0 +1,63 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.ManualActions.SendDeployRequest do
+  @moduledoc false
+
+  use Ash.Resource.Actions.Implementation
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.Actions.Implementation
+  def run(input, _opts, _context) do
+    deployment = input.arguments.deployment
+
+    with {:ok, deployment} <- Ash.load(deployment, device: [], release: [containers: [:image]]) do
+      device = deployment.device
+
+      release = deployment.release
+      containers = release.containers
+      images = containers |> Enum.map(& &1.image) |> Enum.uniq()
+
+      with :ok <- send_create_image_requests(device, images),
+           :ok <- send_create_container_requests(device, containers) do
+        Devices.send_create_deployment_request(device, deployment)
+      end
+    end
+  end
+
+  defp send_create_image_requests(device, images) do
+    Enum.reduce_while(images, :ok, fn image, _acc ->
+      case Devices.send_create_image_request(device, image) do
+        {:ok, _image} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp send_create_container_requests(device, containers) do
+    Enum.reduce_while(containers, :ok, fn container, _acc ->
+      case Devices.send_create_container_request(device, container) do
+        {:ok, _container} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+end

--- a/backend/lib/edgehog/containers/release.ex
+++ b/backend/lib/edgehog/containers/release.ex
@@ -53,7 +53,7 @@ defmodule Edgehog.Containers.Release do
       join_relationship :deployments
     end
 
-    many_to_many :containers, Edgehog.Containers.Release do
+    many_to_many :containers, Edgehog.Containers.Container do
       through Edgehog.Containers.ReleaseContainers
     end
   end

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
@@ -39,10 +39,12 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateContainer do
          {:ok, device} <- Ash.load(device, :appengine_client) do
       env_encoding = container.env_encoding
       restart_policy = to_correct_string(container.restart_policy)
+      image = container.image
 
       data = %RequestData{
         id: container.id,
         imageId: container.image_id,
+        image: image.reference,
         networkIds: [],
         volumeIds: [],
         hostname: container.hostname,

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
@@ -34,33 +34,38 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateContainer do
   def update(changeset, _opts, _context) do
     device = changeset.data
 
-    with {:ok, container} <- Ash.load(changeset.container, :env_encoding) do
+    with {:ok, container} <- Ash.Changeset.fetch_argument(changeset, :container),
+         {:ok, container} <- Ash.load(container, [:env_encoding, :image]),
+         {:ok, device} <- Ash.load(device, :appengine_client) do
       env_encoding = container.env_encoding
       restart_policy = to_correct_string(container.restart_policy)
 
       data = %RequestData{
-        container_id: container.id,
-        image_id: container.image_id,
-        networks_ids: [],
-        volume_ids: [],
+        id: container.id,
+        imageId: container.image_id,
+        networkIds: [],
+        volumeIds: [],
         hostname: container.hostname,
-        restart_policy: restart_policy,
+        restartPolicy: restart_policy,
         env: env_encoding,
         binds: [],
         networks: [],
-        port_bindings: [],
+        portBindings: [],
         privileged: container.privileged
       }
 
-      with {:ok, device} <- Ash.load(device, :appengine_client) do
-        @send_create_container_request_behaviour.send_create_container_request(
-          device.appengine_client,
-          device.device_id,
-          data
-        )
+      with :ok <-
+             @send_create_container_request_behaviour.send_create_container_request(
+               device.appengine_client,
+               device.device_id,
+               data
+             ) do
+        {:ok, device}
       end
     end
   end
 
-  defp to_correct_string(atom), do: String.replace(atom, "_", "-")
+  defp to_correct_string(atom) do
+    atom |> to_string() |> String.replace("_", "-")
+  end
 end

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_deployment.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_deployment.ex
@@ -43,7 +43,7 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateDeployment do
       containers_ids = Enum.map(containers, & &1.id)
 
       data = %RequestData{
-        id: release.id,
+        id: deployment.id,
         containers: containers_ids
       }
 

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_deployment.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_deployment.ex
@@ -36,7 +36,8 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateDeployment do
     device = changeset.data
 
     with {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
-         {:ok, deployment} <- Ash.load(deployment, release: [:containers]) do
+         {:ok, deployment} <- Ash.load(deployment, release: [:containers]),
+         {:ok, device} <- Ash.load(device, :appengine_client) do
       release = deployment.release
       containers = release.containers
       containers_ids = Enum.map(containers, & &1.id)
@@ -46,12 +47,13 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateDeployment do
         containers: containers_ids
       }
 
-      with {:ok, device} <- Ash.load(device, :appengine_client) do
-        @send_create_deployment_request_behaviour.send_create_deployment_request(
-          device.appengine_client,
-          device.device_id,
-          data
-        )
+      with :ok <-
+             @send_create_deployment_request_behaviour.send_create_deployment_request(
+               device.appengine_client,
+               device.device_id,
+               data
+             ) do
+        {:ok, device}
       end
     end
   end

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
@@ -22,8 +22,6 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateImageRequest do
   @moduledoc false
   use Ash.Resource.ManualUpdate
 
-  require Ash.Query
-
   @send_create_image_request_behaviour Application.compile_env(
                                          :edgehog,
                                          :astarte_create_image_request_module,

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
@@ -22,6 +22,8 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateImageRequest do
   @moduledoc false
   use Ash.Resource.ManualUpdate
 
+  alias Edgehog.Astarte.Device.CreateImageRequest.RequestData
+
   @send_create_image_request_behaviour Application.compile_env(
                                          :edgehog,
                                          :astarte_create_image_request_module,
@@ -37,17 +39,20 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateImageRequest do
          {:ok, device} <- Ash.load(device, :appengine_client) do
       credentials = image.credentials.base64_json
 
-      data = %{
-        image_id: image.id,
+      data = %RequestData{
+        id: image.id,
         reference: image.reference,
-        credentials: credentials
+        registryAuth: credentials
       }
 
-      @send_create_image_request_behaviour.send_create_image_request(
-        device.appengine_client,
-        device.device_id,
-        data
-      )
+      with :ok <-
+             @send_create_image_request_behaviour.send_create_image_request(
+               device.appengine_client,
+               device.device_id,
+               data
+             ) do
+        {:ok, device}
+      end
     end
   end
 end

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -83,7 +83,25 @@ defmodule Edgehog.Devices do
   end
 
   resources do
-    resource Device
+    resource Device do
+      define :fetch_device, action: :read, get_by: [:id]
+
+      define :send_create_image_request,
+        action: :send_create_image,
+        args: [:image]
+
+      define :send_create_container_request,
+        action: :send_create_container_request,
+        args: [:container]
+
+      define :send_create_deployment_request,
+        action: :send_create_deployment_request,
+        args: [:deployment]
+
+      define_calculation :available_images
+      define_calculation :available_containers
+    end
+
     resource HardwareType
     resource Edgehog.Devices.HardwareTypePartNumber
     resource SystemModel

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -39,6 +39,14 @@
       "doc": "The ids of the volumes to mount on the container."
     },
     {
+      "endpoint": "/container/image",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "Container image",
+      "doc": "TODO: this will be remove (by only sending the image_id), when it will be supported on the device."
+    },
+    {
       "endpoint": "/container/hostname",
       "type": "string",
       "database_retention_policy": "use_ttl",
@@ -52,7 +60,7 @@
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
       "description": "Container restart policy",
-      "doc": "The behavior to apply when the container exits."
+      "doc": "The behavior to apply when the container exits. Possible values are: ['', 'no', 'always' 'unless-stopped', 'on-failure']"
     },
     {
       "endpoint": "/container/env",

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateDeploymentRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateDeploymentRequest.json
@@ -7,20 +7,20 @@
   "aggregation": "object",
   "mappings": [
     {
-      "endpoint": "/release/id",
+      "endpoint": "/deployment/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
       "description": "Create Deployment Request id",
-      "doc": "Unique id for the release."
+      "doc": "Unique id for the deployment."
     },
     {
-      "endpoint": "/release/containers",
+      "endpoint": "/deployment/containers",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
       "description": "Deployment containers",
-      "doc": "Containers used by the release."
+      "doc": "Containers used by the deployment."
     }
   ]
 }


### PR DESCRIPTION
closes #656

The deployment mechanism consists of an `executor.ex` that handles the stages of the deployment, sending the appropriate calls to the device asyncronously. The `Devices` domain now exposes code interfaces for the `Device` resource

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
