### PR TITLE
UI: Display deployed app's initial status as stopped instead of error

### DIFF
--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -309,7 +309,7 @@ const DeployedApplicationsTable = ({
         />
       ),
       cell: ({ getValue }) => (
-        <DeploymentStatusComponent status={getValue() || "ERROR"} />
+        <DeploymentStatusComponent status={getValue() || "STOPPED"} />
       ),
     }),
     columnHelper.accessor((row) => row, {
@@ -322,7 +322,7 @@ const DeployedApplicationsTable = ({
       ),
       cell: ({ getValue }) => (
         <ActionButtons
-          status={getValue().status || "ERROR"}
+          status={getValue().status || "STOPPED"}
           onStart={() => handleStartDeployedApplication(getValue().id)}
           onStop={() => handleStopDeployedApplication(getValue().id)}
         />


### PR DESCRIPTION
When an app is first deployed on a device, while the device has not yet signaled that the deployment is ready, the deployment has a `nil` status.

It's probably more appealing for the user to see an assumed `STOPPED` status for the deployment instead of an `ERROR` status.

Later work can iterate on this improvement and properly define the initial stages where the deployment is first "sent" to the device, and it later becomes "ready" to be started.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
