### PR TITLE
feat(containers): support network link in release creation

### DIFF
--- a/backend/lib/edgehog/containers/container/container.ex
+++ b/backend/lib/edgehog/containers/container/container.ex
@@ -65,12 +65,18 @@ defmodule Edgehog.Containers.Container do
       accept [:restart_policy, :hostname, :env, :privileged, :port_bindings, :network_mode]
 
       argument :image, :map
+      argument :networks, {:array, :map}
 
       change manage_relationship(:image,
                on_no_match: :create,
                on_lookup: :relate,
                on_match: :ignore,
                use_identities: [:reference]
+             )
+
+      change manage_relationship(:networks,
+               on_no_match: :error,
+               on_lookup: :relate
              )
     end
 

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -97,6 +97,9 @@ defmodule Edgehog.Containers do
                                 containers: [
                                   image: [
                                     image_credentials_id: :image_credentials
+                                  ],
+                                  networks: [
+                                    id: :network
                                   ]
                                 ]
                               ]

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -112,7 +112,16 @@ defmodule Edgehog.ContainersFixtures do
   def network_fixture(opts \\ []) do
     {tenant, opts} = Keyword.pop!(opts, :tenant)
 
-    params = Map.new(opts)
+    random_driver = Enum.random(["bridge", "host", "overlay", "macvlan", "ipvlan"])
+
+    params =
+      Enum.into(opts, %{
+        label: unique_network_label(),
+        driver: random_driver,
+        internal: Enum.random([true, false]),
+        enable_ipv6: Enum.random([true, false]),
+        options: %{}
+      })
 
     Ash.create!(Network, params, tenant: tenant)
   end


### PR DESCRIPTION
Adds support for specifying a network for each container when creating a release.
