### PR TITLE
fix!(containers): remove ready status

### DIFF
--- a/backend/lib/edgehog/containers/deployment/changes/check_images.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_images.ex
@@ -43,7 +43,7 @@ defmodule Edgehog.Containers.Deployment.Changes.CheckImages do
         |> Enum.reject(&(&1 in available_images_ids))
 
       if missing_images == [] do
-        Ash.Changeset.change_attribute(changeset, :status, :pulled_images)
+        Ash.Changeset.change_attribute(changeset, :status, :created_images)
       else
         changeset
       end

--- a/backend/lib/edgehog/containers/deployment/changes/check_networks.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_networks.ex
@@ -29,7 +29,7 @@ defmodule Edgehog.Containers.Deployment.Changes.CheckNetworks do
     %{tenant: tenant} = context
     deployment = changeset.data
 
-    with {:ok, :pulled_images} <- Ash.Changeset.fetch_argument_or_change(changeset, :status),
+    with {:ok, :created_images} <- Ash.Changeset.fetch_argument_or_change(changeset, :status),
          {:ok, deployment} <-
            Ash.load(deployment, [:device, release: [containers: [:networks]]], reuse_values?: true),
          {:ok, available_networks} <-

--- a/backend/lib/edgehog/containers/types/deployment_status.ex
+++ b/backend/lib/edgehog/containers/types/deployment_status.ex
@@ -30,13 +30,12 @@ defmodule Edgehog.Containers.Types.DeploymentStatus do
       stopping: "The deploymen is stopping.",
       created: "The deployment has been received by the backend and will be sent to the device.",
       sent: "All the necessary resources have been sent to the device.",
-      ready: "The deployment is ready on the device. All necessary resources are available.",
       # TODO: these are internal states that should not be exposed.
       # Remove when reimplementing the deployment and its status as a state machine
-      pulled_images: "The device is currently pulling the necessary images for the deployment.",
-      created_networks: "The device is setting up the networks necessary for the deployment.",
-      created_containers: "The device is setting up the containers necessary for the deployment.",
-      created_deployment: "The device is setting up the release of the the deployment."
+      created_images: "The device has received the necessary image descriptions for the deployment.",
+      created_networks: "The device has received all the network descriptions necessary for the deployment.",
+      created_containers: "The device has received all the container descriptions necessary for the deployment.",
+      created_deployment: "The device has received the release description of the the deployment."
     ]
 
   def graphql_type(_), do: :application_deployment_status

--- a/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
+++ b/backend/test/edgehog_web/controllers/astarte_trigger_controller_test.exs
@@ -598,7 +598,7 @@ defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
       |> response(200)
 
       deployment = Ash.get!(Deployment, deployment.id, tenant: tenant)
-      assert deployment.status == :ready
+      assert deployment.status == :stopped
     end
 
     test "AvailableContainers triggers update deployment status", context do
@@ -638,7 +638,7 @@ defmodule EdgehogWeb.Controllers.AstarteTriggerControllerTest do
       |> response(200)
 
       deployment = Ash.get!(Deployment, deployment.id, tenant: tenant)
-      assert deployment.status == :ready
+      assert deployment.status == :stopped
     end
 
     test "AvailableDeployments triggers update deployment status", context do


### PR DESCRIPTION
- `:ready` and `:stopped` are redundant statuses, moved to using only `:stopped` status;
- the `check_deployment` check when the deployment is available sets the deployment status tio the device deployment status

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
