### PR TITLE
feat(containers): delete deployment mutation

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -77,6 +77,7 @@ defmodule Edgehog.Containers do
 
       update Deployment, :start_deployment, :start
       update Deployment, :stop_deployment, :stop
+      update Deployment, :delete_deployment, :delete
     end
   end
 
@@ -92,6 +93,7 @@ defmodule Edgehog.Containers do
       define :send_deploy_request, action: :send_deploy_request, args: [:deployment]
       define :fetch_deployment, action: :read, get_by: [:id]
       define :deployment_set_status, action: :set_status, args: [:status]
+      define :delete_deployment, action: :destroy
     end
 
     resource Edgehog.Containers.Image do

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -63,6 +63,14 @@ defmodule Edgehog.Containers.Deployment do
       manual {ManualActions.SendDeploymentCommand, command: :stop}
     end
 
+    update :delete do
+      description """
+      Sends a :delete command to the release on the device.
+      """
+
+      manual {ManualActions.SendDeploymentCommand, command: :delete}
+    end
+
     action :send_deploy_request do
       argument :deployment, :struct do
         constraints instance_of: __MODULE__

--- a/backend/lib/edgehog/devices/device/deployment_command.ex
+++ b/backend/lib/edgehog/devices/device/deployment_command.ex
@@ -22,6 +22,7 @@ defmodule Edgehog.Devices.Device.DeploymentCommand do
   @moduledoc false
   use Ash.Type.Enum,
     values: [
+      delete: "Delete the deployment.",
       start: "Start the deployment.",
       stop: "Stop the deployment."
     ]

--- a/backend/lib/edgehog/devices/device/manual_actions/send_application_command.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_application_command.ex
@@ -55,6 +55,7 @@ defmodule Edgehog.Devices.Device.ManualActions.SendApplicationCommand do
     case command do
       :start -> {:ok, "Start"}
       :stop -> {:ok, "Stop"}
+      :delete -> {:ok, "Delete"}
       _ -> {:error, "Unknown deployment command"}
     end
   end

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -121,7 +121,11 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
         status = event.value
 
         with {:ok, deployment} <- Containers.fetch_deployment(deployment_id, tenant: tenant) do
-          Containers.deployment_set_status(deployment, status, tenant: tenant)
+          if status == nil do
+            Containers.delete_deployment(deployment)
+          else
+            Containers.deployment_set_status(deployment, status, tenant: tenant)
+          end
         end
 
       _ ->

--- a/backend/test/edgehog_web/schema/mutation/update_deployment_delete_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_deployment_delete_test.exs
@@ -1,0 +1,101 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule EdgehogWeb.Schema.Mutation.UpdateDeploymentDelete do
+  @moduledoc false
+  use EdgehogWeb.GraphqlCase, async: true
+
+  import Edgehog.ContainersFixtures
+
+  alias Edgehog.Astarte.Device.DeploymentCommandMock
+
+  describe "delteDeployment mutation tests" do
+    test "delete on an existing deployment", %{tenant: tenant} do
+      deployment = deployment_fixture(tenant: tenant)
+
+      expect(DeploymentCommandMock, :send_deployment_command, 1, fn _, _, _ -> :ok end)
+
+      [tenant: tenant, deployment: deployment]
+      |> send_delete_deployment_mutation()
+      |> extract_result!()
+    end
+
+    test "delete on a non existing deployment complains", %{tenant: tenant} do
+      deployment = deployment_fixture(tenant: tenant)
+
+      assert :ok = deployment |> Ash.Changeset.for_destroy(:destroy) |> Ash.destroy!()
+
+      [tenant: tenant, deployment: deployment]
+      |> send_delete_deployment_mutation()
+      |> extract_error!()
+    end
+  end
+
+  defp send_delete_deployment_mutation(opts) do
+    default_document = """
+    mutation DeleteDeployment($input: ID!) {
+      deleteDeployment(id: $input) {
+        result {
+          id
+        }
+      }
+    }
+    """
+
+    {tenant, opts} = Keyword.pop!(opts, :tenant)
+    {deployment, opts} = Keyword.pop!(opts, :deployment)
+
+    input = AshGraphql.Resource.encode_relay_id(deployment)
+
+    variables = %{
+      "input" => input
+    }
+
+    document = Keyword.get(opts, :document, default_document)
+
+    Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
+  end
+
+  def extract_result!(result) do
+    assert %{
+             data: %{
+               "deleteDeployment" => %{
+                 "result" => deployment
+               }
+             }
+           } = result
+
+    refute :errors in Map.keys(result)
+    assert deployment != nil
+
+    deployment
+  end
+
+  defp extract_error!(result) do
+    assert %{
+             data: %{
+               "deleteDeployment" => nil
+             },
+             errors: [error]
+           } = result
+
+    error
+  end
+end

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -23,6 +23,7 @@ defmodule Edgehog.ContainersFixtures do
   This module defines test helpers for creating 
   entities via the `Edgehog.Containers` context.
   """
+  alias Edgehog.AstarteFixtures
   alias Edgehog.Containers.Application
   alias Edgehog.Containers.Container
   alias Edgehog.Containers.Deployment
@@ -171,7 +172,10 @@ defmodule Edgehog.ContainersFixtures do
 
     {device_id, opts} =
       Keyword.pop_lazy(opts, :device_id, fn ->
-        Edgehog.DevicesFixtures.device_fixture(tenant: tenant).id
+        {realm_id, _opts} =
+          Keyword.pop(opts, :realm_id, AstarteFixtures.realm_fixture(tenant: tenant).id)
+
+        Edgehog.DevicesFixtures.device_fixture(realm_id: realm_id, tenant: tenant).id
       end)
 
     {release_id, opts} =


### PR DESCRIPTION
Adds a `deleteDeployment` mutation. The delete query itself does not delete the associated  `deployment` resource until the device unsets the `AvailableDeployment` status with the trigger. When the device unsets the property, then the deployment resource gets deleted in the data layer.

Closes #701 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
