### PR TITLE
feat: Add support for regex and glob pattern matching in device selector DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base Image deletion in S3 storage
 
 ## [0.9.2] - 2024-12-09
+### Added
+- Add pattern matching support to device selector DSL with new `~=` and `!~=` operators
 ### Changed
 - Update the docker-compose configuration to allow both physical and virtual devices
   to connect to Edgehog, provided that the devices and the host are on the same LAN.

--- a/backend/lib/edgehog/selector/ast/tag_filter.ex
+++ b/backend/lib/edgehog/selector/ast/tag_filter.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022-2024 SECO Mind Srl
+# Copyright 2022 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,19 +24,58 @@ defmodule Edgehog.Selector.AST.TagFilter do
 
   @type t :: %__MODULE__{
           tag: String.t(),
-          operator: :in | :not_in
+          operator: :in | :not_in | :matches | :not_matches
         }
 
   defstruct [:tag, :operator]
 
   defimpl Edgehog.Selector.Filter do
     def to_ash_expr(tag_filter) do
-      tag_name = tag_filter.tag
+      tag_pattern = tag_filter.tag
 
       case tag_filter.operator do
-        :in -> expr(exists(tags, name == ^tag_name))
-        :not_in -> expr(not exists(tags, name == ^tag_name))
+        :in ->
+          expr(exists(tags, name == ^tag_pattern))
+
+        :not_in ->
+          expr(not exists(tags, name == ^tag_pattern))
+
+        :matches ->
+          if regex_pattern?(tag_pattern) do
+            regex = compile_regex(tag_pattern)
+            expr(exists(tags, fragment("? ~ ?", name, ^regex)))
+          else
+            # Handle glob pattern like "tag-*"
+            like_pattern = glob_to_like_pattern(tag_pattern)
+            expr(exists(tags, like(name, ^like_pattern)))
+          end
+
+        :not_matches ->
+          if regex_pattern?(tag_pattern) do
+            regex = compile_regex(tag_pattern)
+            expr(not exists(tags, fragment("? ~ ?", name, ^regex)))
+          else
+            # Handle glob pattern like "tag-*"
+            like_pattern = glob_to_like_pattern(tag_pattern)
+            expr(not exists(tags, like(name, ^like_pattern)))
+          end
       end
+    end
+
+    defp regex_pattern?(pattern) do
+      String.starts_with?(pattern, "/") and String.ends_with?(pattern, "/")
+    end
+
+    defp compile_regex(pattern) do
+      # Remove leading and trailing slashes
+      regex_str = String.slice(pattern, 1..-2//1)
+      regex_str
+    end
+
+    defp glob_to_like_pattern(pattern) do
+      pattern
+      |> String.replace("*", "%")
+      |> String.replace("?", "_")
     end
   end
 end

--- a/doc/pages/user/core_concepts.md
+++ b/doc/pages/user/core_concepts.md
@@ -123,6 +123,30 @@ Created with the syntax `"<value>" in tags`, it returns `true` if `value` is inc
 tags. It's also possible to use a negative filter with `"value" not in tags`, in this case the
 filter will match all Devices which _don't_ have the tag.
 
+Additionally, Edgehog supports pattern matching on tags using the `~=` (matches) and `!~=` (not matches) operators:
+
+- `"<pattern>" ~= tags`: returns `true` if any Device tag matches the specified pattern
+- `"<pattern>" !~= tags`: returns `true` if no Device tag matches the specified pattern
+
+Pattern matching supports two types of patterns:
+
+**Glob patterns** (using quoted strings):
+
+- `*` matches any sequence of characters
+- `?` matches any single character
+- Example: `"sensor-*" ~= tags` matches tags like `sensor-temperature`, `sensor-humidity`, etc.
+- Example: `"dev?" ~= tags` matches tags like `dev1`, `dev2`, `deva`, but not `device`
+
+**Regular expressions** (using `/pattern/` syntax):
+
+- Full regex support with standard regex metacharacters
+- Can be written with or without quotes: `/pattern/` or `"/pattern/"`
+- Example: `/^sensor-\d+$/ ~= tags` matches tags like `sensor-123`, `sensor-007`
+- Example: `/temp(erature)?/ ~= tags` matches both `temp` and `temperature`
+
+Note that regex patterns (unquoted `/pattern/`) can only be used with the `~=` and `!~=` operators,
+while quoted strings work with all tag operators (`in`, `not in`, `~=`, `!~=`).
+
 ##### Attribute filter*
 
 *_Note that while Attribute filters are already supported, Attributes are going to be available in a


### PR DESCRIPTION
Add support for regex and glob pattern matching in device selector DSL

Features:
- Add new `~=` (matches) and `!~=` (not_matches) operators for pattern matching
- Support unquoted regex patterns (/pattern/) in addition to quoted strings
- Restrict regex patterns to only work with matches operators for type safety
- Maintain backward compatibility with existing "tag" in tags syntax
- Support both glob patterns (`"tag-*"`) and regex patterns (`/tag-\d+/`) with matches operators

Examples of new syntax:
- `/tag-\d+/` `~=` tags (unquoted regex)
- `"tag-*"` `~=` tags (quoted glob pattern)
- `"/pattern/"` `~=` tags (quoted regex pattern)
- `"pattern"` `!~=` tags (negated pattern matching)

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
