### PR TITLE
fix(containers): add missing triggers

### DIFF
--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-containers.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-containers.json.eex
@@ -1,0 +1,19 @@
+{
+    "name": "edgehog-available-containers",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "http_method": "post",
+        "http_static_headers": {},
+        "ignore_ssl_errors": false
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.AvailableContainers",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+}

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-images.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-images.json.eex
@@ -1,0 +1,19 @@
+{
+    "name": "edgehog-available-images",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "http_method": "post",
+        "http_static_headers": {},
+        "ignore_ssl_errors": false
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.AvailableImages",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+}

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-networks.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-networks.json.eex
@@ -1,0 +1,19 @@
+{
+    "name": "edgehog-available-networks",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "http_method": "post",
+        "http_static_headers": {},
+        "ignore_ssl_errors": false
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.AvailableNetworks",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+}

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-volumes.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-volumes.json.eex
@@ -1,0 +1,19 @@
+{
+    "name": "edgehog-available-volumes",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "http_method": "post",
+        "http_static_headers": {},
+        "ignore_ssl_errors": false
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.AvailableVolumes",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+}


### PR DESCRIPTION
Adding `available` triggers to edgehog, so that the conciliation process can correctly install the necessary interfaces for containers management