### PR TITLE
Add Monaco Editor for JSON editing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@hookform/resolvers": "^2.8.3",
+        "@monaco-editor/react": "^4.7.0-rc.0",
         "@tanstack/react-table": "^8.19.2",
         "@types/js-cookie": "^3.0.6",
         "@types/leaflet": "^1.9.12",
@@ -3916,6 +3917,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0-rc.0.tgz",
+      "integrity": "sha512-YfjXkDK0bcwS0zo8PXptvQdCQfOPPtzGsAzmIv7PnoUGFdIohsR+NVDyjbajMddF+3cWUm/3q9NzP/DUke9a+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10260,6 +10284,13 @@
         "ufo": "^1.5.3"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11587,6 +11618,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.7.0",
@@ -15703,6 +15740,22 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "requires": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "@monaco-editor/react": {
+      "version": "4.7.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0-rc.0.tgz",
+      "integrity": "sha512-YfjXkDK0bcwS0zo8PXptvQdCQfOPPtzGsAzmIv7PnoUGFdIohsR+NVDyjbajMddF+3cWUm/3q9NzP/DUke9a+w==",
+      "requires": {
+        "@monaco-editor/loader": "^1.4.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -20519,6 +20572,12 @@
         "ufo": "^1.5.3"
       }
     },
+    "monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "peer": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -21500,6 +21559,11 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "std-env": {
       "version": "3.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hookform/resolvers": "^2.8.3",
+    "@monaco-editor/react": "^4.7.0-rc.0",
     "@tanstack/react-table": "^8.19.2",
     "@types/js-cookie": "^3.0.6",
     "@types/leaflet": "^1.9.12",

