### PR TITLE
chore(containers): update status

### DIFF
--- a/backend/lib/edgehog/containers/container.ex
+++ b/backend/lib/edgehog/containers/container.ex
@@ -69,6 +69,12 @@ defmodule Edgehog.Containers.Container do
                use_identities: [:reference]
              )
     end
+
+    read :filter_by_image do
+      argument :image_id, :uuid
+
+      filter expr(image_id == ^arg(:image_id))
+    end
   end
 
   attributes do

--- a/backend/lib/edgehog/containers/container_network.ex
+++ b/backend/lib/edgehog/containers/container_network.ex
@@ -26,6 +26,12 @@ defmodule Edgehog.Containers.ContainerNetwork do
 
   actions do
     defaults [:read, :destroy, create: [:container_id, :network_id]]
+
+    read :containers_by_network do
+      argument :network_id, :uuid
+
+      filter expr(network_id == ^arg(:network_id))
+    end
   end
 
   relationships do

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -91,6 +91,7 @@ defmodule Edgehog.Containers do
 
     resource Edgehog.Containers.Container do
       define :fetch_container, action: :read, get_by: [:id]
+      define :containers_with_image, action: :filter_by_image, args: [:image_id]
     end
 
     resource Edgehog.Containers.Deployment do
@@ -100,6 +101,8 @@ defmodule Edgehog.Containers do
       define :deployment_set_status, action: :set_status, args: [:status, :message]
 
       define :delete_deployment, action: :destroy
+      define :deployment_update_status, action: :update_status
+      define :deployments_with_release, action: :filter_by_release, args: [:release_id]
     end
 
     resource Edgehog.Containers.Image do
@@ -112,12 +115,22 @@ defmodule Edgehog.Containers do
       define :fetch_release, action: :read, get_by: [:id]
     end
 
-    resource Edgehog.Containers.ReleaseContainers
+    resource Edgehog.Containers.ReleaseContainers do
+      define :releases_with_container,
+        action: :releases_by_container,
+        args: [:container_id]
+    end
+
     resource Edgehog.Containers.Network
     resource Edgehog.Containers.Volume
-    resource Edgehog.Containers.ContainerNetwork
 
     resource Edgehog.Containers.DeploymentReadyAction
     resource Edgehog.Containers.DeploymentReadyAction.Upgrade
+
+    resource Edgehog.Containers.ContainerNetwork do
+      define :containers_with_network,
+        action: :containers_by_network,
+        args: [:network_id]
+    end
   end
 end

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -102,12 +102,29 @@ defmodule Edgehog.Containers.Deployment do
     update :set_status do
       accept [:status, :message]
     end
+
+    update :update_status do
+      change Changes.CheckImages
+      change Changes.CheckNetworks
+      change Changes.CheckContainers
+      change Changes.CheckDeployments
+
+      require_atomic? false
+    end
+
+    read :filter_by_release do
+      argument :release_id, :uuid
+
+      filter expr(release_id == ^arg(:release_id))
+    end
   end
 
   attributes do
     uuid_primary_key :id
 
     attribute :status, DeploymentStatus do
+      allow_nil? false
+      default :created
       public? true
     end
 

