### PR TITLE
Enable server-side pagination for update_campaigns

### DIFF
--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -2344,6 +2344,27 @@ enum UpdateTargetSortField {
   COMPLETION_TIMESTAMP
 }
 
+":update_target connection"
+type UpdateTargetConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_target edges"
+  edges: [UpdateTargetEdge!]
+}
+
+":update_target edge"
+type UpdateTargetEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_target node"
+  node: UpdateTarget!
+}
+
 input UpdateTargetFilterCompletionTimestamp {
   isNil: Boolean
   eq: DateTime
@@ -2689,6 +2710,27 @@ enum UpdateCampaignSortField {
   SUCCESSFUL_TARGET_COUNT
 }
 
+":update_campaign connection"
+type UpdateCampaignConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_campaign edges"
+  edges: [UpdateCampaignEdge!]
+}
+
+":update_campaign edge"
+type UpdateCampaignEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_campaign node"
+  node: UpdateCampaign!
+}
+
 input UpdateCampaignFilterSuccessfulTargetCount {
   isNil: Boolean
   eq: Int
@@ -2872,12 +2914,18 @@ type UpdateCampaign implements Node {
     "A filter to limit the results"
     filter: UpdateTargetFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [UpdateTarget!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateTargetConnection!
 
   "The total number of update targets."
   totalTargetCount: Int!
@@ -2906,7 +2954,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: UpdateCampaignFilterInput
-  ): [UpdateCampaign!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateCampaignConnection
 
   "Returns a single update channel."
   updateChannel("The id of the record" id: ID!): UpdateChannel

--- a/frontend/src/components/UpdateTargetsTabs.tsx
+++ b/frontend/src/components/UpdateTargetsTabs.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -37,8 +37,12 @@ import UpdateTargetStatus from "components/UpdateTargetStatus";
 const UPDATE_TARGETS_TABS_FRAGMENT = graphql`
   fragment UpdateTargetsTabs_UpdateTargetsFragment on UpdateCampaign {
     updateTargets {
-      status
-      ...UpdateTargetsTable_UpdateTargetsFragment
+      edges {
+        node {
+          status
+          ...UpdateTargetsTable_UpdateTargetsFragment
+        }
+      }
     }
   }
 `;
@@ -88,7 +92,10 @@ const UpdateTargetsTabs = ({ updateCampaignRef }: Props) => {
     updateCampaignRef,
   );
   const visibleTargets = useMemo(
-    () => updateTargets.filter(({ status }) => status === activeTab),
+    () =>
+      updateTargets.edges
+        ?.filter(({ node }) => node.status === activeTab)
+        .map(({ node }) => node) || [],
     [activeTab, updateTargets],
   );
   const hiddenColumns = useMemo(() => getHiddenColumns(activeTab), [activeTab]);

--- a/frontend/src/pages/UpdateCampaigns.tsx
+++ b/frontend/src/pages/UpdateCampaigns.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { UpdateCampaigns_getUpdateCampaigns_Query } from "api/__generated__/UpdateCampaigns_getUpdateCampaigns_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import Page from "components/Page";
@@ -33,10 +34,8 @@ import UpdateCampaignsTable from "components/UpdateCampaignsTable";
 import { Link, Route } from "Navigation";
 
 const GET_UPDATE_CAMPAIGNS_QUERY = graphql`
-  query UpdateCampaigns_getUpdateCampaigns_Query {
-    updateCampaigns {
-      ...UpdateCampaignsTable_UpdateCampaignFragment
-    }
+  query UpdateCampaigns_getUpdateCampaigns_Query($first: Int, $after: String) {
+    ...UpdateCampaignsTable_UpdateCampaignFragment
   }
 `;
 
@@ -47,7 +46,7 @@ type UpdateCampaignsContentProps = {
 const UpdateCampaignsContent = ({
   getUpdateCampaignsQuery,
 }: UpdateCampaignsContentProps) => {
-  const { updateCampaigns } = usePreloadedQuery(
+  const updateCampaigns = usePreloadedQuery(
     GET_UPDATE_CAMPAIGNS_QUERY,
     getUpdateCampaignsQuery,
   );
@@ -83,7 +82,11 @@ const UpdateCampaignsPage = () => {
     );
 
   const fetchUpdateCampaigns = useCallback(
-    () => getUpdateCampaigns({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getUpdateCampaigns(
+        { first: 10_000 },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getUpdateCampaigns],
   );
 


### PR DESCRIPTION
Updated queries for `update_campaigns` and `update_targets` to support server-side pagination. This change ensures data fetching is paginated on the backend while maintaining the current client-side logic. A future update will optimize the respective tables to fully leverage pagination, avoiding an immediate rewrite of the client-side implementation.

Part of #779

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
