### PR TITLE
feat(pagination): Enable server-side pagination for update_targets

### DIFF
--- a/frontend/src/components/InfiniteTable.tsx
+++ b/frontend/src/components/InfiniteTable.tsx
@@ -60,7 +60,7 @@ const SortDirectionIndicator = ({
   </span>
 );
 
-type InfiniteTableProps<T extends object> = {
+type InfiniteTableProps<T extends RowData> = {
   columns: TableOptions<T>["columns"];
   data: T[];
   className?: string;
@@ -71,10 +71,10 @@ type InfiniteTableProps<T extends object> = {
   searchFunction?: FilterFnOption<T>;
   hideSearch?: boolean;
   getRowProps?: (row: Row<T>) => object;
-  setSearchText: (value: string | null) => void;
+  setSearchText?: (value: string | null) => void;
 };
 
-const InfiniteTable = <T extends { id: string }>({
+const InfiniteTable = <T extends RowData>({
   columns,
   data,
   className = "",
@@ -115,7 +115,7 @@ const InfiniteTable = <T extends { id: string }>({
     <div className={className}>
       {hideSearch || (
         <div className="py-2 mb-3">
-          <SearchBox onChange={(text) => setSearchText(text)} />
+          <SearchBox onChange={(text) => setSearchText?.(text)} />
         </div>
       )}
       <InfiniteScroll

--- a/frontend/src/components/UpdateTargetsTable.tsx
+++ b/frontend/src/components/UpdateTargetsTable.tsx
@@ -29,8 +29,9 @@ import type {
 } from "api/__generated__/UpdateTargetsTable_UpdateTargetsFragment.graphql";
 
 import Icon from "components/Icon";
-import Table, { createColumnHelper } from "components/Table";
+import { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";
+import InfiniteTable from "./InfiniteTable";
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
@@ -297,12 +298,18 @@ type Props = {
   className?: string;
   hiddenColumns?: ColumnId[];
   updateTargetsRef: UpdateTargetsTable_UpdateTargetsFragment$key;
+  isLoadingNext: boolean;
+  hasNext: boolean;
+  loadNextUpdateTargets: () => void;
 };
 
 const UpdateTargetsTable = ({
   className,
   updateTargetsRef,
   hiddenColumns = [],
+  isLoadingNext,
+  hasNext,
+  loadNextUpdateTargets,
 }: Props) => {
   const updateTargets = useFragment(
     UPDATE_TARGETS_TABLE_FRAGMENT,
@@ -310,10 +317,12 @@ const UpdateTargetsTable = ({
   );
 
   return (
-    <Table
+    <InfiniteTable
       className={className}
       columns={columns}
-      data={updateTargets}
+      data={[...updateTargets]}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextUpdateTargets : undefined}
       hiddenColumns={hiddenColumns}
       hideSearch
     />

--- a/frontend/src/pages/UpdateCampaign.tsx
+++ b/frontend/src/pages/UpdateCampaign.tsx
@@ -47,13 +47,21 @@ import UpdateTargetsTabs from "components/UpdateTargetsTabs";
 import UpdateCampaignForm from "forms/UpdateCampaignForm";
 import { Link, Route } from "Navigation";
 
+const UPDATE_TARGETS_TO_LOAD_FIRST = 15;
+
 const GET_UPDATE_CAMPAIGN_QUERY = graphql`
-  query UpdateCampaign_getUpdateCampaign_Query($updateCampaignId: ID!) {
+  query UpdateCampaign_getUpdateCampaign_Query(
+    $updateCampaignId: ID!
+    $first: Int
+    $after: String
+    $filter: UpdateTargetFilterInput
+  ) {
     updateCampaign(id: $updateCampaignId) {
       name
       ...UpdateCampaignForm_UpdateCampaignFragment
       ...UpdateCampaignStatsChart_UpdateCampaignStatsChartFragment
       ...UpdateTargetsTabs_UpdateTargetsFragment
+        @arguments(first: $first, after: $after, filter: $filter)
       ...UpdateCampaign_RefreshFragment
     }
   }
@@ -180,7 +188,10 @@ const UpdateCampaignPage = () => {
     );
 
   const fetchUpdateCampaign = useCallback(() => {
-    getUpdateCampaign({ updateCampaignId }, { fetchPolicy: "network-only" });
+    getUpdateCampaign(
+      { updateCampaignId, first: UPDATE_TARGETS_TO_LOAD_FIRST },
+      { fetchPolicy: "network-only" },
+    );
   }, [getUpdateCampaign, updateCampaignId]);
 
   useEffect(fetchUpdateCampaign, [fetchUpdateCampaign]);


### PR DESCRIPTION
Refactored `UpdateTargetsTabs` to use `usePaginationFragment` instead of `useFragment`
Added support for server side pagination with `first`, `after`, and `filter` arguments

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
