### PR TITLE
Fixtures: rework setup of container resources

### DIFF
--- a/backend/lib/edgehog/containers/container.ex
+++ b/backend/lib/edgehog/containers/container.ex
@@ -58,14 +58,15 @@ defmodule Edgehog.Containers.Container do
     ]
 
     create :create_with_nested do
-      accept [:restart_policy, :hostname, :env, :privileged]
+      accept [:restart_policy, :hostname, :env, :privileged, :port_bindings, :network_mode]
 
       argument :image, :map
 
       change manage_relationship(:image,
                on_no_match: :create,
                on_lookup: :relate,
-               on_match: :ignore
+               on_match: :ignore,
+               use_identities: [:reference]
              )
     end
   end


### PR DESCRIPTION
This commit changes how the seeds.exs file creates the resources of the Applications feature:
- Avoid using test fixtures, since those modules are only built in the test environment. This fixes the issue where running the seeding routing crashed when using docker compose.
- Fix the Application's default create action so that it correctly reuses existing Image resources, identified by their `reference` field.
- Ensure that `port_bindings` and `network_mode` attributes are accepted when specifying the containers to be created.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
