### PR TITLE
feat(containers): Add searchable app/release selection in deployments

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -95,14 +95,29 @@
   "components.AddAvailableApplications.deviceOfflineError": {
     "defaultMessage": "The device is disconnected. You cannot deploy an application while it is offline."
   },
+  "components.AddAvailableApplications.noApplicationsAvailable": {
+    "defaultMessage": "No applications available"
+  },
+  "components.AddAvailableApplications.noApplicationsFoundMatching": {
+    "defaultMessage": "No applications found matching \"{inputValue}\""
+  },
+  "components.AddAvailableApplications.noReleasesAvailable": {
+    "defaultMessage": "No releases available for this application"
+  },
+  "components.AddAvailableApplications.noReleasesFoundMatching": {
+    "defaultMessage": "No releases found matching \"{inputValue}\""
+  },
+  "components.AddAvailableApplications.searchPlaceholder": {
+    "defaultMessage": "Search or select an application..."
+  },
   "components.AddAvailableApplications.selectARelease": {
     "defaultMessage": "Select a release"
   },
-  "components.AddAvailableApplications.selectAnApplication": {
-    "defaultMessage": "Select an application"
-  },
   "components.AddAvailableApplications.selectApplication": {
     "defaultMessage": "Select Application"
+  },
+  "components.AddAvailableApplications.selectApplicationFirst": {
+    "defaultMessage": "Please select an application first"
   },
   "components.AddAvailableApplications.selectRelease": {
     "defaultMessage": "Select Release"
@@ -496,6 +511,9 @@
   },
   "components.DeployedApplicationsTable.noReleasesAvailable": {
     "defaultMessage": "No Release Versions Available"
+  },
+  "components.DeployedApplicationsTable.noReleasesFoundMatching": {
+    "defaultMessage": "No release versions found matching \"{inputValue}\""
   },
   "components.DeployedApplicationsTable.ready": {
     "defaultMessage": "Ready"


### PR DESCRIPTION
Allow the user to search for a specific app when the user needs to select an app (e.g. for deployment).
When trying to deploy or upgrade an app, the user needs to select the app and the release (i.e. version). Instead of using a static dropdown, the UI offers a search box to quickly filter and refine the options shown in the dropdown.


<details><summary>Screenshots</summary>
<p>

Old:
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/c7a16d94-2032-463e-a761-0848ec6da449" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/441eb0a8-aa2b-460f-98b8-c3ed130261b1" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/91ede5a6-5d4d-4c84-843e-8ceaadb87ee5" />



Update:
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/aa8117f4-375b-420b-80ec-53a04a18a437" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/c0a5d2dc-5f54-4783-8d58-860801b43bfe" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/796692cf-2ad1-48ff-b05e-a50829e1ae5f" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/2d598a97-04a6-4109-8cfa-b3e361132f08" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/248d0b53-0501-4a60-a26a-929ceb5957c7" />



</p>
</details> 
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
