### PR TITLE
Add application name to Release page for better context

### DIFF
--- a/frontend/src/pages/Release.tsx
+++ b/frontend/src/pages/Release.tsx
@@ -42,6 +42,9 @@ const GET_RELEASE_QUERY = graphql`
   query Release_getRelease_Query($releaseId: ID!) {
     release(id: $releaseId) {
       version
+      application {
+        name
+      }
       containers {
         ...ContainersTable_ContainerFragment
       }
@@ -58,7 +61,9 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
 
   return (
     <Page>
-      <Page.Header title={release.version} />
+      <Page.Header
+        title={`${release.application?.name ?? ""} (v${release.version})`}
+      />
       <Page.Main>
         <Alert
           show={!!errorFeedback}


### PR DESCRIPTION
When viewing the page of a Release, the name of the associated application is now displayed. This provides clarity for users opening the page directly, ensuring they can identify which application the release belongs to


<details><summary>Screenshots</summary>
<p>

Before:
![image](https://github.com/user-attachments/assets/089d7393-672a-4e6a-8f5b-aa9d8c891329)


After:
![image](https://github.com/user-attachments/assets/10dfd29c-0d8b-4301-b7c5-5cadab6528ed)


</p>
</details> 
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
