### PR TITLE
refactor(container): send deployment_id to devices when creating deployment resources

### DIFF
--- a/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
 
   defstruct [
     :id,
+    :deploymentId,
     :imageId,
     :image,
     :networkIds,
@@ -41,6 +42,7 @@ defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
 
   @type t() :: %__MODULE__{
           id: String.t(),
+          deploymentId: String.t(),
           imageId: String.t(),
           image: String.t(),
           volumeIds: list(String.t()),

--- a/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_image_request/request_data.ex
@@ -23,12 +23,14 @@ defmodule Edgehog.Astarte.Device.CreateImageRequest.RequestData do
 
   defstruct [
     :id,
+    :deploymentId,
     :reference,
     :registryAuth
   ]
 
   @type t() :: %__MODULE__{
           id: String.t(),
+          deploymentId: String.t(),
           reference: String.t(),
           registryAuth: String.t()
         }

--- a/backend/lib/edgehog/astarte/device/create_network_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_network_request/request_data.ex
@@ -23,6 +23,7 @@ defmodule Edgehog.Astarte.Device.CreateNetworkRequest.RequestData do
 
   defstruct [
     :id,
+    :deploymentId,
     :driver,
     :internal,
     :enableIpv6,
@@ -31,6 +32,7 @@ defmodule Edgehog.Astarte.Device.CreateNetworkRequest.RequestData do
 
   @type t() :: %__MODULE__{
           id: String.t(),
+          deploymentId: String.t(),
           driver: String.t(),
           internal: boolean(),
           enableIpv6: boolean(),

--- a/backend/lib/edgehog/astarte/device/create_volume_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_volume_request/request_data.ex
@@ -23,12 +23,14 @@ defmodule Edgehog.Astarte.Device.CreateVolumeRequest.RequestData do
 
   defstruct [
     :id,
+    :deploymentId,
     :driver,
     :options
   ]
 
   @type t() :: %__MODULE__{
           id: String.t(),
+          deploymentId: String.t(),
           driver: String.t(),
           options: list(String.t())
         }

--- a/backend/lib/edgehog/containers/container/changes/deploy_container_on_device.ex
+++ b/backend/lib/edgehog/containers/container/changes/deploy_container_on_device.ex
@@ -29,9 +29,10 @@ defmodule Edgehog.Containers.Container.Changes.DeployContainerOnDevice do
   def change(changeset, _opts, _context) do
     device = Ash.Changeset.get_argument(changeset, :device)
     container = Ash.Changeset.get_argument(changeset, :container)
+    deployment = Ash.Changeset.get_argument(changeset, :deployment)
 
     Ash.Changeset.after_action(changeset, fn _changeset, container_deployment ->
-      with {:ok, _device} <- Devices.send_create_container_request(device, container) do
+      with {:ok, _device} <- Devices.send_create_container_request(device, container, deployment) do
         Containers.mark_container_deployment_as_sent(container_deployment)
       end
     end)

--- a/backend/lib/edgehog/containers/container/deployment.ex
+++ b/backend/lib/edgehog/containers/container/deployment.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Containers.Container.Deployment do
 
   alias Edgehog.Containers.Container
   alias Edgehog.Containers.Container.Changes
+  alias Edgehog.Containers.Deployment
   alias Edgehog.Devices.Device
 
   graphql do
@@ -47,6 +48,11 @@ defmodule Edgehog.Containers.Container.Deployment do
 
       argument :device, :struct do
         constraints instance_of: Device
+        allow_nil? false
+      end
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
         allow_nil? false
       end
 

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -122,7 +122,7 @@ defmodule Edgehog.Containers do
     end
 
     resource Edgehog.Containers.Container.Deployment do
-      define :deploy_container, action: :deploy, args: [:container, :device]
+      define :deploy_container, action: :deploy, args: [:container, :device, :deployment]
       define :fetch_container_deployment, action: :read, get_by_identity: :container_instance
       define :mark_container_deployment_as_sent, action: :mark_as_sent
       define :mark_container_deployment_as_received, action: :mark_as_received
@@ -155,7 +155,7 @@ defmodule Edgehog.Containers do
     end
 
     resource Edgehog.Containers.Image.Deployment do
-      define :deploy_image, action: :deploy, args: [:image, :device]
+      define :deploy_image, action: :deploy, args: [:image, :device, :deployment]
       define :fetch_image_deployment, action: :read, get_by_identity: :image_instance
       define :mark_image_deployment_as_sent, action: :mark_as_sent
       define :mark_image_deployment_as_unpulled, action: :mark_as_unpulled
@@ -178,7 +178,7 @@ defmodule Edgehog.Containers do
     resource Edgehog.Containers.Network
 
     resource Edgehog.Containers.Network.Deployment do
-      define :deploy_network, action: :deploy, args: [:network, :device]
+      define :deploy_network, action: :deploy, args: [:network, :device, :deployment]
       define :fetch_network_deployment, action: :read, get_by_identity: :network_instance
       define :mark_network_deployment_as_sent, action: :mark_as_sent
       define :mark_network_deployment_as_available, action: :mark_as_available
@@ -189,7 +189,7 @@ defmodule Edgehog.Containers do
     resource Edgehog.Containers.Volume
 
     resource Edgehog.Containers.Volume.Deployment do
-      define :deploy_volume, action: :deploy, args: [:volume, :device]
+      define :deploy_volume, action: :deploy, args: [:volume, :device, :deployment]
       define :fetch_volume_deployment, action: :read, get_by_identity: :volume_instance
       define :mark_volume_deployment_as_sent, action: :mark_as_sent
       define :mark_volume_deployment_as_available, action: :mark_as_available

--- a/backend/lib/edgehog/containers/image/changes/deploy_image_on_device.ex
+++ b/backend/lib/edgehog/containers/image/changes/deploy_image_on_device.ex
@@ -32,9 +32,11 @@ defmodule Edgehog.Containers.Image.Changes.DeployImageOnDevice do
     %{tenant: tenant} = context
     image = Ash.Changeset.get_argument(changeset, :image)
     device = Ash.Changeset.get_argument(changeset, :device)
+    deployment = Ash.Changeset.get_argument(changeset, :deployment)
 
     Ash.Changeset.after_action(changeset, fn _changeset, image_deployment ->
-      with {:ok, _device} <- Devices.send_create_image_request(device, image, tenant: tenant) do
+      with {:ok, _device} <-
+             Devices.send_create_image_request(device, image, deployment, tenant: tenant) do
         Containers.mark_image_deployment_as_sent(image_deployment)
       end
     end)

--- a/backend/lib/edgehog/containers/image/deployment.ex
+++ b/backend/lib/edgehog/containers/image/deployment.ex
@@ -24,6 +24,7 @@ defmodule Edgehog.Containers.Image.Deployment do
     domain: Edgehog.Containers,
     extensions: [AshGraphql.Resource]
 
+  alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Image
   alias Edgehog.Containers.Image.Changes
   alias Edgehog.Devices.Device
@@ -47,6 +48,11 @@ defmodule Edgehog.Containers.Image.Deployment do
 
       argument :device, :struct do
         constraints instance_of: Device
+        allow_nil? false
+      end
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
         allow_nil? false
       end
 

--- a/backend/lib/edgehog/containers/network/changes/deploy_network_on_device.ex
+++ b/backend/lib/edgehog/containers/network/changes/deploy_network_on_device.ex
@@ -29,9 +29,10 @@ defmodule Edgehog.Containers.Network.Changes.DeployNetworkOnDevice do
   def change(changeset, _opts, _context) do
     device = Ash.Changeset.get_argument(changeset, :device)
     network = Ash.Changeset.get_argument(changeset, :network)
+    deployment = Ash.Changeset.get_argument(changeset, :deployment)
 
     Ash.Changeset.after_action(changeset, fn _changeset, network_deployment ->
-      with {:ok, _device} <- Devices.send_create_network_request(device, network) do
+      with {:ok, _device} <- Devices.send_create_network_request(device, network, deployment) do
         Containers.mark_network_deployment_as_sent(network_deployment)
       end
     end)

--- a/backend/lib/edgehog/containers/network/deployment.ex
+++ b/backend/lib/edgehog/containers/network/deployment.ex
@@ -24,6 +24,7 @@ defmodule Edgehog.Containers.Network.Deployment do
     domain: Edgehog.Containers,
     extensions: [AshGraphql.Resource]
 
+  alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Network
   alias Edgehog.Containers.Network.Changes
   alias Edgehog.Devices.Device
@@ -47,6 +48,11 @@ defmodule Edgehog.Containers.Network.Deployment do
 
       argument :device, :struct do
         constraints instance_of: Device
+        allow_nil? false
+      end
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
         allow_nil? false
       end
 

--- a/backend/lib/edgehog/containers/volume/changes/deploy_volume_on_device.ex
+++ b/backend/lib/edgehog/containers/volume/changes/deploy_volume_on_device.ex
@@ -29,9 +29,10 @@ defmodule Edgehog.Containers.Volume.Changes.DeployVolumeOnDevice do
   def change(changeset, _opts, _context) do
     device = Ash.Changeset.get_argument(changeset, :device)
     volume = Ash.Changeset.get_argument(changeset, :volume)
+    deployment = Ash.Changeset.get_argument(changeset, :deployment)
 
     Ash.Changeset.after_action(changeset, fn _changeset, volume_deployment ->
-      with {:ok, _device} <- Devices.send_create_volume_request(device, volume) do
+      with {:ok, _device} <- Devices.send_create_volume_request(device, volume, deployment) do
         Containers.mark_volume_deployment_as_sent(volume_deployment)
       end
     end)

--- a/backend/lib/edgehog/containers/volume/deployment.ex
+++ b/backend/lib/edgehog/containers/volume/deployment.ex
@@ -24,6 +24,7 @@ defmodule Edgehog.Containers.Volume.Deployment do
     domain: Edgehog.Containers,
     extensions: [AshGraphql.Resource]
 
+  alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Volume
   alias Edgehog.Containers.Volume.Changes
   alias Edgehog.Devices.Device
@@ -47,6 +48,11 @@ defmodule Edgehog.Containers.Volume.Deployment do
 
       argument :device, :struct do
         constraints instance_of: Device
+        allow_nil? false
+      end
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
         allow_nil? false
       end
 

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -219,6 +219,12 @@ defmodule Edgehog.Devices.Device do
         allow_nil? false
       end
 
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
+        description "The deployment in which this volume is used"
+        allow_nil? false
+      end
+
       manual ManualActions.SendCreateVolume
     end
 
@@ -263,6 +269,12 @@ defmodule Edgehog.Devices.Device do
         allow_nil? false
       end
 
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
+        description "The deployment in which this image is used"
+        allow_nil? false
+      end
+
       manual ManualActions.SendCreateImageRequest
     end
 
@@ -274,6 +286,12 @@ defmodule Edgehog.Devices.Device do
         description: "The Container the device has to initiate.",
         allow_nil?: false
 
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
+        description "The deployment in which this container is used"
+        allow_nil? false
+      end
+
       manual ManualActions.SendCreateContainer
     end
 
@@ -284,6 +302,12 @@ defmodule Edgehog.Devices.Device do
         constraints: [instance_of: Edgehog.Containers.Network],
         description: "The Network the device has to create.",
         allow_nil?: false
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
+        description "The deployment in which this network is used"
+        allow_nil? false
+      end
 
       manual ManualActions.SendCreateNetwork
     end

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_container.ex
@@ -34,7 +34,8 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateContainer do
   def update(changeset, _opts, _context) do
     device = changeset.data
 
-    with {:ok, container} <- Ash.Changeset.fetch_argument(changeset, :container),
+    with {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
+         {:ok, container} <- Ash.Changeset.fetch_argument(changeset, :container),
          {:ok, container} <-
            Ash.load(container, [:env_encoding, :image, :networks, container_volumes: [:binding]]),
          {:ok, device} <- Ash.load(device, :appengine_client) do
@@ -47,6 +48,7 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateContainer do
 
       data = %RequestData{
         id: container.id,
+        deploymentId: deployment.id,
         imageId: container.image_id,
         image: image.reference,
         volumeIds: volume_ids,

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_image_request.ex
@@ -34,13 +34,15 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateImageRequest do
   def update(changeset, _opts, _context) do
     device = changeset.data
 
-    with {:ok, image} <- Ash.Changeset.fetch_argument(changeset, :image),
+    with {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
+         {:ok, image} <- Ash.Changeset.fetch_argument(changeset, :image),
          {:ok, image} <- Ash.load(image, credentials: [:base64_json]),
          {:ok, device} <- Ash.load(device, :appengine_client) do
       credentials = image.credentials.base64_json |> get_in() |> to_string()
 
       data = %RequestData{
         id: image.id,
+        deploymentId: deployment.id,
         reference: image.reference,
         registryAuth: credentials
       }

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_network.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_network.ex
@@ -35,11 +35,13 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateNetwork do
   def update(changeset, _opts, _context) do
     device = changeset.data
 
-    with {:ok, network} <- Ash.Changeset.fetch_argument(changeset, :network),
+    with {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
+         {:ok, network} <- Ash.Changeset.fetch_argument(changeset, :network),
          {:ok, network} <- Ash.load(network, :options_encoding),
          {:ok, device} <- Ash.load(device, :appengine_client) do
       data = %RequestData{
         id: network.id,
+        deploymentId: deployment.id,
         driver: network.driver,
         internal: network.internal,
         enableIpv6: network.enable_ipv6,

--- a/backend/lib/edgehog/devices/device/manual_actions/send_create_volume.ex
+++ b/backend/lib/edgehog/devices/device/manual_actions/send_create_volume.ex
@@ -34,11 +34,13 @@ defmodule Edgehog.Devices.Device.ManualActions.SendCreateVolume do
   def update(changeset, _opts, _context) do
     device = changeset.data
 
-    with {:ok, volume} <- Ash.Changeset.fetch_argument(changeset, :volume),
+    with {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
+         {:ok, volume} <- Ash.Changeset.fetch_argument(changeset, :volume),
          {:ok, volume} <- Ash.load(volume, :options_encoding),
          {:ok, device} <- Ash.load(device, :appengine_client) do
       data = %RequestData{
         id: volume.id,
+        deploymentId: deployment.id,
         driver: volume.driver,
         options: volume.options_encoding
       }

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -89,19 +89,19 @@ defmodule Edgehog.Devices do
 
       define :send_create_image_request,
         action: :send_create_image,
-        args: [:image]
+        args: [:image, :deployment]
 
       define :send_create_container_request,
         action: :send_create_container_request,
-        args: [:container]
+        args: [:container, :deployment]
 
       define :send_create_network_request,
         action: :send_create_network_request,
-        args: [:network]
+        args: [:network, :deployment]
 
       define :send_create_volume_request,
         action: :send_create_volume_request,
-        args: [:volume]
+        args: [:volume, :deployment]
 
       define :send_create_deployment_request,
         action: :send_create_deployment_request,

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container."
     },
     {
+      "endpoint": "/container/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the container",
+      "doc": "The deployment in which the container is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/container/imageId",
       "type": "string",
       "database_retention_policy": "use_ttl",
@@ -76,7 +85,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container environment",
-      "doc": "Array of KEY=value environment variables"
+      "doc": "Array of key=value environment variables. The key cannot contain `=`."
     },
     {
       "endpoint": "/container/binds",

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateImageRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateImageRequest.json
@@ -18,6 +18,15 @@
       "doc": "Unique id for the container image."
     },
     {
+      "endpoint": "/image/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the image",
+      "doc": "The deployment in which the image is used, so the device can send deployment events to Astarte for te create request"
+    },
+    {
       "endpoint": "/image/reference",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container network."
     },
     {
+      "endpoint": "/network/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the network",
+      "doc": "The deployment in which the network is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/network/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",
@@ -49,7 +58,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options. The key cannot contain `=`. to set for the driver."
     }
   ]
 }

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the volume."
     },
     {
+      "endpoint": "/volume/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the volume",
+      "doc": "The deployment in which the volume is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/volume/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",
@@ -31,7 +40,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options. The key cannot contain `=`. to set for the driver."
     }
   ]
 }


### PR DESCRIPTION
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
adds the id for the deployment when sening requsets to the device.
this can later be used by the device to publish events relative to this specific id, so that astarte can gather information about a specific deployment.

related: edgehog-device-manager/edgehog-astarte-interfaces#70