### PR TITLE
Deployment: fix GraphQL args for deploy_release mutation

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -59,6 +59,7 @@ defmodule Edgehog.Containers do
 
       create Deployment, :deploy_release, :deploy do
         description "Deploy the application on a device"
+        relay_id_translations input: [release_id: :release, device_id: :device]
       end
 
       update Deployment, :start_deployment, :start

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -87,6 +87,7 @@ defmodule Edgehog.Containers.Deployment do
 
   relationships do
     belongs_to :device, Edgehog.Devices.Device do
+      attribute_type :id
       public? true
     end
 


### PR DESCRIPTION
Instead of accepting the resource IDs used internally, expect Relay IDs as the arguments of the mutation.
Indeed, GraphQL queries expose resources with Relay global IDs, so a translation step should be done when accepting those IDs in GraphQL mutations before they are used with Ash actions.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
