### PR TITLE
Add upgrade deployment functionality with version selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Release page**: Provides details of a specific release, including a list of containers and configurations, such as image reference, image credentials (label, username), networks, and port bindings.
 - Added `ApplicationCreate` page to enable users to create a new application with fields for application name and description.
 - Added `ReleaseCreate` page to enable users to create a new release for an application with fields for release Version and a list of Containers.
+- Add upgrade deployment functionality with version selection ([#703](https://github.com/edgehog-device-manager/edgehog/issues/703))
 
 ## [0.9.1] - 2024-10-28
 ### Fixed

--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -22,6 +22,7 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import {
   faAngleDown,
   faAngleUp,
+  faArrowAltCircleUp,
   faArrowDown,
   faArrowUp,
   faBug,
@@ -67,6 +68,7 @@ const icons = {
   close: faTimes,
   otaUpdates: faCloud,
   applications: faRocket,
+  upgrade: faArrowAltCircleUp,
 } as const;
 
 type FontAwesomeIconProps = React.ComponentProps<typeof FontAwesomeIcon>;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -383,6 +383,15 @@
   "components.DeployedApplicationsTable.applicationName": {
     "defaultMessage": "Application Name"
   },
+  "components.DeployedApplicationsTable.confirmLabel": {
+    "defaultMessage": "Confirm"
+  },
+  "components.DeployedApplicationsTable.confirmModal.description": {
+    "defaultMessage": "Are you sure you want to upgrade the deployment <bold>{application}</bold> from version <bold>{currentVersion}</bold> to version:"
+  },
+  "components.DeployedApplicationsTable.confirmModal.title": {
+    "defaultMessage": "Upgrade Deployment"
+  },
   "components.DeployedApplicationsTable.deleteModal.description": {
     "defaultMessage": "This action cannot be undone. This will permanently delete the deployment."
   },
@@ -407,8 +416,14 @@
   "components.DeployedApplicationsTable.noDeployedApplications": {
     "defaultMessage": "No deployed applications"
   },
+  "components.DeployedApplicationsTable.noReleasesAvailable": {
+    "defaultMessage": "No Release Versions Available"
+  },
   "components.DeployedApplicationsTable.releaseVersion": {
     "defaultMessage": "Release Version"
+  },
+  "components.DeployedApplicationsTable.selectOption": {
+    "defaultMessage": "Select a Release Version"
   },
   "components.DeployedApplicationsTable.startErrorFeedback": {
     "defaultMessage": "Could not Start the Deployed Application, please try again."
@@ -436,6 +451,12 @@
   },
   "components.DeployedApplicationsTable.stopping": {
     "defaultMessage": "Stopping"
+  },
+  "components.DeployedApplicationsTable.upgradeErrorFeedback": {
+    "defaultMessage": "Could not upgrade the deployment, please try again."
+  },
+  "components.DeployedApplicationsTable.upgradeErrorOffline": {
+    "defaultMessage": "The device is disconnected. You cannot upgrade an application while it is offline."
   },
   "components.DeviceGroupsTable.handleTitle": {
     "defaultMessage": "Handle",


### PR DESCRIPTION
- Allow users to upgrade existing app deployments from the Applications tab on the Device page
- Users can select from a list of available newer release versions

<details><summary>Screeenshots</summary>
<p>

![image](https://github.com/user-attachments/assets/818260d0-4f32-4e36-90f3-19e720d875e0)
![image](https://github.com/user-attachments/assets/4dfe8147-30b7-447a-bb03-16be00d5405c)
![image](https://github.com/user-attachments/assets/84f164bc-9cd8-46f2-9305-092cb72e0a06)
![image](https://github.com/user-attachments/assets/a80f8410-5d0b-43f7-9350-672d28c1bf34)
![image](https://github.com/user-attachments/assets/0628c645-68a3-4bf0-b7c8-1ebc18c661c7)
![image](https://github.com/user-attachments/assets/04a9ed4c-19d3-4d93-9aa6-b2593bff4687)


</p>
</details> 

Closes #703

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
