### PR TITLE
chore(seeds): reconcile tenant when seeding

### DIFF
--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -128,6 +128,11 @@ tenant =
 {status, realm_pk} =
   read_key!.("SEEDS_REALM_PRIVATE_KEY_FILE", "SEEDS_REALM_ORIGINAL_FILE", "realm_private")
 
+Astarte.create_realm!(
+  %{cluster_id: cluster.id, name: read_env_var.("SEEDS_REALM"), private_key: realm_pk},
+  tenant: tenant
+)
+
 if status == :default do
   """
   You are using the default realm private key. \
@@ -135,11 +140,8 @@ if status == :default do
   """
   |> String.trim_trailing("\n")
   |> Logger.warning()
+else
+  Edgehog.Tenants.reconcile_tenant(tenant)
 end
-
-Astarte.create_realm!(
-  %{cluster_id: cluster.id, name: read_env_var.("SEEDS_REALM"), private_key: realm_pk},
-  tenant: tenant
-)
 
 :ok

--- a/doc/pages/tutorials/edgehog_in_5_minutes.md
+++ b/doc/pages/tutorials/edgehog_in_5_minutes.md
@@ -144,14 +144,6 @@ You can finally navigate to `http://edgehog.localhost` in your browser and login
 
 ## Test Astarte connection
 
-Astarte connectivity may not work right away, as edgehog has not yet reconciled
-its interfaces and triggers with astarte. Without waiting, we can force it to execute
-the reconciler using:
-
-```sh
-$ docker compose exec edgehog-backend bin/edgehog rpc "Edgehog.Tenants.list_tenants |> Enum.each(&Edgehog.Tenants.reconcile_tenant/1)"
-```
-
 If you now connect a device to astarte and open or reload the edgehog web page,
 you should see the new device in the appropriate section.
 


### PR DESCRIPTION
- Reconciling tenant is done directly in seeds when it gets created
- Edgehog in 5 minutes does no longer instruct users to manually reconcile the tenant with astarte

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
