### PR TITLE
fix(bucket_storage): image deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - Unreleased
+### Fixed
+- Base Image deletion in S3 storage
+
 ## [0.9.2] - 2024-12-09
 ### Changed
 - Update the docker-compose configuration to allow both physical and virtual devices

--- a/backend/lib/edgehog/base_images/bucket_storage.ex
+++ b/backend/lib/edgehog/base_images/bucket_storage.ex
@@ -42,8 +42,20 @@ defmodule Edgehog.BaseImages.BucketStorage do
   end
 
   @impl Storage
-  def delete(%BaseImage{} = scope) do
-    %BaseImage{url: url} = scope
+  def delete(%BaseImage{} = base_image) do
+    %BaseImage{
+      url: url,
+      tenant_id: tenant_id,
+      version: base_image_version,
+      base_image_collection_id: base_image_collection_id
+    } = base_image
+
+    scope = %{
+      tenant_id: tenant_id,
+      base_image_collection_id: base_image_collection_id,
+      base_image_version: base_image_version
+    }
+
     Uploaders.BaseImage.delete({url, scope})
   end
 end


### PR DESCRIPTION
previously, calling Ash.destroy! on a base image would crash the program because Edgehog.BaseImages.Uploaders.BaseImage.filename/2 would try to access the field `base_image_version` of a BaseImage, which does not exist

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
