### PR TITLE
fix(realm_fixture): new realm only if not present

### DIFF
--- a/backend/test/edgehog_web/schema/query/device_test.exs
+++ b/backend/test/edgehog_web/schema/query/device_test.exs
@@ -111,7 +111,7 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
     end
 
     test "queries associated application deployments", %{tenant: tenant} do
-      fixture = device_fixture(tenant: tenant)
+      fixture = [tenant: tenant] |> device_fixture() |> Ash.load!(:realm, tenant: tenant)
 
       deployments = [
         Edgehog.ContainersFixtures.deployment_fixture(device_id: fixture.id, tenant: tenant),
@@ -120,7 +120,8 @@ defmodule EdgehogWeb.Schema.Query.DeviceTest do
 
       deployments = Enum.sort_by(deployments, & &1.release_id)
 
-      _extra_deployment = Edgehog.ContainersFixtures.deployment_fixture(tenant: tenant)
+      _extra_deployment =
+        Edgehog.ContainersFixtures.deployment_fixture(realm_id: fixture.realm.id, tenant: tenant)
 
       document = """
       query ($id: ID!) {

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -178,11 +178,19 @@ defmodule Edgehog.ContainersFixtures do
   def deployment_fixture(opts \\ []) do
     {tenant, opts} = Keyword.pop!(opts, :tenant)
 
+    {realm_id, opts} =
+      case opts[:device_id] do
+        nil ->
+          Keyword.pop_lazy(opts, :realm_id, fn ->
+            AstarteFixtures.realm_fixture(tenant: tenant).id
+          end)
+
+        _ ->
+          {nil, opts}
+      end
+
     {device_id, opts} =
       Keyword.pop_lazy(opts, :device_id, fn ->
-        {realm_id, _opts} =
-          Keyword.pop(opts, :realm_id, AstarteFixtures.realm_fixture(tenant: tenant).id)
-
         Edgehog.DevicesFixtures.device_fixture(realm_id: realm_id, tenant: tenant).id
       end)
 


### PR DESCRIPTION
`realm_fixture` does not try to create a new realm if the tenant already has a realm

Fixes #799 CI

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
