### PR TITLE
feat: Add trigger delivery policies support to tenant reconciler

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -23,8 +23,12 @@ Files: backend/priv/astarte_resources/interfaces/*.json
 Copyright: 2023 Seco Mind Srl
 License: Apache-2.0
 
+Files: backend/priv/astarte_resources/delivery_policies/*.json.eex
+Copyright: 2025 Seco Mind Srl
+License: Apache-2.0
+
 Files: backend/priv/astarte_resources/trigger_templates/*.json.eex
-Copyright: 2023 Seco Mind Srl
+Copyright: 2023-2025 Seco Mind Srl
 License: Apache-2.0
 
 Files: backend/priv/resource_snapshots/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose the associated UpdateCampaign (if any) from an OTA Operation on the Software Updates tab  ([#356](https://github.com/edgehog-device-manager/edgehog/issues/356)).
 - Support for using Azure Storage as the persistence layer for asset uploads ([#233](https://github.com/edgehog-device-manager/edgehog/issues/233)).
 - Ecto SSL configuration is exposed trough `DATABASE_*` environment variables (see [.env](./.env))
+- Adds support for trigger delivery policies in the tenant 
+reconciler, allowing Edgehog to automatically provision and manage 
+trigger delivery policies on Astarte realms that support them (v1.1.1+).
 
 ## [0.9.3] - 2025-05-22
 ### Fixed

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,6 +55,10 @@ config :edgehog, :astarte_battery_status_module, Edgehog.Astarte.Device.BatteryS
 config :edgehog,
        :astarte_cellular_connection_module,
        Edgehog.Astarte.Device.CellularConnectionMock
+
+config :edgehog,
+       :astarte_delivery_policies_data_layer,
+       Edgehog.Astarte.DeliveryPolicies.MockDataLayer
 
 config :edgehog, :astarte_device_status_module, Edgehog.Astarte.Device.DeviceStatusMock
 config :edgehog, :astarte_forwarder_session_module, Edgehog.Astarte.Device.ForwarderSessionMock

--- a/backend/lib/edgehog/astarte/trigger/astarte_data_layer.ex
+++ b/backend/lib/edgehog/astarte/trigger/astarte_data_layer.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,11 @@ defmodule Edgehog.Astarte.Trigger.AstarteDataLayer do
   @impl DataLayer
   def get(%RealmManagement{} = client, trigger_name) do
     RealmManagement.Triggers.get(client, trigger_name)
+  end
+
+  @impl DataLayer
+  def list(%RealmManagement{} = client) do
+    RealmManagement.Triggers.list(client)
   end
 
   @impl DataLayer

--- a/backend/lib/edgehog/astarte/trigger_delivery_policies/astarte_data_layer.ex
+++ b/backend/lib/edgehog/astarte/trigger_delivery_policies/astarte_data_layer.ex
@@ -18,19 +18,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.Astarte.Trigger.DataLayer do
+defmodule Edgehog.Astarte.DeliveryPolicies.AstarteDataLayer do
   @moduledoc false
+  @behaviour Edgehog.Astarte.DeliveryPolicies.DataLayer
+
   alias Astarte.Client.RealmManagement
+  alias Edgehog.Astarte.DeliveryPolicies.DataLayer
 
-  @callback get(client :: RealmManagement.t(), trigger_name :: String.t()) ::
-              {:ok, map()} | {:error, term()}
+  @impl DataLayer
+  def get(%RealmManagement{} = client, policy_name) do
+    RealmManagement.DeliveryPolicies.get(client, policy_name)
+  end
 
-  @callback list(client :: RealmManagement.t()) ::
-              {:ok, [map()]} | {:error, term()}
+  @impl DataLayer
+  def create(%RealmManagement{} = client, policy_json) do
+    RealmManagement.DeliveryPolicies.create(client, policy_json)
+  end
 
-  @callback create(client :: RealmManagement.t(), trigger_json :: map()) ::
-              :ok | {:error, term()}
-
-  @callback delete(client :: RealmManagement.t(), trigger_name :: String.t()) ::
-              :ok | {:error, term()}
+  @impl DataLayer
+  def delete(%RealmManagement{} = client, policy_name) do
+    RealmManagement.DeliveryPolicies.delete(client, policy_name)
+  end
 end

--- a/backend/lib/edgehog/astarte/trigger_delivery_policies/data_layer.ex
+++ b/backend/lib/edgehog/astarte/trigger_delivery_policies/data_layer.ex
@@ -18,19 +18,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.Astarte.Trigger.DataLayer do
+defmodule Edgehog.Astarte.DeliveryPolicies.DataLayer do
   @moduledoc false
   alias Astarte.Client.RealmManagement
 
-  @callback get(client :: RealmManagement.t(), trigger_name :: String.t()) ::
+  @callback get(client :: RealmManagement.t(), policy_name :: String.t()) ::
               {:ok, map()} | {:error, term()}
 
-  @callback list(client :: RealmManagement.t()) ::
-              {:ok, [map()]} | {:error, term()}
-
-  @callback create(client :: RealmManagement.t(), trigger_json :: map()) ::
+  @callback create(client :: RealmManagement.t(), policy_json :: map()) ::
               :ok | {:error, term()}
 
-  @callback delete(client :: RealmManagement.t(), trigger_name :: String.t()) ::
+  @callback delete(client :: RealmManagement.t(), policy_name :: String.t()) ::
               :ok | {:error, term()}
 end

--- a/backend/lib/edgehog/astarte/trigger_delivery_policies/trigger_delivery_policies.ex
+++ b/backend/lib/edgehog/astarte/trigger_delivery_policies/trigger_delivery_policies.ex
@@ -18,18 +18,22 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.Astarte.Trigger do
+defmodule Edgehog.Astarte.DeliveryPolicies do
   @moduledoc false
   alias Astarte.Client.APIError
   alias Astarte.Client.RealmManagement
-  alias Edgehog.Astarte.Trigger.AstarteDataLayer
+  alias Edgehog.Astarte.DeliveryPolicies.AstarteDataLayer
 
-  @data_layer Application.compile_env(:edgehog, :astarte_trigger_data_layer, AstarteDataLayer)
+  @data_layer Application.compile_env(
+                :edgehog,
+                :astarte_delivery_policies_data_layer,
+                AstarteDataLayer
+              )
 
-  def fetch_by_name(%RealmManagement{} = client, trigger_name) do
-    case @data_layer.get(client, trigger_name) do
-      {:ok, %{"data" => trigger_map}} ->
-        {:ok, trigger_map}
+  def fetch_by_name(%RealmManagement{} = client, policy_name) do
+    case @data_layer.get(client, policy_name) do
+      {:ok, %{"data" => policy_map}} ->
+        {:ok, policy_map}
 
       {:error, %APIError{status: 404}} ->
         # We just convert a 404 status to :not_found, and return all other errors as-is
@@ -45,7 +49,6 @@ defmodule Edgehog.Astarte.Trigger do
     end
   end
 
-  defdelegate list(client), to: @data_layer
-  defdelegate create(client, trigger_json), to: @data_layer
-  defdelegate delete(client, trigger_name), to: @data_layer
+  defdelegate create(client, policy_json), to: @data_layer
+  defdelegate delete(client, policy_name), to: @data_layer
 end

--- a/backend/lib/edgehog/tenants/reconciler/astarte_resources.ex
+++ b/backend/lib/edgehog/tenants/reconciler/astarte_resources.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@
 defmodule Edgehog.Tenants.Reconciler.AstarteResources do
   @moduledoc false
   @interfaces Path.wildcard("priv/astarte_resources/interfaces/*.json")
+  @delivery_policies Path.wildcard("priv/astarte_resources/delivery_policies/*.json.eex")
   @trigger_templates Path.wildcard("priv/astarte_resources/trigger_templates/*.json.eex")
 
   # Ensure we recompile code if trigger templates or interfaces change
-  for resource <- @interfaces ++ @trigger_templates do
+  for resource <- @interfaces ++ @delivery_policies ++ @trigger_templates do
     @external_resource resource
   end
 
@@ -34,6 +35,10 @@ defmodule Edgehog.Tenants.Reconciler.AstarteResources do
       |> File.read!()
       |> Jason.decode!()
     end)
+  end
+
+  def load_delivery_policies do
+    Enum.map(@delivery_policies, &File.read!/1)
   end
 
   def load_trigger_templates do

--- a/backend/priv/astarte_resources/delivery_policies/edgehog-retry-on-server-error.json.eex
+++ b/backend/priv/astarte_resources/delivery_policies/edgehog-retry-on-server-error.json.eex
@@ -1,0 +1,16 @@
+{
+    "name": "edgehog-retry-on-server-error",
+    "error_handlers": [
+        {
+            "on": "server_error",
+            "strategy": "retry"
+        },
+        {
+            "on": "client_error",
+            "strategy": "discard"
+        }
+    ],
+    "maximum_capacity": 100,
+    "retry_times": 3,
+    "event_ttl": 30
+}

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-connection.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-connection.json.eex
@@ -12,4 +12,7 @@
             "on": "device_connected"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-disconnection.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-disconnection.json.eex
@@ -12,4 +12,7 @@
             "on": "device_disconnected"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-ota-event.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-ota-event.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-system-info.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-system-info.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2023 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,6 +80,10 @@ Mox.defmock(Edgehog.Astarte.Device.ForwarderSessionMock,
 
 Mox.defmock(Edgehog.Astarte.Interface.MockDataLayer,
   for: Edgehog.Astarte.Interface.DataLayer
+)
+
+Mox.defmock(Edgehog.Astarte.DeliveryPolicies.MockDataLayer,
+  for: Edgehog.Astarte.DeliveryPolicies.DataLayer
 )
 
 Mox.defmock(Edgehog.Astarte.Trigger.MockDataLayer,


### PR DESCRIPTION
Adds support for trigger delivery policies in the tenant reconciler, allowing Edgehog to automatically provision and manage trigger delivery policies on Astarte realms that support them (v1.1.1+).

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
