### PR TITLE
feat(containers): support `Application` resource queries

### DIFF
--- a/backend/lib/edgehog/containers/container.ex
+++ b/backend/lib/edgehog/containers/container.ex
@@ -21,11 +21,17 @@
 defmodule Edgehog.Containers.Container do
   @moduledoc false
   use Edgehog.MultitenantResource,
-    domain: Edgehog.Containers
+    domain: Edgehog.Containers,
+    extensions: [AshGraphql.Resource]
 
   alias Edgehog.Containers.Container.EnvEncoding
   alias Edgehog.Containers.Image
   alias Edgehog.Containers.Types.RestartPolicy
+
+  graphql do
+    type :container
+    paginate_relationship_with networks: :relay
+  end
 
   actions do
     defaults [
@@ -39,20 +45,25 @@ defmodule Edgehog.Containers.Container do
   attributes do
     uuid_primary_key :id
 
-    attribute :restart_policy, RestartPolicy
+    attribute :restart_policy, RestartPolicy do
+      public? true
+    end
 
     attribute :hostname, :string do
       constraints allow_empty?: true
       default ""
       allow_nil? false
+      public? true
     end
 
     attribute :env, :map do
       default %{}
+      public? true
     end
 
     attribute :privileged, :boolean do
       default false
+      public? true
     end
 
     timestamps()
@@ -63,6 +74,7 @@ defmodule Edgehog.Containers.Container do
       source_attribute :image_id
       attribute_type :uuid
       allow_nil? false
+      public? true
     end
 
     many_to_many :releases, Edgehog.Containers.Release do
@@ -71,6 +83,7 @@ defmodule Edgehog.Containers.Container do
 
     many_to_many :networks, Edgehog.Containers.Network do
       through Edgehog.Containers.ContainerNetwork
+      public? true
     end
   end
 

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -28,6 +28,7 @@ defmodule Edgehog.Containers do
   alias Edgehog.Containers.Application
   alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.ImageCredentials
+  alias Edgehog.Containers.Release
 
   graphql do
     root_level_errors? true
@@ -47,6 +48,10 @@ defmodule Edgehog.Containers do
 
       get Application, :application, :read do
         description "Returns the desired application."
+      end
+
+      get Release, :release, :read do
+        description "Returns the desired release."
       end
     end
 

--- a/backend/lib/edgehog/containers/image.ex
+++ b/backend/lib/edgehog/containers/image.ex
@@ -21,9 +21,14 @@
 defmodule Edgehog.Containers.Image do
   @moduledoc false
   use Edgehog.MultitenantResource,
-    domain: Edgehog.Containers
+    domain: Edgehog.Containers,
+    extensions: [AshGraphql.Resource]
 
   alias Edgehog.Containers.ImageCredentials
+
+  graphql do
+    type :image
+  end
 
   actions do
     defaults [:read, :destroy, create: [:reference, :image_credentials_id]]
@@ -34,6 +39,7 @@ defmodule Edgehog.Containers.Image do
 
     attribute :reference, :string do
       allow_nil? false
+      public? true
     end
 
     timestamps()
@@ -43,6 +49,7 @@ defmodule Edgehog.Containers.Image do
     belongs_to :credentials, ImageCredentials do
       source_attribute :image_credentials_id
       attribute_type :uuid
+      public? true
     end
   end
 

--- a/backend/lib/edgehog/containers/network.ex
+++ b/backend/lib/edgehog/containers/network.ex
@@ -21,7 +21,12 @@
 defmodule Edgehog.Containers.Network do
   @moduledoc false
   use Edgehog.MultitenantResource,
-    domain: Edgehog.Containers
+    domain: Edgehog.Containers,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :network
+  end
 
   actions do
     defaults [:read, :destroy, create: [:driver, :check_duplicate, :internal, :enable_ipv6]]
@@ -33,21 +38,25 @@ defmodule Edgehog.Containers.Network do
     attribute :driver, :string do
       default "bridge"
       allow_nil? false
+      public? true
     end
 
     attribute :check_duplicate, :boolean do
       default false
       allow_nil? false
+      public? true
     end
 
     attribute :internal, :boolean do
       default false
       allow_nil? false
+      public? true
     end
 
     attribute :enable_ipv6, :boolean do
       default false
       allow_nil? false
+      public? true
     end
 
     timestamps()

--- a/backend/lib/edgehog/containers/release.ex
+++ b/backend/lib/edgehog/containers/release.ex
@@ -64,6 +64,7 @@ defmodule Edgehog.Containers.Release do
 
     many_to_many :containers, Edgehog.Containers.Container do
       through Edgehog.Containers.ReleaseContainers
+      public? true
     end
   end
 

--- a/backend/lib/edgehog/containers/release.ex
+++ b/backend/lib/edgehog/containers/release.ex
@@ -28,6 +28,7 @@ defmodule Edgehog.Containers.Release do
 
   graphql do
     type :release
+    paginate_relationship_with containers: :relay
   end
 
   actions do

--- a/backend/test/edgehog_web/schema/query/application_test.exs
+++ b/backend/test/edgehog_web/schema/query/application_test.exs
@@ -77,13 +77,12 @@ defmodule EdgehogWeb.Schema.Query.ApplicationsTest do
     document = Keyword.get(opts, :document, default_document)
 
     id = Keyword.fetch!(opts, :id)
-    variables = dbg(%{"id" => id})
+    variables = %{"id" => id}
 
     Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
   end
 
   def extract_result!(result) do
-    dbg(result)
     refute :errors in Map.keys(result)
     assert %{data: data} = result
     assert data != nil

--- a/backend/test/edgehog_web/schema/query/release_test.exs
+++ b/backend/test/edgehog_web/schema/query/release_test.exs
@@ -1,0 +1,102 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Query.ReleaseTest do
+  use EdgehogWeb.GraphqlCase, async: true
+
+  import Edgehog.ContainersFixtures
+
+  alias Edgehog.Containers.ContainerNetwork
+  alias Edgehog.Containers.ReleaseContainers
+
+  test "can access containers and netowkrs trough relationship", %{tenant: tenant} do
+    app = application_fixture(tenant: tenant)
+    release = release_fixture(application_id: app.id, tenant: tenant)
+
+    container = container_fixture(tenant: tenant)
+    network = network_fixture(tenant: tenant)
+
+    params = %{container_id: container.id, release_id: release.id}
+    Ash.create!(ReleaseContainers, params, tenant: tenant)
+
+    params = %{container_id: container.id, network_id: network.id}
+    Ash.create!(ContainerNetwork, params, tenant: tenant)
+
+    id = AshGraphql.Resource.encode_relay_id(release)
+
+    release = [tenant: tenant, id: id] |> get_release() |> extract_result!()
+
+    assert get_in(release, ["release", "id"]) == id
+
+    container_result =
+      release
+      |> get_in(["release", "containers", "edges"])
+      |> Enum.map(& &1["node"])
+      |> hd()
+
+    assert container_result["id"] == AshGraphql.Resource.encode_relay_id(container)
+
+    network_result =
+      container_result |> get_in(["networks", "edges"]) |> Enum.map(& &1["node"]) |> hd()
+
+    assert network_result["id"] == AshGraphql.Resource.encode_relay_id(network)
+  end
+
+  defp get_release(opts) do
+    default_document =
+      """
+      query ($id: ID!) {
+        release(id: $id) {
+          id
+          containers {
+            edges {
+              node {
+                id
+                networks {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+
+    {tenant, opts} = Keyword.pop!(opts, :tenant)
+    document = Keyword.get(opts, :document, default_document)
+
+    id = Keyword.fetch!(opts, :id)
+    variables = %{"id" => id}
+
+    Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
+  end
+
+  def extract_result!(result) do
+    refute :errors in Map.keys(result)
+    assert %{data: data} = result
+    assert data != nil
+
+    data
+  end
+end

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -27,6 +27,7 @@ defmodule Edgehog.ContainersFixtures do
   alias Edgehog.Containers.Container
   alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Image
+  alias Edgehog.Containers.Network
   alias Edgehog.Containers.Release
   alias Edgehog.Containers.ReleaseContainers
 
@@ -80,6 +81,14 @@ defmodule Edgehog.ContainersFixtures do
       tenant: tenant
     )
     |> Ash.create!()
+  end
+
+  def network_fixture(opts \\ []) do
+    {tenant, opts} = Keyword.pop!(opts, :tenant)
+
+    params = Map.new(opts)
+
+    Ash.create!(Network, params, tenant: tenant)
   end
 
   def image_fixture(opts \\ []) do


### PR DESCRIPTION
`Application` resource queries are available trough graphql, the frontend can now access an application and all the fields of nested resources

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
