### PR TITLE
feat(containers): Containers api behind feature flag

### DIFF
--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,6 +111,8 @@ config :edgehog, :edgehog_forwarder, %{
   secure_sessions?: false,
   enabled?: true
 }
+
+config :edgehog, :features, containers: true
 
 config :edgehog,
   ecto_repos: [Edgehog.Repo]

--- a/backend/config/prod.exs
+++ b/backend/config/prod.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 config :edgehog, EdgehogWeb.Endpoint, url: [host: "example.com", port: 80]
+config :edgehog, :features, containers: false
 
 # Configure Logfmt
 config :logger, :console, format: {PrettyLog.LogfmtFormatter, :format}

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -218,20 +218,17 @@ if config_env() == :prod do
   forwarder_hostname = System.get_env("EDGEHOG_FORWARDER_HOSTNAME")
 
   config :edgehog, Edgehog.Repo,
-    # socket_options: [:inet6],
+    # Enable / disable features at runtime
     username: database.username,
     password: database.password,
     hostname: database.hostname,
+    # socket_options: [:inet6],
     database: database.name,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     ssl: database.ssl
 
   config :edgehog, EdgehogWeb.Endpoint,
     http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
       ip: {0, 0, 0, 0, 0, 0, 0, 0},
       port: String.to_integer(System.get_env("PORT") || "4000"),
       protocol_options: [idle_timeout: 300_000]
@@ -241,7 +238,13 @@ if config_env() == :prod do
       scheme: url_scheme,
       port: url_port
     ],
+    # Enable IPv6 and bind on all interfaces.
+    # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
+    # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
+    # for details about using IPv6 vs IPv4 and loopback vs public addresses.
     secret_key_base: secret_key_base
+
+  config :edgehog, :features, containers: false
 
   if forwarder_hostname != nil &&
        (String.starts_with?(forwarder_hostname, "http://") ||

--- a/backend/lib/edgehog/containers/application.ex
+++ b/backend/lib/edgehog/containers/application.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2024 SECO Mind Srl
+# Copyright 2024 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ defmodule Edgehog.Containers.Application do
   @moduledoc false
   use Edgehog.MultitenantResource,
     domain: Edgehog.Containers,
-    extensions: [AshGraphql.Resource]
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
 
   graphql do
     type :application

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -22,7 +22,8 @@ defmodule Edgehog.Containers do
   @moduledoc false
   use Ash.Domain,
     extensions: [
-      AshGraphql.Domain
+      AshGraphql.Domain,
+      Ash.Policy.Authorizer
     ]
 
   alias Edgehog.Containers.Application
@@ -201,5 +202,11 @@ defmodule Edgehog.Containers do
     end
 
     resource Upgrade
+  end
+
+  policies do
+    policy always() do
+      authorize_if {Edgehog.Policies.ActorHasFeatureFlag, flag: :containers}
+    end
   end
 end

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -22,7 +22,8 @@ defmodule Edgehog.Containers.Deployment do
   @moduledoc false
   use Edgehog.MultitenantResource,
     domain: Edgehog.Containers,
-    extensions: [AshGraphql.Resource]
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
 
   alias Edgehog.Containers.Deployment.Changes
   alias Edgehog.Containers.Deployment.Types.DeploymentState

--- a/backend/lib/edgehog/containers/image_credentials.ex
+++ b/backend/lib/edgehog/containers/image_credentials.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2024 SECO Mind Srl
+# Copyright 2024 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ defmodule Edgehog.Containers.ImageCredentials do
   @moduledoc false
   use Edgehog.MultitenantResource,
     domain: Edgehog.Containers,
-    extensions: [AshGraphql.Resource]
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
 
   alias Edgehog.Containers.ImageCredentials.Base64JsonEncoding
 

--- a/backend/lib/edgehog/containers/release.ex
+++ b/backend/lib/edgehog/containers/release.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2024 SECO Mind Srl
+# Copyright 2024 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ defmodule Edgehog.Containers.Release do
   @moduledoc false
   use Edgehog.MultitenantResource,
     domain: Edgehog.Containers,
-    extensions: [AshGraphql.Resource]
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
 
   alias Edgehog.Containers.Changes
   alias Edgehog.Validations

--- a/backend/lib/edgehog/policies/actor_has_feature_flag.ex
+++ b/backend/lib/edgehog/policies/actor_has_feature_flag.ex
@@ -1,0 +1,42 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Policies.ActorHasFeatureFlag do
+  @moduledoc """
+  Policy to check weather the current actor has the feature flag to access the feature.
+  """
+  use Ash.Policy.SimpleCheck
+
+  alias Ash.Policy.SimpleCheck
+
+  @impl Ash.Policy.Check
+  def describe(options) do
+    "Checking whether the #{options[:flag]} flag is eneabled."
+  end
+
+  @impl SimpleCheck
+  def match?(_, %{domain: Edgehog.Containers}, options) do
+    flag = Keyword.fetch!(options, :flag)
+
+    Application.get_env(:edgehog, :features)[flag]
+  end
+
+  def match?(_, _, _), do: true
+end


### PR DESCRIPTION
Puts the `containers` module behind a feature flag, disabling it in production and enabling it otherwise.

Compared to #794 this commit uses `Ash` policies to allow/forbid backend queries depending on the value of a configuration in `config.exs`

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
