### PR TITLE
CI: don't upload test coverage multiple times

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -128,6 +128,8 @@ jobs:
     strategy:
       matrix:
         postgres: [13, 14, 15, 16]
+    env:
+      postgres_version_uploading_to_coveralls: 16
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -174,8 +176,14 @@ jobs:
         mix deps.get --only test
         mix deps.compile
 
-    - name: Test
+    # Only send upload coverage from a single test in the matrix
+    - name: Test and upload coverage
+      if: matrix.postgres == env.postgres_version_uploading_to_coveralls
       run: mix coveralls.github -o coverage_results --warnings-as-errors
+
+    - name: Test
+      if: matrix.postgres != env.postgres_version_uploading_to_coveralls
+      run: mix test
 
   build-docker-image:
     name: Build Docker image


### PR DESCRIPTION
Pick a single Postgres version in the matrix and use it to upload coverage. Other versions just run tests.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
