### PR TITLE
Allow to reach your edgehog instance from outside your host

### DIFF
--- a/.env
+++ b/.env
@@ -22,6 +22,14 @@ IPBASE_API_KEY=
 GOOGLE_GEOLOCATION_API_KEY=
 GOOGLE_GEOCODING_API_KEY=
 
+# The top level domain of your edgehog instance.
+# In case you want to make Edgehog visible in your LAN, consider setting the variable
+# to <HOST_IP>.nip.io
+DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN=edgehog.localhost
+# The top level domain of your astarte instance. It must be set according to your
+# configuration for Astarte.
+DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN=astarte.localhost
+
 S3_ACCESS_KEY_ID=minioadmin
 S3_SECRET_ACCESS_KEY=minioadmin
 S3_REGION=local
@@ -29,10 +37,10 @@ S3_SCHEME=http://
 S3_HOST=minio
 S3_PORT=9000
 S3_BUCKET=edgehog
-S3_ASSET_HOST=http://minio-storage.edgehog.localhost/edgehog
+S3_ASSET_HOST=http://minio-storage.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}/edgehog
 S3_GCP_CREDENTIALS=
 
 SEEDS_REALM=test
 SEEDS_REALM_PRIVATE_KEY_FILE=./backend/priv/repo/seeds/keys/realm_private.pem
 SEEDS_TENANT_PRIVATE_KEY_FILE=./backend/priv/repo/seeds/keys/tenant_private.pem
-SEEDS_ASTARTE_BASE_API_URL=http://api.astarte.localhost
+SEEDS_ASTARTE_BASE_API_URL=http://api.${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - Unreleased
+### Changed
+- Update the docker-compose configuration to allow both physical and virtual devices
+  to connect to Edgehog, provided that the devices and the host are on the same LAN.
+
 ## [0.9.1] - 2024-10-28
 ### Fixed
 - Allow receiving `trigger_name` key in trigger payload, which is sent by Astarte >= 1.2.0.

--- a/docker-compose.without-astarte.yml
+++ b/docker-compose.without-astarte.yml
@@ -18,7 +18,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: "3.8"
 services:
   traefik:
     image: traefik:v2.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       URL_HOST: edgehog-backend
       URL_PORT: 4000
       URL_SCHEME: http
-      EDGEHOG_FORWARDER_HOSTNAME: device-forwarder.edgehog.localhost
+      EDGEHOG_FORWARDER_HOSTNAME: device-forwarder.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}
       EDGEHOG_FORWARDER_PORT: 80
       EDGEHOG_FORWARDER_SECURE_SESSIONS: "false"
     restart: on-failure
@@ -63,7 +63,7 @@ services:
       - minio-init
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.edgehog-backend.rule=Host(`api.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-backend.rule=Host(`api.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
       - "traefik.http.routers.edgehog-backend.entrypoints=web"
       - "traefik.http.routers.edgehog-backend.service=edgehog-backend"
       - "traefik.http.services.edgehog-backend.loadbalancer.server.port=4000"
@@ -73,11 +73,11 @@ services:
     build:
       context: frontend
     environment:
-      BACKEND_URL: http://api.edgehog.localhost/
+      BACKEND_URL: http://api.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}/
     restart: on-failure
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.edgehog-frontend.rule=Host(`edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-frontend.rule=Host(`${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
       - "traefik.http.routers.edgehog-frontend.entrypoints=web"
       - "traefik.http.routers.edgehog-frontend.service=edgehog-frontend"
       - "traefik.http.services.edgehog-frontend.loadbalancer.server.port=80"
@@ -88,11 +88,11 @@ services:
       RELEASE_NAME: edgehog-device-forwarder
       SECRET_KEY_BASE: fXzwqLnU1V1bhfOwMRdm3tiGHRlfSpqmrw2aONac2QU4T9iwh3vjSIaweH1n0ZWg
       PORT: 4001
-      PHX_HOST:  device-forwarder.edgehog.localhost
+      PHX_HOST:  device-forwarder.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}
     restart: on-failure
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.edgehog-device-forwarder.rule=Host(`device-forwarder.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-device-forwarder.rule=Host(`device-forwarder.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
       - "traefik.http.routers.edgehog-device-forwarder.entrypoints=web"
       - "traefik.http.routers.edgehog-device-forwarder.service=edgehog-device-forwarder"
       - "traefik.http.services.edgehog-device-forwarder.loadbalancer.server.port=4001"
@@ -107,11 +107,11 @@ services:
     command: server --console-address ":9001" /data
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.edgehog-minio-storage.rule=Host(`minio-storage.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-minio-storage.rule=Host(`minio-storage.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
       - "traefik.http.routers.edgehog-minio-storage.entrypoints=web"
       - "traefik.http.routers.edgehog-minio-storage.service=edgehog-minio-storage"
       - "traefik.http.services.edgehog-minio-storage.loadbalancer.server.port=9000"
-      - "traefik.http.routers.edgehog-minio-console.rule=Host(`minio.edgehog.localhost`)"
+      - "traefik.http.routers.edgehog-minio-console.rule=Host(`minio.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
       - "traefik.http.routers.edgehog-minio-console.entrypoints=web"
       - "traefik.http.routers.edgehog-minio-console.service=edgehog-minio-console"
       - "traefik.http.services.edgehog-minio-console.loadbalancer.server.port=9001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: "3.8"
 services:
   postgresql:
     image: postgres:16.3


### PR DESCRIPTION
Your edgehog (created via docker compose) can now be exposed on an arbitrary domain, making it possible for devices in the same subnet to interact with it.

Fix #758 
