### PR TITLE
Add is online check to deployments 

### DIFF
--- a/frontend/src/components/AddAvailableApplications.tsx
+++ b/frontend/src/components/AddAvailableApplications.tsx
@@ -63,12 +63,14 @@ const DEPLOY_RELEASE_MUTATION = graphql`
 
 type AddAvailableApplicationsProps = {
   deviceId: string;
+  isOnline: boolean;
   setErrorFeedback: (errorMessages: React.ReactNode) => void;
   onDeployComplete: () => void;
 };
 
 const AddAvailableApplications = ({
   deviceId,
+  isOnline,
   setErrorFeedback,
   onDeployComplete,
 }: AddAvailableApplicationsProps) => {
@@ -88,8 +90,17 @@ const AddAvailableApplications = ({
     );
 
   const handleAppChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedApp(e.target.value);
-    setSelectedRelease(null); // Reset release when app changes
+    if (isOnline) {
+      setSelectedApp(e.target.value);
+      setSelectedRelease(null); // Reset release when app changes
+    } else {
+      setErrorFeedback(
+        <FormattedMessage
+          id="components.AddAvailableApplications.deviceOfflineError"
+          defaultMessage="The device is disconnected. You cannot deploy an application while it is offline."
+        />,
+      );
+    }
   };
 
   const handleReleaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -198,7 +209,7 @@ const AddAvailableApplications = ({
         <Button
           variant="primary"
           onClick={handleDeploy}
-          disabled={!selectedRelease || isDeploying} // Disable until a release is selected or deploying
+          disabled={!isOnline || !selectedRelease || isDeploying}
         >
           <FormattedMessage
             id="components.AddAvailableApplications.deployButton"

--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -249,7 +249,7 @@ const DeployedApplicationsTable = ({
           onError: () => {
             setErrorFeedback(
               <FormattedMessage
-                id="components.AddAvailableApplications.startErrorFeedback"
+                id="components.DeployedApplicationsTable.startErrorFeedback"
                 defaultMessage="Could not Start the Deployed Application, please try again."
               />,
             );
@@ -287,7 +287,7 @@ const DeployedApplicationsTable = ({
           onError: () => {
             setErrorFeedback(
               <FormattedMessage
-                id="components.AddAvailableApplications.stopErrorFeedback"
+                id="components.DeployedApplicationsTable.stopErrorFeedback"
                 defaultMessage="Could not Stop the Deployed Application, please try again."
               />,
             );

--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -194,6 +194,7 @@ const ActionButtons = ({
 type DeploymentTableProps = {
   className?: string;
   deviceRef: DeployedApplicationsTable_deployedApplications$key;
+  isOnline: boolean;
   hideSearch?: boolean;
   setErrorFeedback: (errorMessages: React.ReactNode) => void;
   onDeploymentChange: () => void;
@@ -202,6 +203,7 @@ type DeploymentTableProps = {
 const DeployedApplicationsTable = ({
   className,
   deviceRef,
+  isOnline,
   hideSearch = false,
   setErrorFeedback,
   onDeploymentChange,
@@ -229,60 +231,78 @@ const DeployedApplicationsTable = ({
 
   const handleStartDeployedApplication = useCallback(
     (deploymentId: string) => {
-      startDeployment({
-        variables: { id: deploymentId },
-        onCompleted: (data, errors) => {
-          if (errors) {
-            const errorFeedback = errors
-              .map(({ fields, message }) =>
-                fields.length ? `${fields.join(" ")} ${message}` : message,
-              )
-              .join(". \n");
-            return setErrorFeedback(errorFeedback);
-          }
-          onDeploymentChange(); // Trigger data refresh
-          setErrorFeedback(null);
-        },
-        onError: () => {
-          setErrorFeedback(
-            <FormattedMessage
-              id="components.AddAvailableApplications.startErrorFeedback"
-              defaultMessage="Could not Start the Deployed Application, please try again."
-            />,
-          );
-        },
-      });
+      if (isOnline) {
+        startDeployment({
+          variables: { id: deploymentId },
+          onCompleted: (data, errors) => {
+            if (errors) {
+              const errorFeedback = errors
+                .map(({ fields, message }) =>
+                  fields.length ? `${fields.join(" ")} ${message}` : message,
+                )
+                .join(". \n");
+              return setErrorFeedback(errorFeedback);
+            }
+            onDeploymentChange(); // Trigger data refresh
+            setErrorFeedback(null);
+          },
+          onError: () => {
+            setErrorFeedback(
+              <FormattedMessage
+                id="components.AddAvailableApplications.startErrorFeedback"
+                defaultMessage="Could not Start the Deployed Application, please try again."
+              />,
+            );
+          },
+        });
+      } else {
+        setErrorFeedback(
+          <FormattedMessage
+            id="components.DeployedApplicationsTable.startErrorOffline"
+            defaultMessage="The device is disconnected. You cannot start an application while it is offline."
+          />,
+        );
+      }
     },
-    [startDeployment, setErrorFeedback, onDeploymentChange],
+    [isOnline, startDeployment, setErrorFeedback, onDeploymentChange],
   );
 
   const handleStopDeployedApplication = useCallback(
     (deploymentId: string) => {
-      stopDeployment({
-        variables: { id: deploymentId },
-        onCompleted: (data, errors) => {
-          if (errors) {
-            const errorFeedback = errors
-              .map(({ fields, message }) =>
-                fields.length ? `${fields.join(" ")} ${message}` : message,
-              )
-              .join(". \n");
-            return setErrorFeedback(errorFeedback);
-          }
-          onDeploymentChange(); // Trigger data refresh
-          setErrorFeedback(null);
-        },
-        onError: () => {
-          setErrorFeedback(
-            <FormattedMessage
-              id="components.AddAvailableApplications.stopErrorFeedback"
-              defaultMessage="Could not Stop the Deployed Application, please try again."
-            />,
-          );
-        },
-      });
+      if (isOnline) {
+        stopDeployment({
+          variables: { id: deploymentId },
+          onCompleted: (data, errors) => {
+            if (errors) {
+              const errorFeedback = errors
+                .map(({ fields, message }) =>
+                  fields.length ? `${fields.join(" ")} ${message}` : message,
+                )
+                .join(". \n");
+              return setErrorFeedback(errorFeedback);
+            }
+            onDeploymentChange(); // Trigger data refresh
+            setErrorFeedback(null);
+          },
+          onError: () => {
+            setErrorFeedback(
+              <FormattedMessage
+                id="components.AddAvailableApplications.stopErrorFeedback"
+                defaultMessage="Could not Stop the Deployed Application, please try again."
+              />,
+            );
+          },
+        });
+      } else {
+        setErrorFeedback(
+          <FormattedMessage
+            id="components.DeployedApplicationsTable.stopErrorOffline"
+            defaultMessage="The device is disconnected. You cannot stop an application while it is offline."
+          />,
+        );
+      }
     },
-    [stopDeployment, setErrorFeedback, onDeploymentChange],
+    [isOnline, stopDeployment, setErrorFeedback, onDeploymentChange],
   );
 
   const columnHelper = createColumnHelper<(typeof deployments)[0]>();

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -92,6 +92,9 @@
   "components.AddAvailableApplications.deployErrorFeedback": {
     "defaultMessage": "Could not deploy the Application, please try again."
   },
+  "components.AddAvailableApplications.deviceOfflineError": {
+    "defaultMessage": "The device is disconnected. You cannot deploy an application while it is offline."
+  },
   "components.AddAvailableApplications.selectAnApplication": {
     "defaultMessage": "Select an application"
   },
@@ -356,6 +359,9 @@
   "components.DeployedApplicationsTable.startErrorFeedback": {
     "defaultMessage": "Could not Start the Deployed Application, please try again."
   },
+  "components.DeployedApplicationsTable.startErrorOffline": {
+    "defaultMessage": "The device is disconnected. You cannot start an application while it is offline."
+  },
   "components.DeployedApplicationsTable.started": {
     "defaultMessage": "Started"
   },
@@ -367,6 +373,9 @@
   },
   "components.DeployedApplicationsTable.stopErrorFeedback": {
     "defaultMessage": "Could not Stop the Deployed Application, please try again."
+  },
+  "components.DeployedApplicationsTable.stopErrorOffline": {
+    "defaultMessage": "The device is disconnected. You cannot stop an application while it is offline."
   },
   "components.DeployedApplicationsTable.stopped": {
     "defaultMessage": "Stopped"

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -280,6 +280,7 @@ const DEVICE_DEPLOYED_APPLICATIONS_FRAGMENT = graphql`
   @refetchable(queryName: "Device_deployedApplications_RefetchQuery") {
     device(id: $id) {
       id
+      online
       ...DeployedApplicationsTable_deployedApplications
     }
   }
