### PR TITLE
feat(containers): application and release creation

### DIFF
--- a/backend/lib/edgehog/containers/application.ex
+++ b/backend/lib/edgehog/containers/application.ex
@@ -30,7 +30,16 @@ defmodule Edgehog.Containers.Application do
   end
 
   actions do
-    defaults [:read, :destroy, create: [:name, :description], update: [:name, :description]]
+    defaults [:read, :destroy, update: [:name, :description]]
+
+    create :create do
+      primary? true
+      accept [:name, :description]
+
+      argument :initial_release, :map
+
+      change manage_relationship(:initial_release, :releases, type: :create)
+    end
   end
 
   attributes do

--- a/backend/lib/edgehog/containers/container.ex
+++ b/backend/lib/edgehog/containers/container.ex
@@ -40,6 +40,18 @@ defmodule Edgehog.Containers.Container do
       create: [:port_bindings, :restart_policy, :hostname, :env, :privileged, :image_id],
       update: [:port_bindings, :restart_policy, :hostname, :env, :privileged, :image_id]
     ]
+
+    create :create_with_nested do
+      accept [:restart_policy, :hostname, :env, :privileged]
+
+      argument :image, :map
+
+      change manage_relationship(:image,
+               on_no_match: :create,
+               on_lookup: :relate,
+               on_match: :ignore
+             )
+    end
   end
 
   attributes do

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -56,6 +56,14 @@ defmodule Edgehog.Containers do
     end
 
     mutations do
+      create Application, :create_application, :create do
+        description "Create a new application."
+      end
+
+      create Release, :create_release, :create do
+        description "Create a new release."
+      end
+
       create ImageCredentials, :create_image_credentials, :create do
         description "Create image credentials."
       end

--- a/backend/lib/edgehog/containers/release.ex
+++ b/backend/lib/edgehog/containers/release.ex
@@ -32,7 +32,22 @@ defmodule Edgehog.Containers.Release do
   end
 
   actions do
-    defaults [:read, :destroy, create: [:application_id, :version]]
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+
+      accept [:application_id, :version]
+
+      argument :containers, {:array, :map}
+
+      # TODO this should be a manual change, checking for existing containers,
+      # for now each new release creates brand new containers
+      change manage_relationship(:containers,
+               on_no_match: {:create, :create_with_nested},
+               on_match: :ignore
+             )
+    end
   end
 
   validations do

--- a/backend/test/edgehog_web/schema/mutation/create_application_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_application_test.exs
@@ -1,0 +1,167 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.CreateApplicationTest do
+  @moduledoc false
+
+  use EdgehogWeb.GraphqlCase, async: true
+
+  import Edgehog.ContainersFixtures
+
+  describe "createApplication mutation" do
+    test "create application with valid data", %{tenant: tenant} do
+      name = "application_name"
+      description = "application description"
+
+      application =
+        [tenant: tenant, name: name, description: description]
+        |> create_application_mutation()
+        |> extract_result!()
+
+      assert application["name"] == name
+      assert application["description"] == description
+    end
+
+    test "create application with valid data and nested initial release", %{tenant: tenant} do
+      name = "application_name"
+      description = "application description"
+      hostname = unique_container_hostname()
+      reference = unique_image_reference()
+
+      initial_release = %{
+        "version" => "0.0.1",
+        "containers" => [
+          %{
+            "hostname" => hostname,
+            "image" => %{
+              "reference" => reference
+            }
+          }
+        ]
+      }
+
+      input = %{
+        "name" => name,
+        "description" => description,
+        "InitialRelease" => initial_release
+      }
+
+      document = """
+      mutation CreateApplication($input: CreateApplicationInput!) {
+        createApplication(input: $input) {
+          result {
+            name
+            description
+            releases {
+              edges {
+                node {
+                  containers {
+                    edges {
+                      node {
+                        hostname
+                        image {
+                          reference
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+
+      application =
+        [tenant: tenant, input: input, document: document]
+        |> create_application_mutation()
+        |> extract_result!()
+
+      assert application["name"] == name
+      assert application["description"] == description
+
+      assert %{
+               "releases" => %{
+                 "edges" => [
+                   %{
+                     "node" => %{
+                       "containers" => %{
+                         "edges" => [
+                           %{"node" => container_result}
+                         ]
+                       }
+                     }
+                   }
+                 ]
+               }
+             } = application
+
+      assert container_result["hostname"] == hostname
+
+      assert %{"image" => image_result} = container_result
+
+      assert image_result["reference"] == reference
+    end
+  end
+
+  def create_application_mutation(opts) do
+    default_document = """
+    mutation CreateApplication($input: CreateApplicationInput!) {
+      createApplication(input: $input) {
+        result {
+          name
+          description
+        }
+      }
+    }
+    """
+
+    {tenant, opts} = Keyword.pop!(opts, :tenant)
+
+    default_input = %{
+      "name" => Keyword.get(opts, :name, unique_application_name()),
+      "description" => Keyword.get(opts, :description, unique_application_description())
+    }
+
+    input = Keyword.get(opts, :input, default_input)
+
+    variables = %{"input" => input}
+
+    document = Keyword.get(opts, :document, default_document)
+
+    Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
+  end
+
+  def extract_result!(result) do
+    assert %{
+             data: %{
+               "createApplication" => %{
+                 "result" => application
+               }
+             }
+           } = result
+
+    refute :errors in Map.keys(result)
+    assert application != nil
+
+    application
+  end
+end

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -113,7 +113,7 @@ defmodule Edgehog.ContainersFixtures do
         image_id: image_id
       })
 
-    Ash.create!(Container, params, tenant: tenant)
+    Container |> Ash.Changeset.for_create(:create, params, tenant: tenant) |> Ash.create!()
   end
 
   @doc """

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -37,6 +37,16 @@ defmodule Edgehog.ContainersFixtures do
   def unique_application_name, do: "application#{System.unique_integer()}"
 
   @doc """
+  Generate a unique application description.
+  """
+  def unique_application_description, do: "application_description#{System.unique_integer()}"
+
+  @doc """
+  Generate a unique container hostname.
+  """
+  def unique_container_hostname, do: "hostname#{System.unique_integer()}"
+
+  @doc """
   Generate a unique image reference.
   """
   def unique_image_reference, do: "image#{System.unique_integer()}"
@@ -113,7 +123,7 @@ defmodule Edgehog.ContainersFixtures do
         image_id: image_id
       })
 
-    Container |> Ash.Changeset.for_create(:create, params, tenant: tenant) |> Ash.create!()
+    Ash.create!(Container, params, tenant: tenant)
   end
 
   @doc """


### PR DESCRIPTION
Depends on #705 
closes #702 

Adds suport for `createApplication` and `createRelease` mutations, with nested resources as arguments

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
