### PR TITLE
Enable server-side pagination for update_channels 

### DIFF
--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -2528,6 +2528,27 @@ enum UpdateChannelSortField {
   NAME
 }
 
+":update_channel connection"
+type UpdateChannelConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_channel edges"
+  edges: [UpdateChannelEdge!]
+}
+
+":update_channel edge"
+type UpdateChannelEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_channel node"
+  node: UpdateChannel!
+}
+
 input UpdateChannelFilterName {
   isNil: Boolean
   eq: String
@@ -2897,7 +2918,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: UpdateChannelFilterInput
-  ): [UpdateChannel!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateChannelConnection
 
   "Retrieves the current tenant."
   tenantInfo: TenantInfo!

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -1885,6 +1885,27 @@ enum DeviceGroupSortField {
   SELECTOR
 }
 
+":device_group connection"
+type DeviceGroupConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":device_group edges"
+  edges: [DeviceGroupEdge!]
+}
+
+":device_group edge"
+type DeviceGroupEdge {
+  "Cursor"
+  cursor: String!
+
+  ":device_group node"
+  node: DeviceGroup!
+}
+
 input DeviceGroupFilterSelector {
   isNil: Boolean
   eq: String
@@ -2598,12 +2619,18 @@ type UpdateChannel implements Node {
     "A filter to limit the results"
     filter: DeviceGroupFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [DeviceGroup!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): DeviceGroupConnection!
 }
 
 "The result of the :create_update_campaign mutation"
@@ -2906,7 +2933,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: DeviceGroupFilterInput
-  ): [DeviceGroup!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): DeviceGroupConnection
 
   """
   Fetches the forwarder config, if available.

--- a/frontend/src/components/UpdateChannelsTable.tsx
+++ b/frontend/src/components/UpdateChannelsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -39,7 +39,11 @@ const DEVICE_GROUPS_TABLE_FRAGMENT = graphql`
     name
     handle
     targetGroups {
-      name
+      edges {
+        node {
+          name
+        }
+      }
     }
   }
 `;
@@ -85,7 +89,7 @@ const columns = [
     ),
     cell: ({ getValue }) => (
       <>
-        {getValue().map((group) => (
+        {getValue().edges?.map(({ node: group }) => (
           <Tag key={group.name} className="me-2">
             {group.name}
           </Tag>

--- a/frontend/src/forms/CreateUpdateCampaign.tsx
+++ b/frontend/src/forms/CreateUpdateCampaign.tsx
@@ -47,8 +47,12 @@ const UPDATE_CAMPAIGN_OPTIONS_FRAGMENT = graphql`
       }
     }
     updateChannels {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
   }
 `;
@@ -314,7 +318,7 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select an Update Channel",
               })}
             </option>
-            {updateChannels.map((updateChannel) => (
+            {updateChannels?.edges?.map(({ node: updateChannel }) => (
               <option key={updateChannel.id} value={updateChannel.id}>
                 {updateChannel.name}
               </option>

--- a/frontend/src/forms/CreateUpdateChannel.tsx
+++ b/frontend/src/forms/CreateUpdateChannel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import { useForm, Controller } from "react-hook-form";
 import { useIntl, FormattedMessage } from "react-intl";
 import { yupResolver } from "@hookform/resolvers/yup";
 
+import type { CreateUpdateChannel_OptionsFragment$key } from "api/__generated__/CreateUpdateChannel_OptionsFragment.graphql";
+
 import Button from "components/Button";
 import Col from "components/Col";
 import Form from "components/Form";
@@ -32,15 +34,18 @@ import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { updateChannelHandleSchema, yup, messages } from "forms";
 import { graphql, useFragment } from "react-relay/hooks";
-import type { CreateUpdateChannel_OptionsFragment$key } from "api/__generated__/CreateUpdateChannel_OptionsFragment.graphql";
 
 const CREATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT = graphql`
   fragment CreateUpdateChannel_OptionsFragment on RootQueryType {
     deviceGroups {
-      id
-      name
-      updateChannel {
-        name
+      edges {
+        node {
+          id
+          name
+          updateChannel {
+            name
+          }
+        }
       }
     }
   }
@@ -179,18 +184,20 @@ const CreateUpdateChannel = ({
 
   const targetGroupOptions = useMemo(() => {
     // move disabled options to the end
-    return [...targetGroups].sort((group1, group2) => {
-      const group1Disabled = isTargetGroupUsedByOtherChannel(group1);
-      const group2Disabled = isTargetGroupUsedByOtherChannel(group2);
+    return [...(targetGroups?.edges?.map((edge) => edge.node) || [])].sort(
+      (group1, group2) => {
+        const group1Disabled = isTargetGroupUsedByOtherChannel(group1);
+        const group2Disabled = isTargetGroupUsedByOtherChannel(group2);
 
-      if (group1Disabled === group2Disabled) {
-        return 0;
-      }
-      if (group1Disabled) {
-        return 1;
-      }
-      return -1;
-    });
+        if (group1Disabled === group2Disabled) {
+          return 0;
+        }
+        if (group1Disabled) {
+          return 1;
+        }
+        return -1;
+      },
+    );
   }, [targetGroups]);
 
   const onFormSubmit = (data: FormData) => onSubmit(transformOutputData(data));

--- a/frontend/src/pages/DeviceGroup.tsx
+++ b/frontend/src/pages/DeviceGroup.tsx
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
+  ConnectionHandler,
   graphql,
   useMutation,
   usePreloadedQuery,
@@ -137,24 +138,23 @@ const DeviceGroupContent = ({ deviceGroup }: DeviceGroupContentProps) => {
         setShowDeleteModal(false);
       },
       updater(store, data) {
-        if (!data?.deleteDeviceGroup?.result?.id) {
+        const deviceGroupId = data?.deleteDeviceGroup?.result?.id;
+        if (!deviceGroupId) {
           return;
         }
 
         const deviceGroup = store
           .getRootField("deleteDeviceGroup")
           .getLinkedRecord("result");
-        const deviceGroupId = deviceGroup.getDataID();
         const root = store.getRoot();
 
-        const deviceGroups = root.getLinkedRecords("deviceGroups");
-        if (deviceGroups) {
-          root.setLinkedRecords(
-            deviceGroups.filter(
-              (deviceGroup) => deviceGroup.getDataID() !== deviceGroupId,
-            ),
-            "deviceGroups",
-          );
+        const connection = ConnectionHandler.getConnection(
+          root,
+          "DeviceGroupsTable_deviceGroups",
+        );
+
+        if (connection) {
+          ConnectionHandler.deleteNode(connection, deviceGroupId);
         }
 
         const devices = deviceGroup.getLinkedRecords("devices");

--- a/frontend/src/pages/DeviceGroups.tsx
+++ b/frontend/src/pages/DeviceGroups.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022-2024 SECO Mind Srl
+  Copyright 2022-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { DeviceGroups_getDeviceGroups_Query } from "api/__generated__/DeviceGroups_getDeviceGroups_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import DeviceGroupsTable from "components/DeviceGroupsTable";
@@ -33,10 +34,8 @@ import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
 const GET_DEVICE_GROUPS_QUERY = graphql`
-  query DeviceGroups_getDeviceGroups_Query {
-    deviceGroups {
-      ...DeviceGroupsTable_DeviceGroupFragment
-    }
+  query DeviceGroups_getDeviceGroups_Query($first: Int, $after: String) {
+    ...DeviceGroupsTable_DeviceGroupFragment
   }
 `;
 
@@ -47,7 +46,7 @@ interface DeviceGroupsContentProps {
 const DeviceGroupsContent = ({
   getDeviceGroupsQuery,
 }: DeviceGroupsContentProps) => {
-  const { deviceGroups } = usePreloadedQuery(
+  const deviceGroups = usePreloadedQuery(
     GET_DEVICE_GROUPS_QUERY,
     getDeviceGroupsQuery,
   );
@@ -81,7 +80,8 @@ const DevicesPage = () => {
     useQueryLoader<DeviceGroups_getDeviceGroups_Query>(GET_DEVICE_GROUPS_QUERY);
 
   const fetchDeviceGroups = useCallback(
-    () => getDeviceGroups({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getDeviceGroups({ first: 10_000 }, { fetchPolicy: "store-and-network" }),
     [getDeviceGroups],
   );
 

--- a/frontend/src/pages/UpdateCampaignCreate.tsx
+++ b/frontend/src/pages/UpdateCampaignCreate.tsx
@@ -35,6 +35,7 @@ import type {
   UpdateCampaignCreate_getOptions_Query$data,
 } from "api/__generated__/UpdateCampaignCreate_getOptions_Query.graphql";
 import type { UpdateCampaignCreate_createUpdateCampaign_Mutation } from "api/__generated__/UpdateCampaignCreate_createUpdateCampaign_Mutation.graphql";
+
 import Alert from "components/Alert";
 import Button from "components/Button";
 import Center from "components/Center";
@@ -53,6 +54,7 @@ const GET_CREATE_UPDATE_CAMPAIGN_OPTIONS_QUERY = graphql`
     }
     updateChannels {
       __typename
+      count
     }
     ...CreateUpdateCampaign_OptionsFragment
   }
@@ -218,7 +220,7 @@ const UpdateCampaignWrapper = ({
   if (baseImageCollections?.count === 0) {
     return <NoBaseImageCollections />;
   }
-  if (updateChannels.length === 0) {
+  if (updateChannels?.count === 0) {
     return <NoUpdateChannels />;
   }
 

--- a/frontend/src/pages/UpdateChannel.tsx
+++ b/frontend/src/pages/UpdateChannel.tsx
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
+  ConnectionHandler,
   graphql,
   useMutation,
   usePreloadedQuery,
@@ -177,14 +178,13 @@ const UpdateChannelContent = ({
 
         const root = store.getRoot();
 
-        const updateChannels = root.getLinkedRecords("updateChannels");
-        if (updateChannels) {
-          root.setLinkedRecords(
-            updateChannels.filter(
-              (updateChannel) => updateChannel.getDataID() !== updateChannelId,
-            ),
-            "updateChannels",
-          );
+        const connection = ConnectionHandler.getConnection(
+          root,
+          "UpdateChannelsTable_updateChannels",
+        );
+
+        if (connection) {
+          ConnectionHandler.deleteNode(connection, updateChannelId);
         }
 
         const targetGroupIds = new Set(

--- a/frontend/src/pages/UpdateChannels.tsx
+++ b/frontend/src/pages/UpdateChannels.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { UpdateChannels_getUpdateChannels_Query } from "api/__generated__/UpdateChannels_getUpdateChannels_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import UpdateChannelsTable from "components/UpdateChannelsTable";
@@ -33,10 +34,8 @@ import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
 const GET_UPDATE_CHANNELS_QUERY = graphql`
-  query UpdateChannels_getUpdateChannels_Query {
-    updateChannels {
-      ...UpdateChannelsTable_UpdateChannelFragment
-    }
+  query UpdateChannels_getUpdateChannels_Query($first: Int, $after: String) {
+    ...UpdateChannelsTable_UpdateChannelFragment
   }
 `;
 
@@ -47,7 +46,7 @@ type UpdateChannelsContentProps = {
 const UpdateChannelsContent = ({
   getUpdateChannelsQuery,
 }: UpdateChannelsContentProps) => {
-  const { updateChannels } = usePreloadedQuery(
+  const updateChannels = usePreloadedQuery(
     GET_UPDATE_CHANNELS_QUERY,
     getUpdateChannelsQuery,
   );
@@ -83,7 +82,11 @@ const UpdateChannelsPage = () => {
     );
 
   const fetchUpdateChannels = useCallback(
-    () => getUpdateChannels({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getUpdateChannels(
+        { first: 10_000 },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getUpdateChannels],
   );
 


### PR DESCRIPTION
Updated queries for `update_channel` to support server-side pagination. This change ensures data fetching is paginated on the backend while maintaining the current client-side logic. A future update will optimize the respective tables to fully leverage pagination, avoiding an immediate rewrite of the client-side implementation.

Part of https://github.com/edgehog-device-manager/edgehog/issues/779

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