--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -35,6 +35,7 @@ import type {
 import Col from "components/Col";
 import Form from "components/Form";
 import Row from "components/Row";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const FormRow = ({
   id,
@@ -239,15 +240,13 @@ const VolumeDetails = ({ volumes, containerIndex }: volumeDetailsProps) => {
                       />
                     }
                   >
-                    <Form.Control
-                      as="textarea"
+                    <MonacoJsonEditor
                       value={formatJson(vol?.options)}
-                      rows={formatJson(vol?.options).split("\n").length}
-                      readOnly
-                      style={{
-                        fontFamily: "monospace",
-                        whiteSpace: "pre-wrap",
-                      }}
+                      language="json"
+                      onChange={() => {}}
+                      defaultValue={formatJson(vol?.options)}
+                      readonly={true}
+                      initialLines={1}
                     />
                   </FormRow>
                 </div>
@@ -389,11 +388,13 @@ const NetworkDetails = ({ networks, containerIndex }: networkDetailsProps) => {
                       />
                     }
                   >
-                    <Form.Control
-                      as="textarea"
-                      rows={3}
+                    <MonacoJsonEditor
                       value={formatJson(net?.options)}
-                      readOnly
+                      language="json"
+                      onChange={() => {}}
+                      defaultValue={formatJson(net?.options)}
+                      readonly={true}
+                      initialLines={1}
                     />
                   </FormRow>
                 </div>
@@ -426,11 +427,13 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
           />
         }
       >
-        <Form.Control
-          as="textarea"
-          rows={formatJson(container.env).split("\n").length}
+        <MonacoJsonEditor
           value={formatJson(container.env)}
-          readOnly
+          language="json"
+          onChange={() => {}}
+          defaultValue={formatJson(container.env)}
+          readonly={true}
+          initialLines={1}
         />
       </FormRow>
 

--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -44,6 +44,7 @@ import {
   faUser,
   faEye,
   faEyeSlash,
+  faTriangleExclamation,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -73,6 +74,7 @@ const icons = {
   upgrade: faArrowAltCircleUp,
   showPassword: faEye,
   hidePassword: faEyeSlash,
+  warning: faTriangleExclamation,
 } as const;
 
 type FontAwesomeIconProps = React.ComponentProps<typeof FontAwesomeIcon>;

--- a/frontend/src/components/MonacoJsonEditor.tsx
+++ b/frontend/src/components/MonacoJsonEditor.tsx
@@ -1,0 +1,119 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { useRef, useState, useCallback } from "react";
+import { Editor } from "@monaco-editor/react";
+import { FormattedMessage } from "react-intl";
+
+import Icon from "components/Icon";
+
+type MonacoJsonEditorProps = {
+  value: string;
+  language?: string;
+  onChange?: (value: string | undefined) => void;
+  defaultValue?: string;
+  readonly?: boolean;
+  initialLines?: number;
+  autoFormat?: boolean;
+};
+
+const MonacoJsonEditor = ({
+  value,
+  language = "json",
+  onChange,
+  defaultValue,
+  readonly = false,
+  initialLines = 5,
+  autoFormat = true,
+}: MonacoJsonEditorProps) => {
+  const editorRef = useRef<any>(null);
+  const lineHeight = 22;
+  const [height, setHeight] = useState(initialLines * lineHeight);
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  const formatJson = useCallback(() => {
+    if (editorRef.current && autoFormat && language === "json") {
+      try {
+        const currentValue = editorRef.current.getValue();
+        JSON.parse(currentValue); // validacija
+        editorRef.current.getAction("editor.action.formatDocument").run();
+        setJsonError(null); // nema greške
+      } catch (error: any) {
+        setJsonError(error.message); // snimi grešku
+      }
+    }
+  }, [autoFormat, language]);
+
+  const updateHeight = useCallback(() => {
+    if (editorRef.current) {
+      const contentHeight = editorRef.current.getContentHeight();
+      const minHeight = initialLines * lineHeight;
+      setHeight(Math.max(contentHeight, minHeight));
+      editorRef.current.layout();
+    }
+  }, [initialLines]);
+
+  const handleEditorDidMount = (editor: any) => {
+    editorRef.current = editor;
+    editor.onDidContentSizeChange(updateHeight);
+    editor.onDidChangeModelContent(() => {
+      setTimeout(formatJson, 100);
+    });
+    updateHeight();
+  };
+
+  return (
+    <div className="border rounded bg-white p-2 overflow-hidden">
+      <Editor
+        height={height}
+        defaultLanguage={language}
+        value={value}
+        onChange={onChange}
+        defaultValue={defaultValue}
+        onMount={handleEditorDidMount}
+        options={{
+          automaticLayout: true,
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          wordWrap: "on",
+          readOnly: readonly,
+          lineNumbers: "off",
+          scrollbar: {
+            vertical: "hidden",
+            horizontal: "hidden",
+            alwaysConsumeMouseWheel: false,
+          },
+        }}
+      />
+      {jsonError && (
+        <p className="text-red-500 text-sm mt-2">
+          <Icon icon="warning" />
+          <FormattedMessage
+            id="components.MonacoJsonEditor.jsonError"
+            defaultMessage="JSON error: {error}"
+            values={{ error: jsonError }}
+          />
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MonacoJsonEditor;

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -52,6 +52,7 @@ import { yup, envSchema, portBindingsSchema } from "./index";
 import MultiSelect from "components/MultiSelect";
 import Select from "react-select";
 import Icon from "components/Icon";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const IMAGE_CREDENTIALS_OPTIONS_FRAGMENT = graphql`
   fragment CreateRelease_ImageCredentialsOptionsFragment on RootQueryType {
@@ -262,20 +263,21 @@ const ContainerForm = ({
             />
           }
         >
-          <Form.Control
-            {...register(`containers.${index}.env` as const)}
-            isInvalid={!!errors.containers?.[index]?.env}
-            placeholder='e.g., {"KEY": "value"}'
-            as="textarea"
-            rows={3}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.containers?.[index]?.env?.message && (
-              <FormattedMessage id={errors.containers[index].env.message} />
+          <Controller
+            control={control}
+            name={`containers.${index}.env`}
+            render={({ field, fieldState: _fieldState }) => (
+              <MonacoJsonEditor
+                language="json"
+                value={field.value ?? ""}
+                onChange={(value) => {
+                  field.onChange(value ?? "");
+                }}
+                defaultValue={field.value || "{}"}
+              />
             )}
-          </Form.Control.Feedback>
+          />
         </FormRow>
-
         <FormRow
           id={`containers-${index}-image-reference`}
           label={

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -707,6 +707,9 @@
   "components.LedBehaviorDropdown.tooltip": {
     "defaultMessage": "The device LED will blink for 60s."
   },
+  "components.MonacoJsonEditor.jsonError": {
+    "defaultMessage": "JSON error: {error}"
+  },
   "components.NetworkInterfacesTable.macAddressTitle": {
     "defaultMessage": "MAC Address"
   },


### PR DESCRIPTION
- Added a new MonacoJsonEditor component with dynamic height adjustment.
- Replaced the JSON input in the CreateRelease form with MonacoJsonEditor.
- Replaced the textarea in ContainersTable with MonacoJsonEditor for displaying container environment variables in JSON format.

The previous plain textarea/JSON input was not user-friendly. Monaco Editor provides better JSON editing features such as syntax highlighting, auto-indentation, and a more developer-friendly experience.

Implemented a MonacoJsonEditor React component wrapping the Monaco Editor.
Enabled dynamic height adjustment for better readability.
Updated CreateRelease and ContainersTable components to use the new editor.



<details> <summary>Screenshots</summary>
<img width="1566" height="982" alt="image" src="https://github.com/user-attachments/assets/fdde65b1-989c-4ef4-ae9f-fb56f4840122" />
<img width="1566" height="982" alt="image" src="https://github.com/user-attachments/assets/58b0f720-4234-44ad-80f1-ad2b9a223df4" />
Error Message:
<img width="1647" height="909" alt="image" src="https://github.com/user-attachments/assets/749557c3-c902-421b-b179-b836a26fe672" />

</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

 - [*] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
 - [*] Make sure to open your PR against the right branch: master / release-VERSION
 - [*] Make sure to sign-off all your commits
 - [*] GPG signing is appreciated
 - [*] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
