### PR TITLE
Database: avoid LEAKPROOF since it requires superuser privileges

### DIFF
--- a/backend/priv/repo/migrations/20241004151247_install_ash-functions_extension_4.exs
+++ b/backend/priv/repo/migrations/20241004151247_install_ash-functions_extension_4.exs
@@ -62,7 +62,7 @@ defmodule Edgehog.Repo.Migrations.InstallAshFunctionsExtension420241004151245 do
       SELECT to_timestamp(('x0000' || substr(_uuid::TEXT, 1, 8) || substr(_uuid::TEXT, 10, 4))::BIT(64)::BIGINT::NUMERIC / 1000);
     $$
     LANGUAGE SQL
-    IMMUTABLE PARALLEL SAFE STRICT LEAKPROOF;
+    IMMUTABLE PARALLEL SAFE STRICT;
     """)
   end
 


### PR DESCRIPTION
Avoid using LEAKPROOF for database functions because it requires superuser privileges and most installations don't use privileged database users for connecting to Postgres, for example in production environments.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
