### PR TITLE
feat(containers): expose networks and volumes

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -57,6 +57,22 @@ defmodule Edgehog.Containers do
       get Release, :release, :read do
         description "Returns the desired release."
       end
+
+      get Volume, :volume, :read do
+        description "Returns the desired volume."
+      end
+
+      list Volume, :volumes, :read do
+        description "Returns all available volumes."
+      end
+
+      get Network, :network, :read do
+        description "Returns the desired network."
+      end
+
+      list Network, :networks, :read do
+        description "Returns all available networks."
+      end
     end
 
     mutations do


### PR DESCRIPTION
Networks and volumes are resources that can be re-used by multiple containers and possibly releases/applications. This adds support for clients display of such resources trough the apis.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