--- a/backend/lib/edgehog/containers/deployment/changes/check_containers.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_containers.ex
@@ -1,0 +1,51 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.CheckContainers do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, context) do
+    %{tenant: tenant} = context
+    deployment = changeset.data
+
+    with {:ok, :created_networks} <- Ash.Changeset.fetch_argument_or_change(changeset, :status),
+         {:ok, deployment} <-
+           Ash.load(deployment, [:device, release: [:containers]], reuse_values?: true),
+         {:ok, available_containers} <-
+           Devices.available_containers(deployment.device, tenant: tenant) do
+      available_containers = Enum.map(available_containers, & &1.id)
+
+      missing_containers =
+        Enum.reject(deployment.release.containers, &(&1.id in available_containers))
+
+      if missing_containers == [] do
+        Ash.Changeset.change_attribute(changeset, :status, :created_containers)
+      else
+        changeset
+      end
+    else
+      _ -> changeset
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/check_deployments.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_deployments.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.CheckDeployments do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, context) do
+    %{tenant: tenant} = context
+    deployment = changeset.data
+
+    with {:ok, :created_containers} <- Ash.Changeset.fetch_argument_or_change(changeset, :status),
+         {:ok, deployment} <- Ash.load(deployment, :device),
+         {:ok, available_deployments} <-
+           Devices.available_deployments(deployment.device, tenant: tenant) do
+      available_deployments =
+        Enum.map(available_deployments, & &1.id)
+
+      if deployment.id in available_deployments do
+        Ash.Changeset.change_attribute(changeset, :status, :ready)
+      else
+        changeset
+      end
+    else
+      _ ->
+        changeset
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/check_images.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_images.ex
@@ -1,0 +1,55 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.CheckImages do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, context) do
+    %{tenant: tenant} = context
+    deployment = changeset.data
+
+    with :sent <- deployment.status,
+         {:ok, deployment} <-
+           Ash.load(deployment, [:device, release: [containers: [:image]]], reuse_values?: true),
+         {:ok, available_images_statuses} <-
+           Devices.available_images(deployment.device, tenant: tenant) do
+      available_images_ids =
+        Enum.map(available_images_statuses, & &1.id)
+
+      missing_images =
+        deployment.release.containers
+        |> Enum.map(& &1.image.id)
+        |> Enum.reject(&(&1 in available_images_ids))
+
+      if missing_images == [] do
+        Ash.Changeset.change_attribute(changeset, :status, :pulled_images)
+      else
+        changeset
+      end
+    else
+      _ ->
+        changeset
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/check_networks.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_networks.ex
@@ -1,0 +1,56 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.CheckNetworks do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  alias Edgehog.Devices
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, context) do
+    %{tenant: tenant} = context
+    deployment = changeset.data
+
+    with {:ok, :pulled_images} <- Ash.Changeset.fetch_argument_or_change(changeset, :status),
+         {:ok, deployment} <-
+           Ash.load(deployment, [:device, release: [containers: [:networks]]], reuse_values?: true),
+         {:ok, available_networks} <-
+           Devices.available_networks(deployment.device, tenant: tenant) do
+      available_networks =
+        Enum.map(available_networks, & &1.id)
+
+      missing_networks =
+        deployment.release.containers
+        |> Enum.flat_map(& &1.networks)
+        |> Enum.map(& &1.id)
+        |> Enum.uniq()
+        |> Enum.reject(&(&1 in available_networks))
+
+      if missing_networks == [] do
+        Ash.Changeset.change_attribute(changeset, :status, :created_networks)
+      else
+        changeset
+      end
+    else
+      _ -> changeset
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/manual_actions/filter_by_container.ex
+++ b/backend/lib/edgehog/containers/manual_actions/filter_by_container.ex
@@ -1,0 +1,37 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.ManualActions.FilterByContainer do
+  @moduledoc false
+  use Ash.Resource.ManualRead
+
+  alias Edgehog.Containers
+
+  @impl Ash.Resource.ManualRead
+  def read(query, _data_layer_query, _opts, context) do
+    %{tenant: tenant} = context
+
+    with {:ok, container_id} <- Ash.Query.fetch_argument(query, :container_id),
+         {:ok, relations} <-
+           Containers.releases_with_container(container_id, tenant: tenant, load: :release) do
+      {:ok, Enum.map(relations, & &1.release)}
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/release_containers.ex
+++ b/backend/lib/edgehog/containers/release_containers.ex
@@ -26,6 +26,12 @@ defmodule Edgehog.Containers.ReleaseContainers do
 
   actions do
     defaults [:read, :destroy, create: [:release_id, :container_id]]
+
+    read :releases_by_container do
+      argument :container_id, :uuid
+
+      filter expr(container_id == ^arg(:container_id))
+    end
   end
 
   attributes do

--- a/backend/lib/edgehog/containers/types/deployment_status.ex
+++ b/backend/lib/edgehog/containers/types/deployment_status.ex
@@ -27,7 +27,16 @@ defmodule Edgehog.Containers.Types.DeploymentStatus do
       started: "The deployment is running.",
       starting: "The deployment is starting.",
       stopped: "The deployment has stopped.",
-      stopping: "The deploymen is stopping."
+      stopping: "The deploymen is stopping.",
+      created: "The deployment has been received by the backend and will be sent to the device.",
+      sent: "All the necessary resources have been sent to the device.",
+      ready: "The deployment is ready on the device. All necessary resources are available.",
+      # TODO: these are internal states that should not be exposed.
+      # Remove when reimplementing the deployment and its status as a state machine
+      pulled_images: "The device is currently pulling the necessary images for the deployment.",
+      created_networks: "The device is setting up the networks necessary for the deployment.",
+      created_containers: "The device is setting up the containers necessary for the deployment.",
+      created_deployment: "The device is setting up the release of the the deployment."
     ]
 
   def graphql_type(_), do: :application_deployment_status

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -108,8 +108,10 @@ defmodule Edgehog.Devices do
 
       define :update_application, action: :update_application, args: [:from, :to]
 
-      define_calculation :available_images
-      define_calculation :available_containers
+      define_calculation :available_images, args: [:_record]
+      define_calculation :available_containers, args: [:_record]
+      define_calculation :available_networks, args: [:_record]
+      define_calculation :available_deployments, args: [:_record]
     end
 
     resource HardwareType


### PR DESCRIPTION
Deployment status update at each container interface trigger, status interface richer, expresses new deployment statuses:
- `:created` when the backend has recived the deployment description
- `:sent` when the deployment description has been sent to the device
- `:puled_images` when the device has created all the image resources
- `:created_networks` when the device has set up all the network resources
- `:created_containers` when the device has created all the container resources
- `:created_deployment` when the device has set up the deployment resource
- `:ready` when all resources have been created and the deployment is ready to be started

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