@@ -558,6 +559,8 @@ const ApplicationsTab = ({ deviceRef }: ApplicationsTabProps) => {
     Device_deployedApplications$key
   >(DEVICE_DEPLOYED_APPLICATIONS_FRAGMENT, deviceRef);
 
+  const isOnline = useMemo(() => device?.online ?? false, [device]);
+
   const handleRefetch = useCallback(() => {
     refetch({ id: device?.id }, { fetchPolicy: "store-and-network" });
   }, [refetch, device?.id]);
@@ -592,6 +595,7 @@ const ApplicationsTab = ({ deviceRef }: ApplicationsTabProps) => {
         </h5>
         <AddAvailableApplications
           deviceId={device.id}
+          isOnline={isOnline}
           setErrorFeedback={setErrorFeedback}
           onDeployComplete={handleRefetch}
         />
@@ -603,6 +607,7 @@ const ApplicationsTab = ({ deviceRef }: ApplicationsTabProps) => {
         </h5>
         <DeployedApplicationsTable
           deviceRef={device}
+          isOnline={isOnline}
           setErrorFeedback={setErrorFeedback}
           onDeploymentChange={handleRefetch}
         />


### PR DESCRIPTION
- Added `isOnline` state to track the device's online status
- Passed `isOnline` as a prop to `AddAvailableApplications` and `DeployedApplicationsTable`
- Displayed an error message when the device is offline, preventing new deployments and restricting starting/stopping existing ones


<details><summary>Screenshots</summary>
<p>

![image](https://github.com/user-attachments/assets/1ac2c147-4955-43e1-9cbe-1d128017526d)
![image](https://github.com/user-attachments/assets/29fae112-2e37-400f-8c76-ab26a986456e)
![image](https://github.com/user-attachments/assets/1cc675d9-498b-438a-98bf-edc9d4cbe69c)


</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
