### PR TITLE
docs(admin): fix tenant provisioning example to use Edgehog.Tenants

### DIFF
--- a/doc/pages/admin/deploying_with_kubernetes.md
+++ b/doc/pages/admin/deploying_with_kubernetes.md
@@ -836,7 +836,7 @@ The following commands will create a database entry representing the tenant, wit
 Astarte cluster and Realm.
 
 ```elixir
-iex> alias Edgehog.Provisioning
+iex> alias Edgehog.Tenants
 iex> tenant_name = "<TENANT-NAME>"
 iex> tenant_slug = "<TENANT-SLUG>"
 iex> tenant_public_key = """
@@ -847,7 +847,7 @@ iex> realm_name = "<ASTARTE-REALM-NAME>"
 iex> realm_private_key = """
 <ASTARTE-REALM-PRIVATE-KEY>
 """
-iex> {:ok, tenant} = Provisioning.provision_tenant(
+iex> {:ok, tenant} = Tenants.provision_tenant(
   %{
     name: tenant_name,
     slug: tenant_slug,


### PR DESCRIPTION
Update the Kubernetes deployment documentation to use the correct module and function for tenant provisioning (Edgehog.Tenants and Tenants.provision_tenant/1 instead of Edgehog.Provisioning).

Closes #811.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
