### PR TITLE
Fix Confirm Modal `closeButton` not functional without onCancel handler

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022 SECO Mind Srl
+  Copyright 2022-2024 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ const ConfirmModal = ({
   return (
     <div onKeyDown={handleKeyDown} {...restProps}>
       <Modal show centered size={size} onHide={handleHide}>
-        <Modal.Header closeButton>
+        <Modal.Header closeButton onClick={onCancel}>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>{children}</Modal.Body>


### PR DESCRIPTION
Resolved an issue where the `closeButton` in the `ConfirmModal` was non-functional without an explicit `onCancel` handler

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
