### PR TITLE
feat(containers): Add image credentials to release creation form

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -64,7 +64,11 @@ defmodule Edgehog.Containers do
 
       create Release, :create_release, :create do
         description "Create a new release."
-        relay_id_translations input: [application_id: :application]
+
+        relay_id_translations input: [
+                                application_id: :application,
+                                containers: [image: [image_credentials_id: :image_credentials]]
+                              ]
       end
 
       create ImageCredentials, :create_image_credentials, :create do

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -324,6 +324,12 @@
   "components.CreateRelease.hostnameLabel": {
     "defaultMessage": "Hostname"
   },
+  "components.CreateRelease.imageCredentialOption": {
+    "defaultMessage": "Select Image Credentials"
+  },
+  "components.CreateRelease.imageCredentialsLabel": {
+    "defaultMessage": "Image Credentials"
+  },
   "components.CreateRelease.imageReferenceLabel": {
     "defaultMessage": "Image Reference"
   },

--- a/frontend/src/i18n/langs/en.json.license
+++ b/frontend/src/i18n/langs/en.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021-2024 SECO Mind Srl
+SPDX-FileCopyrightText: 2021 - 2025 SECO Mind Srl
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Introduces a new field for selecting image credentials when creating a release. This allows users to specify which image credentials to use for the containers in the release.

<details><summary>Screenshots</summary>
<p>

OLD:
<img width="1623" height="506" alt="image" src="https://github.com/user-attachments/assets/a76d7b36-021c-4b5c-8315-cdfe389ecda3" />


Updated:
<img width="1623" height="546" alt="image" src="https://github.com/user-attachments/assets/0a21d30c-92db-4b67-a1fb-a64e4d0865e4" />
<img width="1623" height="550" alt="image" src="https://github.com/user-attachments/assets/0c834ac2-5d71-48d3-bde5-1126355ca22d" />
<img width="1623" height="546" alt="image" src="https://github.com/user-attachments/assets/7d26a1b7-635a-40f1-9077-71d060106005" />


</p>
</details> 


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
