### PR TITLE
feat: add Volumes page with list, creation, and details view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for trigger delivery policies in the tenant 
 reconciler, allowing Edgehog to automatically provision and manage 
 trigger delivery policies on Astarte realms that support them (v1.1.1+).
+- **Volumes management feature**:
+  - **Volumes page** – lists all existing volumes and allows navigation to individual volume pages.
+  - **Volume page** – displays details of a selected volume, including its label, driver, and options.
+  - **VolumeCreate page** – enables creating a new volume with fields for label, driver, and options.
 
 ## [0.9.3] - 2025-05-22
 ### Fixed

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,9 @@ import UpdateCampaigns from "pages/UpdateCampaigns";
 import UpdateChannelsEdit from "pages/UpdateChannel";
 import UpdateChannelsCreate from "pages/UpdateChannelCreate";
 import UpdateChannels from "pages/UpdateChannels";
+import Volumes from "pages/Volumes";
+import Volume from "pages/Volume";
+import VolumeCreatePage from "pages/VolumeCreate";
 
 import { bugs, repository, version } from "../package.json";
 
@@ -106,6 +109,9 @@ const authenticatedRoutes: RouterRule[] = [
   { path: Route.application, element: <Application /> },
   { path: Route.release, element: <Release /> },
   { path: Route.releaseNew, element: <ReleaseCreatePage /> },
+  { path: Route.volumes, element: <Volumes /> },
+  { path: Route.volumeEdit, element: <Volume /> },
+  { path: Route.volumesNew, element: <VolumeCreatePage /> },
   { path: Route.logout, element: <Logout /> },
   { path: "*", element: <Navigate to={Route.devices} replace /> },
 ];

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -61,6 +61,10 @@ enum Route {
   imageCredentials = "/image-credentials",
   imageCredentialsEdit = "/image-credentials/:imageCredentialId/edit",
   imageCredentialsNew = "/image-credentials/new",
+  volumes = "/volumes",
+  volumeEdit = "/volumes/:volumeId",
+  volumesNew = "/volumes/new",
+
   login = "/login",
   logout = "/logout",
 }
@@ -111,6 +115,8 @@ const matchingParametricRoute = (
     case Route.applicationNew:
     case Route.imageCredentials:
     case Route.imageCredentialsNew:
+    case Route.volumes:
+    case Route.volumesNew:
     case Route.login:
     case Route.logout:
       return { route } as ParametricRoute;
@@ -227,6 +233,13 @@ const matchingParametricRoute = (
         ? {
             route,
             params: { imageCredentialId: params.imageCredentialId },
+          }
+        : null;
+    case Route.volumeEdit:
+      return params && typeof params["volumeId"] === "string"
+        ? {
+            route,
+            params: { volumeId: params.volumeId },
           }
         : null;
   }
@@ -398,6 +411,18 @@ const routeTitles: Record<Route, MessageDescriptor> = defineMessages({
   [Route.logout]: {
     id: "navigation.routeTitle.Logout",
     defaultMessage: "Logout",
+  },
+  [Route.volumes]: {
+    id: "navigation.routeTitle.Volumes",
+    defaultMessage: "Volumes",
+  },
+  [Route.volumeEdit]: {
+    id: "navigation.routeTitle.VolumeEdit",
+    defaultMessage: "Volume Details",
+  },
+  [Route.volumesNew]: {
+    id: "navigation.routeTitle.VolumesNew",
+    defaultMessage: "Create Volumes",
   },
 });
 

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -91,6 +91,7 @@ const useBreadcrumbItems = (): BreadcrumbItem[] => {
       case Route.updateCampaigns:
       case Route.applications:
       case Route.imageCredentials:
+      case Route.volumes:
       case Route.login:
       case Route.logout:
         return [currentRoute];
@@ -155,6 +156,9 @@ const useBreadcrumbItems = (): BreadcrumbItem[] => {
       case Route.imageCredentialsNew:
         return [{ route: Route.imageCredentials }, currentRoute];
 
+      case Route.volumeEdit:
+      case Route.volumesNew:
+        return [{ route: Route.volumes }, currentRoute];
       default:
         return [];
     }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -244,6 +244,16 @@ const Sidebar = () => (
           Route.imageCredentialsEdit,
         ]}
       />
+      <SidebarItem
+        label={
+          <FormattedMessage
+            id="components.Sidebar.volumes.volumesLabel"
+            defaultMessage="Volumes"
+          />
+        }
+        route={Route.volumes}
+        activeRoutes={[Route.volumes, Route.volumeEdit, Route.volumesNew]}
+      />
     </SidebarItemGroup>
   </Navbar>
 );

