### PR TITLE
Show network `internal` for containers on Release page

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -47,6 +47,7 @@ const CONTAINERS_TABLE_FRAGMENT = graphql`
           edges {
             node {
               driver
+              internal
             }
           }
         }
@@ -95,7 +96,14 @@ const columns = [
     cell: ({ getValue }) => getValue(),
   }),
   columnHelper.accessor(
-    (row) => row.networks.edges?.map((edge) => edge.node.driver).join(", "),
+    (row) =>
+      row.networks.edges
+        ?.map((edge) =>
+          `${edge.node.driver} ${
+            edge.node.internal ? "(internal)" : ""
+          }`.trim(),
+        )
+        .join(", "),
     {
       id: "networks",
       header: () => (


### PR DESCRIPTION
- Added information indicating whether each network is internal (restricts app container internet access) or external


<details><summary>Screenshots</summary>
<p>

![image](https://github.com/user-attachments/assets/d61af66b-5ccc-416b-b322-a19208d938d1)


</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
