### PR TITLE
feat(containers): start and stop deployments

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Containers do
     ]
 
   alias Edgehog.Containers.Application
+  alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.ImageCredentials
 
   graphql do
@@ -55,6 +56,9 @@ defmodule Edgehog.Containers do
       end
 
       destroy ImageCredentials, :delete_image_credentials, :destroy
+
+      update Deployment, :start_deployment, :start
+      update Deployment, :stop_deployment, :stop
     end
   end
 

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -47,6 +47,22 @@ defmodule Edgehog.Containers.Deployment do
       change Changes.CreateDeploymentOnDevice
     end
 
+    update :start do
+      description """
+      Sends a :start command to the release on the device.
+      """
+
+      manual {ManualActions.SendDeploymentCommand, command: :start}
+    end
+
+    update :stop do
+      description """
+      Sends a :stop command to the release on the device.
+      """
+
+      manual {ManualActions.SendDeploymentCommand, command: :stop}
+    end
+
     action :send_deploy_request do
       argument :deployment, :struct do
         constraints instance_of: __MODULE__

--- a/backend/lib/edgehog/containers/manual_actions/send_deployment_command.ex
+++ b/backend/lib/edgehog/containers/manual_actions/send_deployment_command.ex
@@ -1,0 +1,41 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.ManualActions.SendDeploymentCommand do
+  @moduledoc false
+  use Ash.Resource.ManualUpdate
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.ManualUpdate
+  def update(changeset, opts, context) do
+    deployment = changeset.data
+    {:ok, command} = Keyword.pop!(opts, :command)
+    %{tenant: tenant} = context
+
+    with {:ok, deployment} <- Ash.load(deployment, [:device, :release]),
+         device = deployment.device,
+         release = deployment.release,
+         {:ok, _device} <-
+           Devices.send_release_command(device, release, command, tenant: tenant) do
+      {:ok, deployment}
+    end
+  end
+end

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -98,6 +98,10 @@ defmodule Edgehog.Devices do
         action: :send_create_deployment_request,
         args: [:deployment]
 
+      define :send_release_command,
+        action: :send_release_command,
+        args: [:release, :command]
+
       define_calculation :available_images
       define_calculation :available_containers
     end

--- a/backend/test/edgehog_web/schema/mutation/update_deployment_start.ex
+++ b/backend/test/edgehog_web/schema/mutation/update_deployment_start.ex
@@ -1,0 +1,110 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.UpdateDeploymentStart do
+  @moduledoc false
+  use EdgehogWeb.GraphqlCase, async: true
+
+  import Edgehog.ContainersFixtures
+
+  alias Edgehog.Astarte.Device.DeploymentCommandMock
+
+  describe "startDeployment mutation tests" do
+    test "start on an existing deployment", %{tenant: tenant} do
+      deployment = deployment_fixture(tenant: tenant)
+
+      expect(DeploymentCommandMock, :send_deployment_command, 1, fn _, _, _ -> :ok end)
+
+      [tenant: tenant, deployment: deployment]
+      |> send_start_deployment_mutation()
+      |> extract_result!()
+    end
+
+    test "start on a non existing deployment complains" do
+      deployment = deployment_fixture(tenant: tenant)
+
+      deployment = deployment |> Ash.Changeset.for_destroy(:destroy) |> Ash.destroy!()
+
+      [tenant: tenant, deployment: deployment]
+      |> send_start_deployment_mutation()
+      |> extract_error!()
+    end
+  end
+
+  defp send_start_deployment_mutation(opts) do
+    default_document = """
+    mutation StartDeployment($input: ID!) {
+      startDeployment(id: $input) {
+        result {
+          id
+        }
+      }
+    }
+    """
+
+    {tenant, opts} = Keyword.pop!(opts, :tenant)
+    {deployment, opts} = Keyword.pop!(opts, :deployment)
+
+    {device_id, opts} =
+      Keyword.pop_lazy(opts, :device_id, fn ->
+        [tenant: tenant]
+        |> device_fixture()
+        |> AshGraphql.Resource.encode_relay_id()
+      end)
+
+    input = %{
+      "id" => deployment.id
+    }
+
+    variables = %{
+      "input" => input
+    }
+
+    document = Keyword.get(opts, :document, default_document)
+
+    Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
+  end
+
+  def extract_result!(result) do
+    assert %{
+             data: %{
+               "startDeployment" => %{
+                 "result" => deployment
+               }
+             }
+           } = result
+
+    refute :errors in Map.keys(result)
+    assert deployment != nil
+
+    deployment
+  end
+
+  defp extract_error!(result) do
+    assert %{
+             data: %{
+               "startDeployment" => %{"result" => nil}
+             },
+             errors: [error]
+           } = result
+
+    error
+  end
+end


### PR DESCRIPTION
Implements both the start and stop command to a release from the graphql api call.

closes #669
closes #670

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
