### PR TITLE
feat!(pagination): paginate device relationships

### DIFF
--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -50,6 +50,11 @@ defmodule Edgehog.Devices.Device do
 
   graphql do
     type :device
+
+    # TODO: add :device_groups as a relay-paginated relationship. Since it's a
+    # manual relationship, it needs to implement callbacks that define
+    # datalayer subqueries so Ash can compose and support the functionality.
+    paginate_relationship_with ota_operations: :relay, tags: :relay
   end
 
   actions do

--- a/backend/test/edgehog_web/schema/mutation/update_device_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_device_test.exs
@@ -52,6 +52,13 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateDeviceTest do
           name
           deviceId
           online
+          otaOperations {
+            edges {
+              node {
+                id
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Part of #779
Paginates device's `:ota_operations` and `:tags` relationships with relay

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
