### PR TITLE
feat(ota): exposing optional update target of OTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10] - Unreleased
+### Added
+- Managed OTA operations expose the update target that created them in graphql ([#356](https://github.com/edgehog-device-manager/edgehog/issues/356).
+
 ## [0.9.2] - 2024-12-09
 ### Changed
 - Update the docker-compose configuration to allow both physical and virtual devices

--- a/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
@@ -191,6 +191,15 @@ defmodule Edgehog.OSManagement.OTAOperation do
       attribute_public? false
       allow_nil? false
     end
+
+    has_one :update_target, Edgehog.UpdateCampaigns.UpdateTarget do
+      description """
+      The update target of an update campaing that created the managed
+      ota operation, if any.
+      """
+
+      public? true
+    end
   end
 
   calculations do


### PR DESCRIPTION
Ota operations expose an optional `UpdateTarget`. It is a reference to the update target that created the managed ota operation

Closes #356

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