--- a/frontend/src/components/VolumesTable.tsx
+++ b/frontend/src/components/VolumesTable.tsx
@@ -1,0 +1,98 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
+import { useMemo } from "react";
+
+import type {
+  VolumesTable_VolumeFragment$data,
+  VolumesTable_VolumeFragment$key,
+} from "api/__generated__/VolumesTable_VolumeFragment.graphql";
+
+import { Link, Route } from "Navigation";
+import Table, { createColumnHelper } from "components/Table";
+
+// We use graphql fields below in columns configuration
+/* eslint-disable relay/unused-fields */
+const VOLUMES_TABLE_FRAGMENT = graphql`
+  fragment VolumesTable_VolumeFragment on Volume @relay(plural: true) {
+    id
+    label
+    driver
+    options
+  }
+`;
+
+type TableRecord = VolumesTable_VolumeFragment$data[0];
+
+const columnHelper = createColumnHelper<TableRecord>();
+const columns = [
+  columnHelper.accessor("label", {
+    header: () => (
+      <FormattedMessage
+        id="components.VolumesTable.label"
+        defaultMessage="Label"
+        description="Title for the Label column of the volumes table"
+      />
+    ),
+    cell: ({ row, getValue }) => (
+      <Link route={Route.volumeEdit} params={{ volumeId: row.original.id }}>
+        {getValue()}
+      </Link>
+    ),
+  }),
+  columnHelper.accessor("driver", {
+    header: () => (
+      <FormattedMessage
+        id="components.VolumesTable.driverTitle"
+        defaultMessage="Driver"
+        description="Title for the Driver column of the volumes table"
+      />
+    ),
+  }),
+];
+
+type VolumesTableProps = {
+  className?: string;
+  volumesRef: VolumesTable_VolumeFragment$key;
+  hideSearch?: boolean;
+};
+
+const VolumesTable = ({
+  className,
+  volumesRef,
+  hideSearch = false,
+}: VolumesTableProps) => {
+  const volumes = useFragment(VOLUMES_TABLE_FRAGMENT, volumesRef);
+
+  const memoizedColumns = useMemo(() => columns, []);
+
+  return (
+    <Table
+      className={className}
+      columns={memoizedColumns}
+      data={volumes}
+      hideSearch={hideSearch}
+    />
+  );
+};
+
+export default VolumesTable;

