### PR TITLE
Fix calculations of Astarte values for container resources

### DIFF
--- a/backend/lib/edgehog/containers/deployment/changes/check_images.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/check_images.ex
@@ -22,20 +22,15 @@ defmodule Edgehog.Containers.Deployment.Changes.CheckImages do
   @moduledoc false
   use Ash.Resource.Change
 
-  alias Edgehog.Devices
-
   @impl Ash.Resource.Change
-  def change(changeset, _opts, context) do
-    %{tenant: tenant} = context
+  def change(changeset, _opts, _context) do
     deployment = changeset.data
 
     with :sent <- deployment.status,
          {:ok, deployment} <-
-           Ash.load(deployment, [:device, release: [containers: [:image]]], reuse_values?: true),
-         {:ok, available_images_statuses} <-
-           Devices.available_images(deployment.device, tenant: tenant) do
+           Ash.load(deployment, device: :available_images, release: [containers: [:image]]) do
       available_images_ids =
-        Enum.map(available_images_statuses, & &1.id)
+        Enum.map(deployment.device.available_images, & &1.id)
 
       missing_images =
         deployment.release.containers

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -107,11 +107,6 @@ defmodule Edgehog.Devices do
         args: [:release, :command]
 
       define :update_application, action: :update_application, args: [:from, :to]
-
-      define_calculation :available_images, args: [:_record]
-      define_calculation :available_containers, args: [:_record]
-      define_calculation :available_networks, args: [:_record]
-      define_calculation :available_deployments, args: [:_record]
     end
 
     resource HardwareType


### PR DESCRIPTION
The calculations defined in the Devices domain do not correctly load the calculation's dependencies, so the calculations cannot be computed. The proposed change is to just load the calculations with Ash.load, which was already done in the addressed code anyway.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
