### PR TITLE
Handle incoming Starting deployment status when already Started

### DIFF
--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -36,7 +36,7 @@ defmodule Edgehog.Containers.Deployment do
   end
 
   actions do
-    defaults [:read, :destroy, create: [:device_id, :release_id]]
+    defaults [:read, :destroy, create: [:device_id, :release_id, :status, :message]]
 
     create :deploy do
       description """

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -115,7 +115,18 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
     } = event.value
 
     with {:ok, deployment} <- Containers.fetch_deployment(deployment_id, tenant: tenant) do
-      Containers.deployment_set_status(deployment, status, message, tenant: tenant)
+      case {deployment.status, status} do
+        {:started, "Starting"} ->
+          # Skip Starting if already Started
+          {:ok, deployment}
+
+        {:stopped, "Stopping"} ->
+          # Skip Stopping if already Stopped
+          {:ok, deployment}
+
+        _ ->
+          Containers.deployment_set_status(deployment, status, message, tenant: tenant)
+      end
     end
   end
 


### PR DESCRIPTION
There are cases where starting an already Started deployment may happen. In this cases, a Starting status is received on the DeploymentEvent Astarte interface but no Started status is later received on the AvailableDeployments interface since the deployment was already available in a Started status.
The Deployment is then stuck in the Starting status.

To overcome this scenario, this change avoids handling a Starting status coming from Astarte triggers when the deployment is already in the Started status.

For simmetry, the same is done for the transition between the Stopping and Stopped statuses.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
