### PR TITLE
Enable server-side pagination for device ota operations

### DIFF
--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -761,6 +761,27 @@ type BaseImage implements Node {
   ): [LocalizedAttribute!]
 }
 
+"A relay page info"
+type PageInfo {
+  "When paginating backwards, are there more items?"
+  hasPreviousPage: Boolean!
+
+  "When paginating forwards, are there more items?"
+  hasNextPage: Boolean!
+
+  "When paginating backwards, the cursor to continue"
+  startCursor: String
+
+  "When paginating forwards, the cursor to continue"
+  endCursor: String
+}
+
+"A relay node"
+interface Node {
+  "A unique identifier"
+  id: ID!
+}
+
 enum SortOrder {
   DESC
   DESC_NULLS_FIRST
@@ -1517,12 +1538,18 @@ type Device implements Node {
     "A filter to limit the results"
     filter: TagFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [Tag!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): TagConnection!
 
   "The groups the device belongs to."
   deviceGroups(
@@ -1547,12 +1574,18 @@ type Device implements Node {
     "A filter to limit the results"
     filter: OtaOperationFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [OtaOperation!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): OtaOperationConnection!
 
   "The capabilities that the device can support."
   capabilities: [DeviceCapability!]!
@@ -1840,6 +1873,27 @@ enum TagSortField {
   NAME
 }
 
+":tag connection"
+type TagConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":tag edges"
+  edges: [TagEdge!]
+}
+
+":tag edge"
+type TagEdge {
+  "Cursor"
+  cursor: String!
+
+  ":tag node"
+  node: Tag!
+}
+
 input TagFilterName {
   isNil: Boolean
   eq: String
@@ -1909,6 +1963,27 @@ enum OtaOperationSortField {
   MESSAGE
   CREATED_AT
   UPDATED_AT
+}
+
+":ota_operation connection"
+type OtaOperationConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":ota_operation edges"
+  edges: [OtaOperationEdge!]
+}
+
+":ota_operation edge"
+type OtaOperationEdge {
+  "Cursor"
+  cursor: String!
+
+  ":ota_operation node"
+  node: OtaOperation!
 }
 
 input OtaOperationFilterUpdatedAt {
@@ -2035,6 +2110,12 @@ input OtaOperationFilterInput {
 
   "The device targeted from the operation"
   device: DeviceFilterInput
+
+  """
+  The update target of an update campaing that created the managed
+  ota operation, if any.
+  """
+  updateTarget: UpdateTargetFilterInput
 }
 
 input OtaOperationSortInput {
@@ -2069,6 +2150,12 @@ type OtaOperation {
 
   "The device targeted from the operation"
   device: Device!
+
+  """
+  The update target of an update campaing that created the managed
+  ota operation, if any.
+  """
+  updateTarget: UpdateTarget
 }
 
 type TenantInfo {
@@ -2616,14 +2703,7 @@ type UpdateCampaign implements Node {
   successfulTargetCount: Int!
 }
 
-interface Node {
-  "The ID of the object."
-  id: ID!
-}
-
 type RootQueryType {
-  node("The ID of an object." id: ID!): Node
-
   "Returns a single update campaign."
   updateCampaign("The id of the record" id: ID!): UpdateCampaign
 
@@ -2663,7 +2743,7 @@ type RootQueryType {
   "Returns a single device group."
   deviceGroup("The id of the record" id: ID!): DeviceGroup
 
-  "Returns the list of all device groups."
+  "Returns a list of device groups."
   deviceGroups(
     "How to sort the records in the response"
     sort: [DeviceGroupSortInput]
@@ -2693,7 +2773,7 @@ type RootQueryType {
     filter: DeviceFilterInput
   ): [Device!]!
 
-  "Returns a hardware type."
+  "Returns a single hardware type."
   hardwareType("The id of the record" id: ID!): HardwareType
 
   "Returns a list of hardware types."
@@ -2705,7 +2785,7 @@ type RootQueryType {
     filter: HardwareTypeFilterInput
   ): [HardwareType!]!
 
-  "Returns a system model."
+  "Returns a single system model."
   systemModel("The id of the record" id: ID!): SystemModel
 
   "Returns a list of system models."
@@ -2717,13 +2797,16 @@ type RootQueryType {
     filter: SystemModelFilterInput
   ): [SystemModel!]!
 
+  "Retrieves a Node from its global id"
+  node("The Node unique identifier" id: ID!): Node!
+
   "Returns a single base image."
   baseImage("The id of the record" id: ID!): BaseImage
 
-  "Returns a single base image."
+  "Returns a single base image collection."
   baseImageCollection("The id of the record" id: ID!): BaseImageCollection
 
-  "Returns a list of base images."
+  "Returns a list of base image collections."
   baseImageCollections(
     "How to sort the records in the response"
     sort: [BaseImageCollectionSortInput]

--- a/frontend/src/api/schema.graphql.license
+++ b/frontend/src/api/schema.graphql.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021-2023 SECO Mind Srl
+SPDX-FileCopyrightText: 2021-2025 SECO Mind Srl
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/src/components/DevicesTable.tsx
+++ b/frontend/src/components/DevicesTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -49,7 +49,11 @@ const DEVICES_TABLE_FRAGMENT = graphql`
       }
     }
     tags {
-      name
+      edges {
+        node {
+          name
+        }
+      }
     }
   }
 `;
@@ -145,7 +149,7 @@ const columns = [
     ),
     cell: ({ getValue }) => (
       <>
-        {getValue().map(({ name: tag }) => (
+        {getValue().edges?.map(({ node: { name: tag } }) => (
           <Tag key={tag} className="me-2">
             {tag}
           </Tag>

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import {
   useMutation,
   fetchQuery,
   useRelayEnvironment,
+  usePaginationFragment,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import type { PayloadError, Subscription } from "relay-runtime";
@@ -43,6 +44,7 @@ import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import dayjs from "dayjs";
 import _ from "lodash";
 
+import type { Device_PaginationQuery } from "api/__generated__/Device_PaginationQuery.graphql";
 import type { Device_batteryStatus$key } from "api/__generated__/Device_batteryStatus.graphql";
 import type { Device_hardwareInfo$key } from "api/__generated__/Device_hardwareInfo.graphql";
 import type { Device_location$key } from "api/__generated__/Device_location.graphql";
@@ -173,14 +175,20 @@ const DEVICE_BATTERY_STATUS_FRAGMENT = graphql`
 `;
 
 const DEVICE_OTA_OPERATIONS_FRAGMENT = graphql`
-  fragment Device_otaOperations on Device {
+  fragment Device_otaOperations on Device
+  @refetchable(queryName: "Device_PaginationQuery") {
     id
     capabilities
-    otaOperations {
-      id
-      baseImageUrl
-      status
-      createdAt
+    otaOperations(first: $first, after: $after)
+      @connection(key: "Device_otaOperations") {
+      edges {
+        node {
+          id
+          baseImageUrl
+          status
+          createdAt
+        }
+      }
     }
     ...OperationTable_otaOperations
   }
@@ -221,7 +229,7 @@ const DEVICE_CONNECTION_STATUS_FRAGMENT = graphql`
 `;
 
 const GET_DEVICE_QUERY = graphql`
-  query Device_getDevice_Query($id: ID!) {
+  query Device_getDevice_Query($id: ID!, $first: Int, $after: String) {
     forwarderConfig {
       __typename
     }
@@ -239,8 +247,12 @@ const GET_DEVICE_QUERY = graphql`
         }
       }
       tags {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       deviceGroups {
         id
@@ -264,7 +276,11 @@ const GET_DEVICE_QUERY = graphql`
 `;
 
 const GET_DEVICE_OTA_OPERATIONS_QUERY = graphql`
-  query Device_getDeviceOtaOperations_Query($id: ID!) {
+  query Device_getDeviceOtaOperations_Query(
+    $id: ID!
+    $first: Int
+    $after: String
+  ) {
     device(id: $id) {
       id
       online
@@ -315,8 +331,12 @@ const ADD_DEVICE_TAGS_MUTATION = graphql`
       result {
         id
         tags {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         deviceGroups {
           id
@@ -336,8 +356,12 @@ const REMOVE_DEVICE_TAGS_MUTATION = graphql`
       result {
         id
         tags {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         deviceGroups {
           id
@@ -1011,25 +1035,29 @@ const SoftwareUpdateTab = ({ deviceRef }: SoftwareUpdateTabProps) => {
   const intl = useIntl();
   const relayEnvironment = useRelayEnvironment();
 
-  const device = useFragment(DEVICE_OTA_OPERATIONS_FRAGMENT, deviceRef);
-  const deviceId = device.id;
+  const { data } = usePaginationFragment<
+    Device_PaginationQuery,
+    Device_otaOperations$key
+  >(DEVICE_OTA_OPERATIONS_FRAGMENT, deviceRef);
+
+  const deviceId = data.id;
 
   const [createOtaOperation, isCreatingOtaOperation] =
     useMutation<Device_createManualOtaOperation_Mutation>(
       DEVICE_CREATE_MANUAL_OTA_OPERATION_MUTATION,
     );
 
-  const otaOperations = device.otaOperations
-    .map((operation) => ({ ...operation }))
-    .sort((a, b) => {
-      if (a.createdAt > b.createdAt) {
-        return -1;
-      }
-      if (a.createdAt < b.createdAt) {
-        return 1;
-      }
-      return 0;
-    });
+  const otaOperations = (
+    data.otaOperations?.edges?.map(({ node }) => node) || []
+  ).sort((a, b) => {
+    if (a.createdAt > b.createdAt) {
+      return -1;
+    }
+    if (a.createdAt < b.createdAt) {
+      return 1;
+    }
+    return 0;
+  });
 
   const lastFinishedOperationIndex = otaOperations.findIndex(
     ({ status }) => status === "SUCCESS" || status === "FAILURE",
@@ -1063,6 +1091,7 @@ const SoftwareUpdateTab = ({ deviceRef }: SoftwareUpdateTabProps) => {
         GET_DEVICE_OTA_OPERATIONS_QUERY,
         {
           id: deviceId,
+          first: 10_000,
         },
       ).subscribe({
         complete: () => {
@@ -1085,7 +1114,7 @@ const SoftwareUpdateTab = ({ deviceRef }: SoftwareUpdateTabProps) => {
     deviceId,
   ]);
 
-  if (!device.capabilities.includes("SOFTWARE_UPDATES")) {
+  if (!data.capabilities.includes("SOFTWARE_UPDATES")) {
     return null;
   }
 
@@ -1187,7 +1216,7 @@ const SoftwareUpdateTab = ({ deviceRef }: SoftwareUpdateTabProps) => {
             defaultMessage="History"
           />
         </h5>
-        <OperationTable deviceRef={device} />
+        <OperationTable deviceRef={data} />
       </div>
     </Tab>
   );
@@ -1354,7 +1383,7 @@ const DeviceContent = ({
 
   const deviceTags = useMemo(
     () =>
-      device?.tags?.map(({ name: tag }) => ({
+      device?.tags?.edges?.map(({ node: { name: tag } }) => ({
         label: tag,
         value: tag,
       })) || [],
@@ -1908,7 +1937,7 @@ const DevicePage = () => {
   );
 
   useEffect(() => {
-    getDevice({ id: deviceId });
+    getDevice({ id: deviceId, first: 10_000 });
     refreshTags();
   }, [getDevice, deviceId, refreshTags]);
 
@@ -1927,7 +1956,7 @@ const DevicePage = () => {
           </Center>
         )}
         onReset={() => {
-          getDevice({ id: deviceId });
+          getDevice({ id: deviceId, first: 10_000 });
           refreshTags();
         }}
       >


### PR DESCRIPTION
Updated queries for device `ota_operations` to support server-side pagination. This change ensures data fetching is paginated on the backend while maintaining the current client-side logic. A future update will optimize the respective tables to fully leverage pagination, avoiding an immediate rewrite of the client-side implementation.

Part of #779

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
