### PR TITLE
test(containers): add deployments fixtures

### DIFF
--- a/backend/test/edgehog_web/schema/mutation/create_image_credentials_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_image_credentials_test.exs
@@ -22,7 +22,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateImageCredentialsTest do
   @moduledoc false
   use EdgehogWeb.GraphqlCase, async: true
 
-  import Edgehog.ImageCredentialsFixtures
+  import Edgehog.ContainersFixtures
 
   describe "createImageCredentials mutation" do
     test "create image credentials with valid data", %{tenant: tenant} do

--- a/backend/test/edgehog_web/schema/mutation/delete_image_credentials_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/delete_image_credentials_test.exs
@@ -22,7 +22,7 @@ defmodule EdgehogWeb.Schema.Mutation.DeleteImageCredentialsTest do
   @moduledoc false
   use EdgehogWeb.GraphqlCase, async: true
 
-  import Edgehog.ImageCredentialsFixtures
+  import Edgehog.ContainersFixtures
 
   describe "deleteImageCredentials mutation" do
     setup %{tenant: tenant} do

--- a/backend/test/edgehog_web/schema/query/image_credentials_test.exs
+++ b/backend/test/edgehog_web/schema/query/image_credentials_test.exs
@@ -21,7 +21,7 @@
 defmodule EdgehogWeb.Schema.Query.ImageCredentialsTest do
   use EdgehogWeb.GraphqlCase, async: true
 
-  import Edgehog.ImageCredentialsFixtures
+  import Edgehog.ContainersFixtures
 
   describe "image credentials queries" do
     test "returns image credentials if present", %{tenant: tenant} do

--- a/backend/test/edgehog_web/schema/query/list_image_credentials_test.exs
+++ b/backend/test/edgehog_web/schema/query/list_image_credentials_test.exs
@@ -21,7 +21,7 @@
 defmodule EdgehogWeb.Schema.Query.ListImageCredentialsTest do
   use EdgehogWeb.GraphqlCase, async: true
 
-  import Edgehog.ImageCredentialsFixtures
+  import Edgehog.ContainersFixtures
 
   describe "image credentials queries" do
     test "no image credentials at startup", %{tenant: tenant} do

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.ImageCredentialsFixtures do
+defmodule Edgehog.ContainersFixtures do
   @moduledoc """
   This module defines test helpers for creating 
-  entities via the `Edgehog.ImageCredentials` context.
+  entities via the `Edgehog.Containers` context.
   """
 
   @doc """


### PR DESCRIPTION
while deployment fixtures are not used anywhere in this pr, they're needed for work on multiple pr, so we have decided to have an ad-hoc pr to add them first.

image credentials fixtures are refactored into containers fixtuers to align with other fixture modules
