### PR TITLE
Add support for DEPLOYING status in DeployedApplicationsTable 

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -341,6 +341,9 @@
   "components.DeployedApplicationsTable.deleting": {
     "defaultMessage": "Deleting"
   },
+  "components.DeployedApplicationsTable.deploying": {
+    "defaultMessage": "Deploying"
+  },
   "components.DeployedApplicationsTable.error": {
     "defaultMessage": "Error"
   },


### PR DESCRIPTION
- When an app is first deployed, the deployment has a null status
- Introduced `DEPLOYING` as an additional status to handle deployments in progress
- Updated `statusColors` and `statusMessages`

<details><summary>Screenshots</summary>
<p>

Before:
![image](https://github.com/user-attachments/assets/7c68f8e0-592c-4247-b71b-02542c78a2b2)


After:
![image](https://github.com/user-attachments/assets/1fa0e5ba-56bc-432a-9bd1-a782978279e8)

</p>
</details> 


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
