### PR TITLE
fix(containers): deployment upgrade not working

### DIFF
--- a/backend/lib/edgehog/astarte/device/deployment_update.ex
+++ b/backend/lib/edgehog/astarte/device/deployment_update.ex
@@ -30,6 +30,8 @@ defmodule Edgehog.Astarte.Device.DeploymentUpdate do
 
   @impl Edgehog.Astarte.Device.DeploymentUpdate.Behaviour
   def update(client, device_id, data) do
+    data = Map.from_struct(data)
+
     api_call =
       AppEngine.Devices.send_datastream(client, device_id, @interface, "/deployment", data)
 


### PR DESCRIPTION
tesla throws an exception if a struct does not implement json conversion. converting to a map fixes it

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
