### PR TITLE
fix(campaigns): Add missing UpdateCampaign alias in Campaigns.Supervisor

### DIFF
--- a/backend/lib/edgehog/campaigns/supervisor.ex
+++ b/backend/lib/edgehog/campaigns/supervisor.ex
@@ -52,7 +52,7 @@ defmodule Edgehog.Campaigns.Supervisor do
 
       defp update_campaigns_resumer do
         update_campaigns_stream =
-          UpdateCampaign
+          Edgehog.UpdateCampaigns.UpdateCampaign
           |> Ash.Query.for_read(:read_all_resumable)
           |> Ash.stream!()
 


### PR DESCRIPTION
Fix supervisor startup error by adding missing alias for UpdateCampaign module.

The Campaigns.Supervisor was failing to start due to an ArgumentError when trying to create an Ash query for UpdateCampaign. The module was referenced but not properly aliased, causing Ash.Query.for_read/4 to not recognize it as a valid resource.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
