### PR TITLE
chore(reuse): apache license template

### DIFF
--- a/.reuse/templates/apache.jinja2
+++ b/.reuse/templates/apache.jinja2
@@ -1,0 +1,21 @@
+This file is part of Edgehog.
+
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}


### PR DESCRIPTION
Adds a template that can be used with the `reuse` tool.
Files can be updated automatically with:

```sh
reuse annotate <file> \
      --copyright 'SECO Mind Srl' \
      --copyright-prefix string \
      --merge-copyrights \
      --template apache
```

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
