### PR TITLE
Fix Device relationship not loaded in Campaign executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.3] - Unreleased
 ### Fixed
 - Base Image deletion in S3 storage
+- Update Campaign executor crashing when handling events because of `device` relationship not loaded ([#828](https://github.com/edgehog-device-manager/edgehog/pull/828)).
 
 ## [0.9.2] - 2024-12-09
 ### Changed

--- a/backend/lib/edgehog/update_campaigns/rollout_mechanism/push_rollout/executor.ex
+++ b/backend/lib/edgehog/update_campaigns/rollout_mechanism/push_rollout/executor.ex
@@ -241,7 +241,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   def handle_event(:internal, {:already_updated, target}, :rollout, data) do
     # The target already has the same version as the target base_image, we consider this
     # a success.
-    Logger.info("Device #{target.device.device_id} was already updated.")
+    Logger.info("Device #{target.device_id} was already updated.")
     _ = Core.mark_target_as_successful!(target)
 
     # We free up the slot since the target is considered completed
@@ -267,7 +267,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
 
   def handle_event(:internal, {:rollout_temporary_error, target, reason}, :rollout, data) do
     reason
-    |> Core.error_message(target.device.device_id)
+    |> Core.error_message(target.device_id)
     |> Logger.notice()
 
     # Since this is a temporary error, and we failed during the initial rollout, for now we do
@@ -284,7 +284,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
 
   def handle_event(:internal, {:rollout_failure, target, reason}, :rollout, data) do
     reason
-    |> Core.error_message(target.device.device_id)
+    |> Core.error_message(target.device_id)
     |> Logger.notice()
 
     # This is a permanent failure, so we mark the target as failed
@@ -398,9 +398,8 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
           [internal_event({:ota_operation_failure, ota_operation})]
 
         Core.ota_operation_acknowledged?(ota_operation) ->
-          ota_operation = Ash.load!(ota_operation, :device)
           # Handle this explicitly so we log a message
-          Logger.info("Device #{ota_operation.device.device_id} acknowledged the update")
+          Logger.info("Device #{ota_operation.device_id} acknowledged the update")
           []
 
         true ->
@@ -417,9 +416,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   end
 
   def handle_event(:internal, {:ota_operation_success, ota_operation}, _state, data) do
-    ota_operation = Ash.load!(ota_operation, :device)
-
-    Logger.info("Device #{ota_operation.device.device_id} updated successfully")
+    Logger.info("Device #{ota_operation.device_id} updated successfully")
 
     _ =
       data.tenant_id
@@ -433,9 +430,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   end
 
   def handle_event(:internal, {:ota_operation_failure, ota_operation}, state, data) do
-    ota_operation = Ash.load!(ota_operation, :device)
-
-    Logger.notice("Device #{ota_operation.device.device_id} failed to update: #{ota_operation.status_code}")
+    Logger.notice("Device #{ota_operation.device_id} failed to update: #{ota_operation.status_code}")
 
     _ =
       data.tenant_id
@@ -503,7 +498,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
 
       {:error, reason} ->
         reason
-        |> Core.error_message(target.device.device_id)
+        |> Core.error_message(target.device_id)
         |> Logger.notice()
 
         # We don't check if the error is temporary or not, since by definition it shouldn't be
@@ -520,7 +515,7 @@ defmodule Edgehog.UpdateCampaigns.RolloutMechanism.PushRollout.Executor do
   end
 
   def handle_event(:internal, {:retry_threshold_exceeded, target}, _state, data) do
-    Logger.notice("Device #{target.device.device_id} update failed: no more retries left")
+    Logger.notice("Device #{target.device_id} update failed: no more retries left")
 
     # Just mark the OTA Operation as failed with request_timeout. The associated target will
     # be marked as failed when it receives the :ota_operation_updated message from the PubSub


### PR DESCRIPTION
Event handlers in the Update Campaign executor try to access the `device` relationship either on the update target or the OTA operation struct.
However, sometimes the relationship is not loaded beforehand and result into a crash when handling events.
This change fixes the issue by reading the `.device_id` field directly, which is defined by the belongs_to directive in the schemas of the update target and OTA operation, without needing to access `.device.device_id`.

Closes #828.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