--- a/frontend/src/forms/CreateVolume.tsx
+++ b/frontend/src/forms/CreateVolume.tsx
@@ -1,0 +1,175 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import React from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FieldError, useForm } from "react-hook-form";
+import { FormattedMessage } from "react-intl";
+
+import Button from "components/Button";
+import Col from "components/Col";
+import Form from "components/Form";
+import Row from "components/Row";
+import Spinner from "components/Spinner";
+
+import { yup, envSchema } from "forms";
+
+const FormRow = ({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <Form.Group as={Row} controlId={id} className="mb-4">
+    <Form.Label column sm={3} className="fw-bold">
+      {label}
+    </Form.Label>
+    <Col sm={9}>{children}</Col>
+  </Form.Group>
+);
+
+type VolumeData = {
+  label: string;
+  driver?: string;
+  options?: string;
+};
+
+const volumeSchema = yup
+  .object({
+    label: yup.string().required(),
+    driver: yup.string().nullable(),
+    options: envSchema.nullable().notRequired(),
+  })
+  .required();
+
+const initialData: VolumeData = {
+  label: "",
+  driver: "",
+  options: "",
+};
+
+interface Props {
+  isLoading?: boolean;
+  onSubmit: (data: VolumeData) => void;
+}
+
+const ErrorMessage = ({ error }: { error?: FieldError }) => {
+  if (!error?.message) return null;
+  return (
+    <Form.Control.Feedback type="invalid" role="alert">
+      <FormattedMessage id={error.message} defaultMessage={error.message} />
+    </Form.Control.Feedback>
+  );
+};
+
+const CreateVolume = React.memo(({ isLoading = false, onSubmit }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<VolumeData>({
+    mode: "onTouched",
+    defaultValues: initialData,
+    resolver: yupResolver(volumeSchema),
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
+      <FormRow
+        id="volumeLabel"
+        label={
+          <FormattedMessage
+            id="components.CreateVolumeForm.labelLabel"
+            defaultMessage="Label"
+          />
+        }
+      >
+        <Form.Control
+          as="textarea"
+          rows={1}
+          {...register("label")}
+          isInvalid={!!errors.label}
+        />
+        <ErrorMessage error={errors.label} />
+      </FormRow>
+
+      <FormRow
+        id="volumeDriver"
+        label={
+          <FormattedMessage
+            id="components.CreateVolumeForm.driverLabel"
+            defaultMessage="Driver"
+          />
+        }
+      >
+        <Form.Control
+          as="textarea"
+          rows={1}
+          {...register("driver")}
+          isInvalid={!!errors.driver}
+        />
+        <ErrorMessage error={errors.driver} />
+      </FormRow>
+
+      <FormRow
+        id="volumeOptions"
+        label={
+          <FormattedMessage
+            id="components.CreateVolumeForm.optionsLabel"
+            defaultMessage="Options"
+          />
+        }
+      >
+        <Form.Control
+          as="textarea"
+          rows={5}
+          {...register("options")}
+          isInvalid={!!errors.options}
+        />
+        <ErrorMessage error={errors.options} />
+      </FormRow>
+
+      <Row className="mt-4">
+        <Col
+          sm={{ span: 10, offset: 2 }}
+          className="d-flex justify-content-end"
+        >
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={isLoading || isSubmitting || !isValid}
+          >
+            {isLoading && <Spinner size="sm" className="me-2" />}
+            <FormattedMessage
+              id="components.CreateVolumeForm.submitButton"
+              defaultMessage="Create"
+            />
+          </Button>
+        </Col>
+      </Row>
+    </form>
+  );
+});
+
+export type { VolumeData };
+export default CreateVolume;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -387,6 +387,18 @@
   "components.CreateSystemModelForm.submitButton": {
     "defaultMessage": "Create"
   },
+  "components.CreateVolumeForm.driverLabel": {
+    "defaultMessage": "Driver"
+  },
+  "components.CreateVolumeForm.labelLabel": {
+    "defaultMessage": "Label"
+  },
+  "components.CreateVolumeForm.optionsLabel": {
+    "defaultMessage": "Options"
+  },
+  "components.CreateVolumeForm.submitButton": {
+    "defaultMessage": "Create"
+  },
   "components.DeleteModal.confirmButton": {
     "defaultMessage": "Delete",
     "description": "Title for the button to confirm a deletion modal"
@@ -675,6 +687,9 @@
   "components.Sidebar.updateChannelsLabel": {
     "defaultMessage": "Update Channels"
   },
+  "components.Sidebar.volumes.volumesLabel": {
+    "defaultMessage": "Volumes"
+  },
   "components.StorageTable.freeSpaceTitle": {
     "defaultMessage": "Free Space"
   },
@@ -834,6 +849,18 @@
   },
   "components.UpdateTargetsTabs.updateTargetsLabel": {
     "defaultMessage": "Devices"
+  },
+  "components.VolumesTable.driverTitle": {
+    "defaultMessage": "Driver",
+    "description": "Title for the Driver column of the volumes table"
+  },
+  "components.VolumesTable.label": {
+    "defaultMessage": "Label",
+    "description": "Title for the Label column of the volumes table"
+  },
+  "components.VolumesTable.optionsTitle": {
+    "defaultMessage": "Options",
+    "description": "Title for the Options column of the volumes table"
   },
   "components.WiFiScanResultsTable.apChannelTitle": {
     "defaultMessage": "Channel"
@@ -1259,6 +1286,15 @@
   },
   "navigation.routeTitle.UpdateChannelsNew": {
     "defaultMessage": "Create Update Channel"
+  },
+  "navigation.routeTitle.VolumeEdit": {
+    "defaultMessage": "Volume Details"
+  },
+  "navigation.routeTitle.Volumes": {
+    "defaultMessage": "Volumes"
+  },
+  "navigation.routeTitle.VolumesNew": {
+    "defaultMessage": "Create Volumes"
   },
   "pages.Application.applicationNotFound.message": {
     "defaultMessage": "Return to the applications list."
@@ -1708,6 +1744,33 @@
   },
   "pages.UpdateChannels.title": {
     "defaultMessage": "Update Channels"
+  },
+  "pages.Volume.volumeNotFound.message": {
+    "defaultMessage": "Return to the volumes list."
+  },
+  "pages.Volume.volumeNotFound.title": {
+    "defaultMessage": "Volume not found."
+  },
+  "pages.VolumeCreate.creationErrorFeedback": {
+    "defaultMessage": "Could not create the Volume, please try again."
+  },
+  "pages.VolumeCreate.title": {
+    "defaultMessage": "Create Volume"
+  },
+  "pages.Volumes.createButton": {
+    "defaultMessage": "Create Volume"
+  },
+  "pages.Volumes.title": {
+    "defaultMessage": "Volumes"
+  },
+  "pages.volume.driver": {
+    "defaultMessage": "Driver"
+  },
+  "pages.volume.label": {
+    "defaultMessage": "Label"
+  },
+  "pages.volume.options": {
+    "defaultMessage": "Options"
   },
   "validation.array.min": {
     "defaultMessage": "Does not have enough values."

--- a/frontend/src/pages/Volume.tsx
+++ b/frontend/src/pages/Volume.tsx
@@ -1,0 +1,209 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Suspense, useCallback, useEffect, useState } from "react";
+import { Form, Row, Col } from "react-bootstrap";
+import { useParams } from "react-router-dom";
+import { ErrorBoundary } from "react-error-boundary";
+import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
+import type { PreloadedQuery } from "react-relay/hooks";
+import { FormattedMessage } from "react-intl";
+
+import type {
+  Volume_getVolume_Query,
+  Volume_getVolume_Query$data,
+} from "api/__generated__/Volume_getVolume_Query.graphql";
+
+import { Link, Route } from "Navigation";
+import Alert from "components/Alert";
+import Center from "components/Center";
+import Page from "components/Page";
+import Result from "components/Result";
+import Spinner from "components/Spinner";
+
+const GET_VOLUME_QUERY = graphql`
+  query Volume_getVolume_Query($volumeId: ID!) {
+    volume(id: $volumeId) {
+      label
+      driver
+      options
+    }
+  }
+`;
+
+const FormRow = ({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <Form.Group as={Row} controlId={id} className="mb-4">
+    <Form.Label column sm={3} className="fw-bold">
+      {label}
+    </Form.Label>
+    <Col sm={9}>{children}</Col>
+  </Form.Group>
+);
+
+interface VolumeContentProps {
+  volume: NonNullable<Volume_getVolume_Query$data["volume"]>;
+}
+
+const VolumeContent = ({ volume }: VolumeContentProps) => {
+  const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
+
+  const getPrettyOptions = () => {
+    try {
+      if (!volume.options) return "";
+      if (typeof volume.options === "string") {
+        return JSON.stringify(JSON.parse(volume.options), null, 2);
+      }
+      return JSON.stringify(volume.options, null, 2);
+    } catch (err) {
+      setErrorFeedback("Failed to parse volume options JSON.");
+      return "";
+    }
+  };
+
+  return (
+    <Page>
+      <Page.Header title={volume.label} />
+      <Page.Main>
+        <Alert
+          show={!!errorFeedback}
+          variant="danger"
+          onClose={() => setErrorFeedback(null)}
+          dismissible
+        >
+          {errorFeedback}
+        </Alert>
+
+        <FormRow
+          id="volumeLabel"
+          label={
+            <FormattedMessage id="pages.volume.label" defaultMessage="Label" />
+          }
+        >
+          <Form.Control value={volume.label ?? ""} readOnly />
+        </FormRow>
+
+        <FormRow
+          id="volumeDriver"
+          label={
+            <FormattedMessage
+              id="pages.volume.driver"
+              defaultMessage="Driver"
+            />
+          }
+        >
+          <Form.Control value={volume.driver ?? ""} readOnly />
+        </FormRow>
+
+        <FormRow
+          id="volumeOptions"
+          label={
+            <FormattedMessage
+              id="pages.volume.options"
+              defaultMessage="Options"
+            />
+          }
+        >
+          <Form.Control
+            as="textarea"
+            value={getPrettyOptions()}
+            rows={getPrettyOptions().split("\n").length}
+            readOnly
+            style={{ fontFamily: "monospace", whiteSpace: "pre-wrap" }}
+          />
+        </FormRow>
+      </Page.Main>
+    </Page>
+  );
+};
+
+type VolumeWrapperProps = {
+  getVolumeQuery: PreloadedQuery<Volume_getVolume_Query>;
+};
+
+const VolumeWrapper = ({ getVolumeQuery }: VolumeWrapperProps) => {
+  const { volume } = usePreloadedQuery(GET_VOLUME_QUERY, getVolumeQuery);
+
+  if (!volume) {
+    return (
+      <Result.NotFound
+        title={
+          <FormattedMessage
+            id="pages.Volume.volumeNotFound.title"
+            defaultMessage="Volume not found."
+          />
+        }
+      >
+        <Link route={Route.volumes}>
+          <FormattedMessage
+            id="pages.Volume.volumeNotFound.message"
+            defaultMessage="Return to the volumes list."
+          />
+        </Link>
+      </Result.NotFound>
+    );
+  }
+
+  return <VolumeContent volume={volume} />;
+};
+
+const VolumePage = () => {
+  const { volumeId = "" } = useParams();
+
+  const [getVolumeQuery, getVolume] =
+    useQueryLoader<Volume_getVolume_Query>(GET_VOLUME_QUERY);
+
+  const fetchVolume = useCallback(
+    () => getVolume({ volumeId }, { fetchPolicy: "network-only" }),
+    [getVolume, volumeId],
+  );
+
+  useEffect(fetchVolume, [fetchVolume]);
+
+  return (
+    <Suspense
+      fallback={
+        <Center data-testid="page-loading">
+          <Spinner />
+        </Center>
+      }
+    >
+      <ErrorBoundary
+        FallbackComponent={(props) => (
+          <Center data-testid="page-error">
+            <Page.LoadingError onRetry={props.resetErrorBoundary} />
+          </Center>
+        )}
+        onReset={fetchVolume}
+      >
+        {getVolumeQuery && <VolumeWrapper getVolumeQuery={getVolumeQuery} />}
+      </ErrorBoundary>
+    </Suspense>
+  );
+};
+
+export default VolumePage;

--- a/frontend/src/pages/VolumeCreate.tsx
+++ b/frontend/src/pages/VolumeCreate.tsx
@@ -1,0 +1,143 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2024-2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { ReactNode, useCallback, useState } from "react";
+import { FormattedMessage } from "react-intl";
+import { graphql, useMutation } from "react-relay/hooks";
+
+import type { VolumeCreate_volumeCreate_Mutation } from "api/__generated__/VolumeCreate_volumeCreate_Mutation.graphql";
+
+import Alert from "components/Alert";
+import Page from "components/Page";
+import { Route, useNavigate } from "Navigation";
+import CreateVolumeForm, { VolumeData } from "forms/CreateVolume";
+
+const CREATE_VOLUME_MUTATION = graphql`
+  mutation VolumeCreate_volumeCreate_Mutation($input: CreateVolumeInput!) {
+    createVolume(input: $input) {
+      result {
+        id
+      }
+    }
+  }
+`;
+
+const VolumeCreatePage = () => {
+  const [errorFeedback, setErrorFeedback] = useState<ReactNode>(null);
+  const navigate = useNavigate();
+
+  const [createVolume, isCreatingVolume] =
+    useMutation<VolumeCreate_volumeCreate_Mutation>(CREATE_VOLUME_MUTATION);
+
+  const handleCreateVolume = useCallback(
+    (volume: VolumeData) => {
+      const input: VolumeData = {
+        label: volume.label.trim(),
+      };
+      if (volume.driver && volume.driver.trim() !== "") {
+        input.driver = volume.driver.trim();
+      }
+      if (volume.options && volume.options.trim() !== "") {
+        input.options = volume.options.trim();
+      }
+
+      createVolume({
+        variables: { input },
+        onCompleted(data, errors) {
+          const volumeId = data.createVolume?.result?.id;
+          if (volumeId) {
+            navigate({ route: Route.volumes });
+            return;
+          }
+          if (errors) {
+            const errorFeedback = errors
+              .map(({ fields, message }) =>
+                fields.length ? `${fields.join(" ")} ${message}` : message,
+              )
+              .join(". \n");
+            setErrorFeedback(errorFeedback);
+          }
+        },
+        onError() {
+          setErrorFeedback(
+            <FormattedMessage
+              id="pages.VolumeCreate.creationErrorFeedback"
+              defaultMessage="Could not create the Volume, please try again."
+            />,
+          );
+        },
+
+        updater(store, data) {
+          if (!data?.createVolume?.result?.id) {
+            return;
+          }
+
+          const volume = store
+            .getRootField("createVolume")
+            .getLinkedRecord("result");
+          const root = store.getRoot();
+
+          const volumes = root.getLinkedRecord("volumes", {
+            id: "root",
+          });
+
+          if (volumes) {
+            root.setLinkedRecords(
+              volumes
+                ? [...(volumes.getLinkedRecords("volumes") || []), volume]
+                : [volume],
+              "volumes",
+            );
+          }
+        },
+      });
+    },
+    [createVolume, navigate],
+  );
+
+  return (
+    <Page>
+      <Page.Header
+        title={
+          <FormattedMessage
+            id="pages.VolumeCreate.title"
+            defaultMessage="Create Volume"
+          />
+        }
+      />
+      <Page.Main>
+        <Alert
+          show={!!errorFeedback}
+          variant="danger"
+          onClose={() => setErrorFeedback(null)}
+          dismissible
+        >
+          {errorFeedback}
+        </Alert>
+        <CreateVolumeForm
+          onSubmit={handleCreateVolume}
+          isLoading={isCreatingVolume}
+        />
+      </Page.Main>
+    </Page>
+  );
+};
+
+export default VolumeCreatePage;

--- a/frontend/src/pages/Volumes.tsx
+++ b/frontend/src/pages/Volumes.tsx
@@ -1,0 +1,109 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Suspense, useCallback, useEffect } from "react";
+import { FormattedMessage } from "react-intl";
+import { ErrorBoundary } from "react-error-boundary";
+import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
+import type { PreloadedQuery } from "react-relay/hooks";
+
+import type { Volumes_getVolumes_Query } from "api/__generated__/Volumes_getVolumes_Query.graphql";
+
+import Page from "components/Page";
+import Center from "components/Center";
+import Spinner from "components/Spinner";
+import VolumesTable from "components/VolumesTable";
+import Button from "components/Button";
+import { Link, Route } from "Navigation";
+
+const GET_VOLUMES_QUERY = graphql`
+  query Volumes_getVolumes_Query {
+    volumes {
+      results {
+        ...VolumesTable_VolumeFragment
+      }
+    }
+  }
+`;
+
+interface VolumesContentProps {
+  getVolumesQuery: PreloadedQuery<Volumes_getVolumes_Query>;
+}
+
+const VolumesContent = ({ getVolumesQuery }: VolumesContentProps) => {
+  const { volumes } = usePreloadedQuery(GET_VOLUMES_QUERY, getVolumesQuery);
+
+  return (
+    <Page>
+      <Page.Header
+        title={
+          <FormattedMessage id="pages.Volumes.title" defaultMessage="Volumes" />
+        }
+      >
+        <Button as={Link} route={Route.volumesNew}>
+          <FormattedMessage
+            id="pages.Volumes.createButton"
+            defaultMessage="Create Volume"
+          />
+        </Button>
+      </Page.Header>
+      <Page.Main>
+        <VolumesTable volumesRef={volumes?.results ?? []} />
+      </Page.Main>
+    </Page>
+  );
+};
+
+const VolumesPage = () => {
+  const [getVolumesQuery, getVolumes] =
+    useQueryLoader<Volumes_getVolumes_Query>(GET_VOLUMES_QUERY);
+
+  const fetchVolumes = useCallback(
+    () => getVolumes({}, { fetchPolicy: "store-and-network" }),
+    [getVolumes],
+  );
+
+  useEffect(fetchVolumes, [fetchVolumes]);
+
+  return (
+    <Suspense
+      fallback={
+        <Center data-testid="page-loading">
+          <Spinner />
+        </Center>
+      }
+    >
+      <ErrorBoundary
+        FallbackComponent={(props) => (
+          <Center data-testid="page-error">
+            <Page.LoadingError onRetry={props.resetErrorBoundary} />
+          </Center>
+        )}
+        onReset={fetchVolumes}
+      >
+        {getVolumesQuery && (
+          <VolumesContent getVolumesQuery={getVolumesQuery} />
+        )}
+      </ErrorBoundary>
+    </Suspense>
+  );
+};
+
+export default VolumesPage;


### PR DESCRIPTION
Added a new Volumes page that:
- Displays all available volumes
- Allows creating a new volume
- Provides a detailed view for each volume

<details>
<summary>
Screenshots
</summary>
<img width="1897" height="916" alt="image" src="https://github.com/user-attachments/assets/6af987f4-854c-4552-b96b-ba2fc010a08d" />
<img width="1897" height="676" alt="Screenshot from 2025-08-11 15-05-11" src="https://github.com/user-attachments/assets/32afbb88-b060-422c-b642-6f974665e64a" />
<img width="1937" height="995" alt="image" src="https://github.com/user-attachments/assets/82094530-fdfa-4d70-a2a8-78d2b8e36fee" />

</details>