### PR TITLE
Merge feature/server side pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Managed OTA operations expose the update target that created them in graphql ([#356](https://github.com/edgehog-device-manager/edgehog/issues/356)).
 - Expose the associated UpdateCampaign (if any) from an OTA Operation on the Software Updates tab  ([#356](https://github.com/edgehog-device-manager/edgehog/issues/356)).
 - Support for using Azure Storage as the persistence layer for asset uploads ([#233](https://github.com/edgehog-device-manager/edgehog/issues/233)).
-- Ecto SSL configuration is exposed trough `DATABASE_*` environment variables (see [.env](./.env))
-- Adds support for trigger delivery policies in the tenant 
-reconciler, allowing Edgehog to automatically provision and manage 
-trigger delivery policies on Astarte realms that support them (v1.1.1+).
+- Ecto SSL configuration is exposed through `DATABASE_*` environment variables (see [.env](./.env))
+- Adds support for trigger delivery policies in the tenant reconciler, allowing Edgehog to automatically provision and manage trigger delivery policies on Astarte realms that support them (v1.1.1+).
+### Changed
+- BREAKING: GraphQL API that return unbounded lists now use Relay/keyset pagination. Edgehog's dashboard now relies on server-side pagination for queries and filtering, and uses tables with infinite scrolling instead of client-side paginated tables.
 
 ## [0.9.3] - 2025-05-22
 ### Fixed

--- a/backend/lib/edgehog/base_images/base_image_collection.ex
+++ b/backend/lib/edgehog/base_images/base_image_collection.ex
@@ -39,6 +39,8 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
 
   graphql do
     type :base_image_collection
+
+    paginate_relationship_with base_images: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/base_images/base_images.ex
+++ b/backend/lib/edgehog/base_images/base_images.ex
@@ -45,7 +45,8 @@ defmodule Edgehog.BaseImages do
 
       list BaseImageCollection, :base_image_collections, :read do
         description "Returns a list of base image collections."
-        paginate_with nil
+        relay? true
+        paginate_with :keyset
       end
     end
 

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -50,6 +50,11 @@ defmodule Edgehog.Devices.Device do
 
   graphql do
     type :device
+
+    # TODO: add :device_groups as a relay-paginated relationship. Since it's a
+    # manual relationship, it needs to implement callbacks that define
+    # datalayer subqueries so Ash can compose and support the functionality.
+    paginate_relationship_with ota_operations: :relay, tags: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/devices/devices.ex
+++ b/backend/lib/edgehog/devices/devices.ex
@@ -1,4 +1,3 @@
-#
 # This file is part of Edgehog.
 #
 # Copyright 2021-2025 SECO Mind Srl
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule Edgehog.Devices do
   @moduledoc """
@@ -42,7 +40,8 @@ defmodule Edgehog.Devices do
 
       list Device, :devices, :read do
         description "Returns a list of devices."
-        paginate_with nil
+        paginate_with :keyset
+        relay? true
       end
 
       get HardwareType, :hardware_type, :read do
@@ -51,7 +50,8 @@ defmodule Edgehog.Devices do
 
       list HardwareType, :hardware_types, :read do
         description "Returns a list of hardware types."
-        paginate_with nil
+        paginate_with :keyset
+        relay? true
       end
 
       get SystemModel, :system_model, :read do
@@ -60,7 +60,8 @@ defmodule Edgehog.Devices do
 
       list SystemModel, :system_models, :read do
         description "Returns a list of system models."
-        paginate_with nil
+        relay? true
+        paginate_with :keyset
       end
     end
 

--- a/backend/lib/edgehog/devices/hardware_type.ex
+++ b/backend/lib/edgehog/devices/hardware_type.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ defmodule Edgehog.Devices.HardwareType do
 
   graphql do
     type :hardware_type
+
+    paginate_relationship_with part_numbers: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/devices/system_model/system_model.ex
+++ b/backend/lib/edgehog/devices/system_model/system_model.ex
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule Edgehog.Devices.SystemModel do
   @moduledoc false
@@ -43,6 +41,8 @@ defmodule Edgehog.Devices.SystemModel do
 
   graphql do
     type :system_model
+
+    paginate_relationship_with part_numbers: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/devices/system_model_part_number.ex
+++ b/backend/lib/edgehog/devices/system_model_part_number.ex
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule Edgehog.Devices.SystemModelPartNumber do
   @moduledoc false
@@ -28,6 +26,8 @@ defmodule Edgehog.Devices.SystemModelPartNumber do
 
   graphql do
     type :system_model_part_number
+
+    paginate_relationship_with devices: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/groups/device_group/device_group.ex
+++ b/backend/lib/edgehog/groups/device_group/device_group.ex
@@ -31,6 +31,8 @@ defmodule Edgehog.Groups.DeviceGroup do
 
   graphql do
     type :device_group
+
+    # TODO: paginate `device` relationship with relay
   end
 
   actions do

--- a/backend/lib/edgehog/groups/groups.ex
+++ b/backend/lib/edgehog/groups/groups.ex
@@ -37,7 +37,8 @@ defmodule Edgehog.Groups do
 
       list DeviceGroup, :device_groups, :read do
         description "Returns a list of device groups."
-        paginate_with nil
+        paginate_with :keyset
+        relay? true
       end
     end
 

--- a/backend/lib/edgehog/labeling/labeling.ex
+++ b/backend/lib/edgehog/labeling/labeling.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022-2024 SECO Mind Srl
+# Copyright 2022 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ defmodule Edgehog.Labeling do
 
     queries do
       list Tag, :existing_device_tags, :read_assigned_to_devices do
-        paginate_with nil
+        description "Returns the list of device tags associated to some device group."
+        relay? true
+        paginate_with :keyset
       end
     end
   end

--- a/backend/lib/edgehog/labeling/tag.ex
+++ b/backend/lib/edgehog/labeling/tag.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ defmodule Edgehog.Labeling.Tag do
 
   graphql do
     type :tag
+
+    paginate_relationship_with device_tags: :relay
   end
 
   actions do
@@ -52,6 +54,13 @@ defmodule Edgehog.Labeling.Tag do
     read :read_assigned_to_devices do
       description "Returns Tags currently assigned to some device."
       prepare build(filter: expr(exists(device_tags, true)))
+
+      pagination do
+        required? false
+        offset? true
+        keyset? true
+        countable true
+      end
     end
   end
 

--- a/backend/lib/edgehog/update_campaigns/update_campaign/update_campaign.ex
+++ b/backend/lib/edgehog/update_campaigns/update_campaign/update_campaign.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023-2024 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ defmodule Edgehog.UpdateCampaigns.UpdateCampaign do
 
   graphql do
     type :update_campaign
+
+    paginate_relationship_with update_targets: :relay
   end
 
   actions do

--- a/backend/lib/edgehog/update_campaigns/update_campaigns.ex
+++ b/backend/lib/edgehog/update_campaigns/update_campaigns.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023-2024 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ defmodule Edgehog.UpdateCampaigns do
 
       list UpdateCampaign, :update_campaigns, :read do
         description "Returns a list of update campaigns."
-        paginate_with nil
+        paginate_with :keyset
+        relay? true
       end
 
       get UpdateChannel, :update_channel, :read do
@@ -50,7 +51,8 @@ defmodule Edgehog.UpdateCampaigns do
 
       list UpdateChannel, :update_channels, :read do
         description "Returns a list of update channels."
-        paginate_with nil
+        paginate_with :keyset
+        relay? true
       end
     end
 

--- a/backend/lib/edgehog/update_campaigns/update_channel/update_channel.ex
+++ b/backend/lib/edgehog/update_campaigns/update_channel/update_channel.ex
@@ -43,6 +43,8 @@ defmodule Edgehog.UpdateCampaigns.UpdateChannel do
     type :update_channel
 
     error_handler {ErrorHandler, :handle_error, []}
+
+    paginate_relationship_with target_groups: :relay, update_campaigns: :relay
   end
 
   actions do

--- a/backend/test/edgehog_web/schema/mutation/create_base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_base_image_collection_test.exs
@@ -44,6 +44,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateBaseImageCollectionTest do
                  "id" => ^system_model_id,
                  "name" => ^system_model_name,
                  "handle" => ^system_model_handle
+               },
+               "baseImages" => %{
+                 "edges" => []
                }
              } = base_image_collection
     end
@@ -158,6 +161,15 @@ defmodule EdgehogWeb.Schema.Mutation.CreateBaseImageCollectionTest do
             id
             name
             handle
+          }
+          baseImages {
+            count
+            edges {
+              node {
+                id
+                version
+              }
+            }
           }
         }
       }

--- a/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_hardware_type_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,8 +41,12 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
                "id" => _,
                "name" => "Foobar",
                "handle" => "foobar",
-               "partNumbers" => part_numbers
+               "partNumbers" => %{
+                 "edges" => part_numbers
+               }
              } = hardware_type
+
+      part_numbers = extract_nodes!(part_numbers)
 
       assert length(part_numbers) == 2
       assert %{"partNumber" => "123"} in part_numbers
@@ -126,7 +130,11 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
           name
           handle
           partNumbers {
-            partNumber
+            edges {
+              node {
+                partNumber
+              }
+            }
           }
         }
       }
@@ -174,5 +182,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateHardwareTypeTest do
     assert hardware_type != nil
 
     hardware_type
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_system_model_test.exs
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
   use EdgehogWeb.GraphqlCase, async: true
@@ -49,15 +47,15 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
                "name" => "Foobar",
                "handle" => "foobar",
                "pictureUrl" => nil,
-               "partNumbers" => part_numbers,
+               "partNumbers" => %{"edges" => part_numbers},
                "hardwareType" => %{
                  "id" => ^hardware_type_id
                }
              } = system_model
 
       assert length(part_numbers) == 2
-      assert %{"partNumber" => "123"} in part_numbers
-      assert %{"partNumber" => "456"} in part_numbers
+      assert %{"node" => %{"partNumber" => "123"}} in part_numbers
+      assert %{"node" => %{"partNumber" => "456"}} in part_numbers
     end
 
     test "allows passing localized descriptions", %{tenant: tenant} do
@@ -233,7 +231,11 @@ defmodule EdgehogWeb.Schema.Mutation.CreateSystemModelTest do
           handle
           pictureUrl
           partNumbers {
-            partNumber
+            edges {
+              node {
+                partNumber
+              }
+            }
           }
           hardwareType {
             id

--- a/backend/test/edgehog_web/schema/mutation/create_update_campaign_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_update_campaign_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023-2024 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
       assert update_campaign_data["updateChannel"]["id"] == update_channel_id
       assert update_campaign_data["updateChannel"]["name"] == update_channel.name
       assert update_campaign_data["updateChannel"]["handle"] == update_channel.handle
-      assert [target_data] = update_campaign_data["updateTargets"]
+      assert [target_data] = extract_nodes!(update_campaign_data["updateTargets"]["edges"])
       assert target_data["status"] == "IDLE"
       assert target_data["device"]["id"] == AshGraphql.Resource.encode_relay_id(device)
 
@@ -81,7 +81,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
       assert update_campaign_data["name"] == "My Update Campaign"
       assert update_campaign_data["status"] == "FINISHED"
       assert update_campaign_data["outcome"] == "SUCCESS"
-      assert update_campaign_data["updateTargets"] == []
+      assert update_campaign_data["updateTargets"]["edges"] == []
 
       # Check that no executor got started
       update_campaign = fetch_update_campaign_from_graphql_id!(tenant, update_campaign_data["id"])
@@ -353,9 +353,13 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
             handle
           }
           updateTargets {
-            status
-            device {
-              id
+            edges {
+              node {
+                status
+                device {
+                  id
+                }
+              }
             }
           }
         }
@@ -460,5 +464,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateCampaignTest do
       [] -> :error
       [{pid, _}] -> {:ok, pid}
     end
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/create_update_channel_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_update_channel_test.exs
@@ -43,7 +43,10 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateChannelTest do
 
       assert update_channel_data["name"] == "My Update Channel"
       assert update_channel_data["handle"] == "my-update-channel"
-      assert [target_group_data] = update_channel_data["targetGroups"]
+
+      assert [target_group_data] =
+               extract_nodes!(update_channel_data["targetGroups"]["edges"])
+
       assert target_group_data["id"] == target_group_id
       assert target_group_data["name"] == target_group.name
       assert target_group_data["handle"] == target_group.handle
@@ -60,7 +63,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateChannelTest do
 
       assert result["name"] == name
       assert result["handle"] == handle
-      assert result["targetGroups"] == []
+      assert result["targetGroups"]["edges"] == []
     end
 
     test "creates update_channel with empty target_group_ids", %{tenant: tenant} do
@@ -74,7 +77,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateChannelTest do
 
       assert result["name"] == name
       assert result["handle"] == handle
-      assert result["targetGroups"] == []
+      assert result["targetGroups"]["edges"] == []
     end
 
     test "fails with missing name", %{tenant: tenant} do
@@ -222,9 +225,13 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateChannelTest do
           name
           handle
           targetGroups {
-            id
-            name
-            handle
+            edges {
+              node {
+                id
+                name
+                handle
+              }
+            }
           }
         }
       }
@@ -285,5 +292,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateUpdateChannelTest do
     :ok = Ash.destroy!(fixture)
 
     id
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/update_device_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_device_test.exs
@@ -52,6 +52,13 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateDeviceTest do
           name
           deviceId
           online
+          otaOperations {
+            edges {
+              node {
+                id
+              }
+            }
+          }
         }
       }
     }

--- a/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_hardware_type_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,9 +56,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
                "id" => _id,
                "name" => "Updated Name",
                "handle" => "updatedhandle",
-               "partNumbers" => [
-                 %{"partNumber" => "updated-1234"}
-               ]
+               "partNumbers" => %{
+                 "edges" => [
+                   %{"node" => %{"partNumber" => "updated-1234"}}
+                 ]
+               }
              } = hardware_type
     end
 
@@ -77,8 +79,12 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
       assert %{
                "name" => "Only Name Update",
                "handle" => ^old_handle,
-               "partNumbers" => part_numbers
+               "partNumbers" => %{
+                 "edges" => part_numbers
+               }
              } = hardware_type
+
+      part_numbers = extract_nodes!(part_numbers)
 
       assert length(part_numbers) == length(old_part_numbers)
 
@@ -99,7 +105,10 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
 
       hardware_type = extract_result!(result)
 
-      assert %{"partNumbers" => part_numbers} = hardware_type
+      assert %{"partNumbers" => %{"edges" => part_numbers}} = hardware_type
+
+      part_numbers = extract_nodes!(part_numbers)
+
       assert length(part_numbers) == 2
       assert %{"partNumber" => "B"} in part_numbers
       assert %{"partNumber" => "D"} in part_numbers
@@ -202,7 +211,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
           name
           handle
           partNumbers {
-            partNumber
+            edges {
+              node {
+                partNumber
+              }
+            }
           }
         }
       }
@@ -254,5 +267,9 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateHardwareTypeTest do
     assert hardware_type != nil
 
     hardware_type
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_system_model_test.exs
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
   use EdgehogWeb.GraphqlCase, async: true
@@ -57,9 +55,13 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
                "id" => _id,
                "name" => "Updated Name",
                "handle" => "updatedhandle",
-               "partNumbers" => [
-                 %{"partNumber" => "updated-1234"}
-               ]
+               "partNumbers" => %{
+                 "edges" => [
+                   %{
+                     "node" => %{"partNumber" => "updated-1234"}
+                   }
+                 ]
+               }
              } = system_model
     end
 
@@ -78,13 +80,15 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
       assert %{
                "name" => "Only Name Update",
                "handle" => ^old_handle,
-               "partNumbers" => part_numbers
+               "partNumbers" => %{
+                 "edges" => part_numbers
+               }
              } = system_model
 
       assert length(part_numbers) == length(old_part_numbers)
 
       Enum.each(old_part_numbers, fn pn ->
-        assert %{"partNumber" => pn} in part_numbers
+        assert %{"node" => %{"partNumber" => pn}} in part_numbers
       end)
     end
 
@@ -100,10 +104,10 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
 
       system_model = extract_result!(result)
 
-      assert %{"partNumbers" => part_numbers} = system_model
+      assert %{"partNumbers" => %{"edges" => part_numbers}} = system_model
       assert length(part_numbers) == 2
-      assert %{"partNumber" => "B"} in part_numbers
-      assert %{"partNumber" => "D"} in part_numbers
+      assert %{"node" => %{"partNumber" => "B"}} in part_numbers
+      assert %{"node" => %{"partNumber" => "D"}} in part_numbers
     end
 
     test "allows updating localized descriptions", %{tenant: tenant} do
@@ -387,7 +391,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateSystemModelTest do
           handle
           pictureUrl
           partNumbers {
-            partNumber
+            edges {
+              node {
+                partNumber
+              }
+            }
           }
         }
       }

--- a/backend/test/edgehog_web/schema/mutation/update_update_channel_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_update_channel_test.exs
@@ -50,7 +50,10 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateUpdateChannelTest do
       assert update_channel_data["id"] == id
       assert update_channel_data["name"] == "Updated name"
       assert update_channel_data["handle"] == "updated-handle"
-      assert [target_group_data] = update_channel_data["targetGroups"]
+
+      assert [target_group_data] =
+               extract_nodes!(update_channel_data["targetGroups"]["edges"])
+
       assert target_group_data["id"] == target_group_id
       assert target_group_data["name"] == target_group.name
       assert target_group_data["handle"] == target_group.handle
@@ -188,9 +191,13 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateUpdateChannelTest do
           name
           handle
           targetGroups {
-            id
-            name
-            handle
+            edges {
+              node {
+                id
+                name
+                handle
+              }
+            }
           }
         }
       }
@@ -245,5 +252,9 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateUpdateChannelTest do
     :ok = Ash.destroy!(fixture)
 
     id
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/backend/test/edgehog_web/schema/query/base_image_collection_test.exs
+++ b/backend/test/edgehog_web/schema/query/base_image_collection_test.exs
@@ -69,12 +69,17 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionTest do
       result = base_image_collection_query(tenant: tenant, id: base_image_collection_id)
 
       assert %{
-               "baseImages" => [
-                 %{
-                   "id" => ^base_image_id,
-                   "version" => "2.0.0"
-                 }
-               ]
+               "baseImages" => %{
+                 "count" => 1,
+                 "edges" => [
+                   %{
+                     "node" => %{
+                       "id" => ^base_image_id,
+                       "version" => "2.0.0"
+                     }
+                   }
+                 ]
+               }
              } = extract_result!(result)
     end
   end
@@ -94,8 +99,13 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionTest do
         name
         handle
         baseImages {
-          id
-          version
+          count
+          edges {
+            node {
+              id
+              version
+            }
+          }
         }
         systemModel {
           id

--- a/backend/test/edgehog_web/schema/query/base_image_collections_test.exs
+++ b/backend/test/edgehog_web/schema/query/base_image_collections_test.exs
@@ -26,8 +26,7 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionsTest do
 
   describe "baseImageCollections field" do
     test "returns empty base image collections", %{tenant: tenant} do
-      assert %{data: %{"baseImageCollections" => []}} ==
-               base_image_collections_query(tenant: tenant)
+      assert [] = [tenant: tenant] |> base_image_collections_query() |> extract_result!()
     end
 
     test "returns base image collections if they're present", %{tenant: tenant} do
@@ -39,8 +38,8 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionsTest do
           system_model_id: system_model.id
         )
 
-      assert %{data: %{"baseImageCollections" => [base_image_collection]}} =
-               base_image_collections_query(tenant: tenant)
+      assert [base_image_collection] =
+               [tenant: tenant] |> base_image_collections_query() |> extract_result!()
 
       assert base_image_collection["name"] == fixture.name
       assert base_image_collection["handle"] == fixture.handle
@@ -55,10 +54,15 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionsTest do
       """
       query BaseImageCollections($filter: BaseImageCollectionFilterInput, $sort: [BaseImageCollectionSortInput]) {
         baseImageCollections(filter: $filter, sort: $sort) {
-          name
-          handle
-          systemModel {
-            id
+          count
+          edges {
+            node {
+              name
+              handle
+              systemModel {
+                id
+              }
+            }
           }
         }
       }
@@ -74,5 +78,16 @@ defmodule EdgehogWeb.Schema.Query.BaseImageCollectionsTest do
       }
 
     Absinthe.run!(document, EdgehogWeb.Schema, variables: variables, context: %{tenant: tenant})
+  end
+
+  defp extract_result!(result) do
+    assert %{data: %{"baseImageCollections" => %{"count" => count, "edges" => edges}}} = result
+    refute :errors in Map.keys(result)
+
+    base_image_collections = Enum.map(edges, & &1["node"])
+
+    assert length(base_image_collections) == count
+
+    base_image_collections
   end
 end

--- a/backend/test/edgehog_web/schema/query/system_model_test.exs
+++ b/backend/test/edgehog_web/schema/query/system_model_test.exs
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule EdgehogWeb.Schema.Query.SystemModelTest do
   use EdgehogWeb.GraphqlCase, async: true
@@ -46,10 +44,10 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
       assert system_model["name"] == fixture.name
       assert system_model["handle"] == fixture.handle
       assert system_model["pictureUrl"] == fixture.picture_url
-      assert length(system_model["partNumbers"]) == length(fixture.part_number_strings)
+      assert length(system_model["partNumbers"]["edges"]) == length(fixture.part_number_strings)
 
       Enum.each(fixture.part_number_strings, fn pn ->
-        assert(%{"partNumber" => pn} in system_model["partNumbers"])
+        assert(%{"node" => %{"partNumber" => pn}} in system_model["partNumbers"]["edges"])
       end)
 
       assert system_model["hardwareType"]["id"] ==
@@ -164,7 +162,11 @@ defmodule EdgehogWeb.Schema.Query.SystemModelTest do
         handle
         pictureUrl
         partNumbers {
-          partNumber
+          edges {
+            node {
+              partNumber
+            }
+          }
         }
         hardwareType {
           id

--- a/backend/test/edgehog_web/schema/query/update_channel_test.exs
+++ b/backend/test/edgehog_web/schema/query/update_channel_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023-2024 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ defmodule EdgehogWeb.Schema.Query.UpdateChannelTest do
 
       assert update_channel_data["handle"] == update_channel.handle
       assert update_channel_data["name"] == update_channel.name
-      assert [response_group] = update_channel_data["targetGroups"]
+      assert [response_group] = extract_nodes!(update_channel_data["targetGroups"]["edges"])
       assert response_group["handle"] == target_group.handle
       assert response_group["name"] == target_group.name
     end
@@ -57,8 +57,12 @@ defmodule EdgehogWeb.Schema.Query.UpdateChannelTest do
         handle
         name
         targetGroups {
-          name
-          handle
+          edges {
+            node {
+              name
+              handle
+            }
+          }
         }
       }
     }
@@ -95,5 +99,9 @@ defmodule EdgehogWeb.Schema.Query.UpdateChannelTest do
     :ok = Ash.destroy!(fixture)
 
     id
+  end
+
+  defp extract_nodes!(data) do
+    Enum.map(data, &Map.fetch!(&1, "node"))
   end
 end

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -485,6 +485,27 @@ enum BaseImageCollectionSortField {
   HANDLE
 }
 
+":base_image_collection connection"
+type BaseImageCollectionConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":base_image_collection edges"
+  edges: [BaseImageCollectionEdge!]
+}
+
+":base_image_collection edge"
+type BaseImageCollectionEdge {
+  "Cursor"
+  cursor: String!
+
+  ":base_image_collection node"
+  node: BaseImageCollection!
+}
+
 input BaseImageCollectionFilterHandle {
   isNil: Boolean
   eq: String
@@ -582,12 +603,18 @@ type BaseImageCollection implements Node {
     "A filter to limit the results"
     filter: BaseImageFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [BaseImage!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): BaseImageConnection!
 }
 
 "The result of the :delete_base_image mutation"
@@ -653,6 +680,27 @@ enum BaseImageSortField {
   VERSION
   STARTING_VERSION_REQUIREMENT
   URL
+}
+
+":base_image connection"
+type BaseImageConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":base_image edges"
+  edges: [BaseImageEdge!]
+}
+
+":base_image edge"
+type BaseImageEdge {
+  "Cursor"
+  cursor: String!
+
+  ":base_image node"
+  node: BaseImage!
 }
 
 input BaseImageFilterUrl {
@@ -761,6 +809,21 @@ type BaseImage implements Node {
   ): [LocalizedAttribute!]
 }
 
+"A relay page info"
+type PageInfo {
+  "When paginating backwards, are there more items?"
+  hasPreviousPage: Boolean!
+
+  "When paginating forwards, are there more items?"
+  hasNextPage: Boolean!
+
+  "When paginating backwards, the cursor to continue"
+  startCursor: String
+
+  "When paginating forwards, the cursor to continue"
+  endCursor: String
+}
+
 "A relay node"
 interface Node {
   "A unique identifier"
@@ -797,6 +860,27 @@ type MutationError {
 enum SystemModelPartNumberSortField {
   ID
   PART_NUMBER
+}
+
+":system_model_part_number connection"
+type SystemModelPartNumberConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":system_model_part_number edges"
+  edges: [SystemModelPartNumberEdge!]
+}
+
+":system_model_part_number edge"
+type SystemModelPartNumberEdge {
+  "Cursor"
+  cursor: String!
+
+  ":system_model_part_number node"
+  node: SystemModelPartNumber!
 }
 
 input SystemModelPartNumberFilterPartNumber {
@@ -942,6 +1026,27 @@ enum SystemModelSortField {
   PICTURE_URL
 }
 
+":system_model connection"
+type SystemModelConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":system_model edges"
+  edges: [SystemModelEdge!]
+}
+
+":system_model edge"
+type SystemModelEdge {
+  "Cursor"
+  cursor: String!
+
+  ":system_model node"
+  node: SystemModel!
+}
+
 input SystemModelFilterPictureUrl {
   isNil: Boolean
   eq: String
@@ -1056,12 +1161,18 @@ type SystemModel implements Node {
     "A filter to limit the results"
     filter: SystemModelPartNumberFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [SystemModelPartNumber!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): SystemModelPartNumberConnection!
 
   "The Hardware type associated with the System Model"
   hardwareType: HardwareType
@@ -1073,6 +1184,27 @@ type SystemModel implements Node {
 enum HardwareTypePartNumberSortField {
   ID
   PART_NUMBER
+}
+
+":hardware_type_part_number connection"
+type HardwareTypePartNumberConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":hardware_type_part_number edges"
+  edges: [HardwareTypePartNumberEdge!]
+}
+
+":hardware_type_part_number edge"
+type HardwareTypePartNumberEdge {
+  "Cursor"
+  cursor: String!
+
+  ":hardware_type_part_number node"
+  node: HardwareTypePartNumber!
 }
 
 input HardwareTypePartNumberFilterPartNumber {
@@ -1190,6 +1322,27 @@ enum HardwareTypeSortField {
   NAME
 }
 
+":hardware_type connection"
+type HardwareTypeConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":hardware_type edges"
+  edges: [HardwareTypeEdge!]
+}
+
+":hardware_type edge"
+type HardwareTypeEdge {
+  "Cursor"
+  cursor: String!
+
+  ":hardware_type node"
+  node: HardwareType!
+}
+
 input HardwareTypeFilterName {
   isNil: Boolean
   eq: String
@@ -1284,12 +1437,18 @@ type HardwareType implements Node {
     "A filter to limit the results"
     filter: HardwareTypePartNumberFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [HardwareTypePartNumber!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): HardwareTypePartNumberConnection!
 }
 
 "The result of the :set_device_led_behavior mutation"
@@ -1354,6 +1513,27 @@ enum DeviceSortField {
   LAST_CONNECTION
   LAST_DISCONNECTION
   SERIAL_NUMBER
+}
+
+":device connection"
+type DeviceConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":device edges"
+  edges: [DeviceEdge!]
+}
+
+":device edge"
+type DeviceEdge {
+  "Cursor"
+  cursor: String!
+
+  ":device node"
+  node: Device!
 }
 
 input DeviceFilterSerialNumber {
@@ -1523,12 +1703,18 @@ type Device implements Node {
     "A filter to limit the results"
     filter: TagFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [Tag!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): TagConnection!
 
   "The groups the device belongs to."
   deviceGroups(
@@ -1553,12 +1739,18 @@ type Device implements Node {
     "A filter to limit the results"
     filter: OtaOperationFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [OtaOperation!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): OtaOperationConnection!
 
   "The capabilities that the device can support."
   capabilities: [DeviceCapability!]!
@@ -1714,6 +1906,27 @@ enum DeviceGroupSortField {
   SELECTOR
 }
 
+":device_group connection"
+type DeviceGroupConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":device_group edges"
+  edges: [DeviceGroupEdge!]
+}
+
+":device_group edge"
+type DeviceGroupEdge {
+  "Cursor"
+  cursor: String!
+
+  ":device_group node"
+  node: DeviceGroup!
+}
+
 input DeviceGroupFilterSelector {
   isNil: Boolean
   eq: String
@@ -1846,6 +2059,27 @@ enum TagSortField {
   NAME
 }
 
+":tag connection"
+type TagConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":tag edges"
+  edges: [TagEdge!]
+}
+
+":tag edge"
+type TagEdge {
+  "Cursor"
+  cursor: String!
+
+  ":tag node"
+  node: Tag!
+}
+
 input TagFilterName {
   isNil: Boolean
   eq: String
@@ -1915,6 +2149,27 @@ enum OtaOperationSortField {
   MESSAGE
   CREATED_AT
   UPDATED_AT
+}
+
+":ota_operation connection"
+type OtaOperationConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":ota_operation edges"
+  edges: [OtaOperationEdge!]
+}
+
+":ota_operation edge"
+type OtaOperationEdge {
+  "Cursor"
+  cursor: String!
+
+  ":ota_operation node"
+  node: OtaOperation!
 }
 
 input OtaOperationFilterUpdatedAt {
@@ -2110,6 +2365,27 @@ enum UpdateTargetSortField {
   COMPLETION_TIMESTAMP
 }
 
+":update_target connection"
+type UpdateTargetConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_target edges"
+  edges: [UpdateTargetEdge!]
+}
+
+":update_target edge"
+type UpdateTargetEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_target node"
+  node: UpdateTarget!
+}
+
 input UpdateTargetFilterCompletionTimestamp {
   isNil: Boolean
   eq: DateTime
@@ -2294,6 +2570,27 @@ enum UpdateChannelSortField {
   NAME
 }
 
+":update_channel connection"
+type UpdateChannelConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_channel edges"
+  edges: [UpdateChannelEdge!]
+}
+
+":update_channel edge"
+type UpdateChannelEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_channel node"
+  node: UpdateChannel!
+}
+
 input UpdateChannelFilterName {
   isNil: Boolean
   eq: String
@@ -2385,12 +2682,18 @@ type UpdateChannel implements Node {
     "A filter to limit the results"
     filter: DeviceGroupFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [DeviceGroup!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): DeviceGroupConnection!
 }
 
 "The result of the :create_update_campaign mutation"
@@ -2426,6 +2729,27 @@ enum UpdateCampaignSortField {
   IN_PROGRESS_TARGET_COUNT
   FAILED_TARGET_COUNT
   SUCCESSFUL_TARGET_COUNT
+}
+
+":update_campaign connection"
+type UpdateCampaignConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":update_campaign edges"
+  edges: [UpdateCampaignEdge!]
+}
+
+":update_campaign edge"
+type UpdateCampaignEdge {
+  "Cursor"
+  cursor: String!
+
+  ":update_campaign node"
+  node: UpdateCampaign!
 }
 
 input UpdateCampaignFilterSuccessfulTargetCount {
@@ -2611,12 +2935,18 @@ type UpdateCampaign implements Node {
     "A filter to limit the results"
     filter: UpdateTargetFilterInput
 
-    "The number of records to return."
-    limit: Int
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
 
-    "The number of records to skip."
-    offset: Int
-  ): [UpdateTarget!]!
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateTargetConnection!
 
   "The total number of update targets."
   totalTargetCount: Int!
@@ -2645,7 +2975,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: UpdateCampaignFilterInput
-  ): [UpdateCampaign!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateCampaignConnection
 
   "Returns a single update channel."
   updateChannel("The id of the record" id: ID!): UpdateChannel
@@ -2657,19 +2999,43 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: UpdateChannelFilterInput
-  ): [UpdateChannel!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): UpdateChannelConnection
 
   "Retrieves the current tenant."
   tenantInfo: TenantInfo!
 
-  "Returns Tags currently assigned to some device."
+  "Returns the list of device tags associated to some device group."
   existingDeviceTags(
     "How to sort the records in the response"
     sort: [TagSortInput]
 
     "A filter to limit the results"
     filter: TagFilterInput
-  ): [Tag!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): TagConnection
 
   "Returns a single device group."
   deviceGroup("The id of the record" id: ID!): DeviceGroup
@@ -2681,7 +3047,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: DeviceGroupFilterInput
-  ): [DeviceGroup!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): DeviceGroupConnection
 
   """
   Fetches the forwarder config, if available.
@@ -2702,7 +3080,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: DeviceFilterInput
-  ): [Device!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): DeviceConnection
 
   "Returns a single hardware type."
   hardwareType("The id of the record" id: ID!): HardwareType
@@ -2714,7 +3104,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: HardwareTypeFilterInput
-  ): [HardwareType!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): HardwareTypeConnection
 
   "Returns a single system model."
   systemModel("The id of the record" id: ID!): SystemModel
@@ -2726,7 +3128,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: SystemModelFilterInput
-  ): [SystemModel!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): SystemModelConnection
 
   "Retrieves a Node from its global id"
   node("The Node unique identifier" id: ID!): Node!
@@ -2744,7 +3158,19 @@ type RootQueryType {
 
     "A filter to limit the results"
     filter: BaseImageCollectionFilterInput
-  ): [BaseImageCollection!]!
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): BaseImageCollectionConnection
 }
 
 type RootMutationType {

--- a/frontend/src/components/BaseImageCollectionsTable.tsx
+++ b/frontend/src/components/BaseImageCollectionsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,33 +18,50 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import _ from "lodash";
 
+import type { BaseImageCollectionsTable_PaginationQuery } from "api/__generated__/BaseImageCollectionsTable_PaginationQuery.graphql";
 import type {
   BaseImageCollectionsTable_BaseImageCollectionFragment$data,
   BaseImageCollectionsTable_BaseImageCollectionFragment$key,
 } from "api/__generated__/BaseImageCollectionsTable_BaseImageCollectionFragment.graphql";
 
-import Table, { createColumnHelper } from "components/Table";
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "./InfiniteTable";
 import { Link, Route } from "Navigation";
 
+const BASE_IMAGE_COLLECTIONS_TO_LOAD_FIRST = 40;
+const BASE_IMAGE_COLLECTIONS_TO_LOAD_NEXT = 10;
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const BASE_IMAGE_COLLECTIONS_TABLE_FRAGMENT = graphql`
-  fragment BaseImageCollectionsTable_BaseImageCollectionFragment on BaseImageCollection
-  @relay(plural: true) {
-    id
-    name
-    handle
-    systemModel {
-      name
+  fragment BaseImageCollectionsTable_BaseImageCollectionFragment on RootQueryType
+  @refetchable(queryName: "BaseImageCollectionsTable_PaginationQuery")
+  @argumentDefinitions(filter: { type: "BaseImageCollectionFilterInput" }) {
+    baseImageCollections(first: $first, after: $after, filter: $filter)
+      @connection(key: "BaseImageCollectionsTable_baseImageCollections") {
+      edges {
+        node {
+          id
+          name
+          handle
+          systemModel {
+            name
+          }
+        }
+      }
     }
   }
 `;
 
-type TableRecord =
-  BaseImageCollectionsTable_BaseImageCollectionFragment$data[number];
+type TableRecord = NonNullable<
+  NonNullable<
+    BaseImageCollectionsTable_BaseImageCollectionFragment$data["baseImageCollections"]
+  >["edges"]
+>[number]["node"];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
@@ -96,16 +113,85 @@ const BaseImageCollectionsTable = ({
   className,
   baseImageCollectionsRef,
 }: Props) => {
-  const baseImageCollections = useFragment(
-    BASE_IMAGE_COLLECTIONS_TABLE_FRAGMENT,
-    baseImageCollectionsRef,
+  const {
+    data: paginationData,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<
+    BaseImageCollectionsTable_PaginationQuery,
+    BaseImageCollectionsTable_BaseImageCollectionFragment$key
+  >(BASE_IMAGE_COLLECTIONS_TABLE_FRAGMENT, baseImageCollectionsRef);
+  const [searchText, setSearchText] = useState<string | null>(null);
+
+  const debounceRefetch = useMemo(
+    () =>
+      _.debounce((text: string) => {
+        if (text === "") {
+          refetch(
+            {
+              first: BASE_IMAGE_COLLECTIONS_TO_LOAD_FIRST,
+            },
+            { fetchPolicy: "network-only" },
+          );
+        } else {
+          refetch(
+            {
+              first: BASE_IMAGE_COLLECTIONS_TO_LOAD_FIRST,
+              filter: {
+                or: [
+                  { name: { ilike: `%${text}%` } },
+                  { handle: { ilike: `%${text}%` } },
+                  {
+                    systemModel: {
+                      name: {
+                        ilike: `%${text}%`,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            { fetchPolicy: "network-only" },
+          );
+        }
+      }, 500),
+    [refetch],
   );
 
+  useEffect(() => {
+    if (searchText !== null) {
+      debounceRefetch(searchText);
+    }
+  }, [debounceRefetch, searchText]);
+
+  const loadNextBaseImageCollections = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(BASE_IMAGE_COLLECTIONS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const baseImageCollections = useMemo(() => {
+    return (
+      paginationData.baseImageCollections?.edges
+        ?.map((edge) => edge?.node)
+        .filter((node): node is TableRecord => node != null) ?? []
+    );
+  }, [paginationData]);
+
+  if (!paginationData.baseImageCollections) {
+    return null;
+  }
+
   return (
-    <Table
+    <InfiniteTable
       className={className}
       columns={columns}
       data={baseImageCollections}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextBaseImageCollections : undefined}
+      setSearchText={setSearchText}
     />
   );
 };

--- a/frontend/src/components/BaseImageSelect.tsx
+++ b/frontend/src/components/BaseImageSelect.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -38,15 +38,21 @@ import Stack from "components/Stack";
 
 type SelectProps = ComponentProps<typeof Form.Select>;
 type BaseImage = NonNullable<
-  BaseImageSelect_getBaseImages_Query$data["baseImageCollection"]
->["baseImages"][number];
+  NonNullable<
+    BaseImageSelect_getBaseImages_Query$data["baseImageCollection"]
+  >["baseImages"]["edges"]
+>[number]["node"];
 
 const GET_BASE_IMAGES_QUERY = graphql`
   query BaseImageSelect_getBaseImages_Query($baseImageCollectionId: ID!) {
     baseImageCollection(id: $baseImageCollectionId) {
       baseImages {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
     }
   }
@@ -97,13 +103,10 @@ const BaseImageSelectContent = forwardRef<
     return notFoundComponent;
   }
 
-  return (
-    <BaseImageSelect
-      {...selectProps}
-      baseImages={baseImageCollection.baseImages}
-      ref={ref}
-    />
-  );
+  const baseImages =
+    baseImageCollection.baseImages.edges?.map((edge) => edge.node) ?? [];
+
+  return <BaseImageSelect {...selectProps} baseImages={baseImages} ref={ref} />;
 });
 BaseImageSelectContent.displayName = "BaseImageSelectContent";
 

--- a/frontend/src/components/BaseImagesTable.tsx
+++ b/frontend/src/components/BaseImagesTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,37 +18,51 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import _ from "lodash";
 
+import type { BaseImagesTable_PaginationQuery } from "api/__generated__/BaseImagesTable_PaginationQuery.graphql";
 import type {
   BaseImagesTable_BaseImagesFragment$data,
   BaseImagesTable_BaseImagesFragment$key,
 } from "api/__generated__/BaseImagesTable_BaseImagesFragment.graphql";
 
-import Table, { createColumnHelper } from "components/Table";
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "components/InfiniteTable";
 import { Link, Route } from "Navigation";
+
+const BASE_IMAGES_TO_LOAD_FIRST = 40;
+const BASE_IMAGES_TO_LOAD_NEXT = 10;
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const BASE_IMAGES_TABLE_FRAGMENT = graphql`
-  fragment BaseImagesTable_BaseImagesFragment on BaseImageCollection {
+  fragment BaseImagesTable_BaseImagesFragment on BaseImageCollection
+  @refetchable(queryName: "BaseImagesTable_PaginationQuery")
+  @argumentDefinitions(filter: { type: "BaseImageFilterInput" }) {
     id
-    baseImages {
-      id
-      version
-      startingVersionRequirement
-      localizedReleaseDisplayNames {
-        value
-        languageTag
+    baseImages(first: $first, after: $after, filter: $filter)
+      @connection(key: "BaseImagesTable_baseImages") {
+      edges {
+        node {
+          id
+          version
+          startingVersionRequirement
+          localizedReleaseDisplayNames {
+            value
+            languageTag
+          }
+        }
       }
     }
   }
 `;
 
-type TableRecord =
-  BaseImagesTable_BaseImagesFragment$data["baseImages"][number];
+type TableRecord = NonNullable<
+  NonNullable<BaseImagesTable_BaseImagesFragment$data["baseImages"]>["edges"]
+>[number]["node"];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const getColumnsDefinition = (baseImageCollectionId: string) => [
@@ -110,21 +124,89 @@ const BaseImagesTable = ({
   baseImageCollectionRef,
   hideSearch = false,
 }: Props) => {
-  const baseImageCollection = useFragment(
-    BASE_IMAGES_TABLE_FRAGMENT,
-    baseImageCollectionRef,
-  );
+  const {
+    data: paginationData,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<
+    BaseImagesTable_PaginationQuery,
+    BaseImagesTable_BaseImagesFragment$key
+  >(BASE_IMAGES_TABLE_FRAGMENT, baseImageCollectionRef);
+
+  const [searchText, setSearchText] = useState<string | null>(null);
 
   const columns = useMemo(
-    () => getColumnsDefinition(baseImageCollection.id),
-    [baseImageCollection.id],
+    () => getColumnsDefinition(paginationData.id),
+    [paginationData.id],
   );
 
+  const debounceRefetch = useMemo(
+    () =>
+      _.debounce((text: string) => {
+        if (text === "") {
+          refetch(
+            {
+              first: BASE_IMAGES_TO_LOAD_FIRST,
+            },
+            { fetchPolicy: "network-only" },
+          );
+        } else {
+          refetch(
+            {
+              first: BASE_IMAGES_TO_LOAD_FIRST,
+              filter: {
+                or: [
+                  { version: { ilike: `%${text}%` } },
+                  { url: { ilike: `%${text}%` } },
+                  {
+                    startingVersionRequirement: {
+                      ilike: `%${text}%`,
+                    },
+                  },
+                ],
+              },
+            },
+            { fetchPolicy: "network-only" },
+          );
+        }
+      }, 500),
+    [refetch],
+  );
+
+  useEffect(() => {
+    if (searchText !== null) {
+      debounceRefetch(searchText);
+    }
+  }, [debounceRefetch, searchText]);
+
+  const loadNextBaseImageCollections = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(BASE_IMAGES_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const baseImages = useMemo(() => {
+    return (
+      paginationData.baseImages?.edges
+        ?.map((edge) => edge?.node)
+        .filter((node): node is TableRecord => node != null) ?? []
+    );
+  }, [paginationData]);
+
+  if (!paginationData.baseImages) {
+    return null;
+  }
+
   return (
-    <Table
+    <InfiniteTable
       className={className}
       columns={columns}
-      data={baseImageCollection.baseImages}
+      data={baseImages}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextBaseImageCollections : undefined}
+      setSearchText={setSearchText}
       hideSearch={hideSearch}
     />
   );

--- a/frontend/src/components/DeviceGroupsTable.tsx
+++ b/frontend/src/components/DeviceGroupsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022-2023 SECO Mind Srl
+  Copyright 2022-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,30 +18,49 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import _ from "lodash";
 
+import type { DeviceGroupsTable_PaginationQuery } from "api/__generated__/DeviceGroupsTable_PaginationQuery.graphql";
 import type {
   DeviceGroupsTable_DeviceGroupFragment$data,
   DeviceGroupsTable_DeviceGroupFragment$key,
 } from "api/__generated__/DeviceGroupsTable_DeviceGroupFragment.graphql";
 
-import Table, { createColumnHelper } from "components/Table";
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "components/InfiniteTable";
 import { Link, Route } from "Navigation";
+
+const DEVICE_GROUPS_TO_LOAD_FIRST = 40;
+const DEVICE_GROUPS_TO_LOAD_NEXT = 10;
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const DEVICE_GROUPS_TABLE_FRAGMENT = graphql`
-  fragment DeviceGroupsTable_DeviceGroupFragment on DeviceGroup
-  @relay(plural: true) {
-    id
-    name
-    handle
-    selector
+  fragment DeviceGroupsTable_DeviceGroupFragment on RootQueryType
+  @refetchable(queryName: "DeviceGroupsTable_PaginationQuery")
+  @argumentDefinitions(filter: { type: "DeviceGroupFilterInput" }) {
+    deviceGroups(first: $first, after: $after, filter: $filter)
+      @connection(key: "DeviceGroupsTable_deviceGroups") {
+      edges {
+        node {
+          id
+          name
+          handle
+          selector
+        }
+      }
+    }
   }
 `;
 
-type TableRecord = DeviceGroupsTable_DeviceGroupFragment$data[0];
+type TableRecord = NonNullable<
+  NonNullable<
+    DeviceGroupsTable_DeviceGroupFragment$data["deviceGroups"]
+  >["edges"]
+>[number]["node"];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
@@ -85,15 +104,90 @@ const columns = [
 type Props = {
   className?: string;
   deviceGroupsRef: DeviceGroupsTable_DeviceGroupFragment$key;
+  hideSearch?: boolean;
 };
 
-const DeviceGroupsTable = ({ className, deviceGroupsRef }: Props) => {
-  const deviceGroups = useFragment(
-    DEVICE_GROUPS_TABLE_FRAGMENT,
-    deviceGroupsRef,
+const DeviceGroupsTable = ({
+  className,
+  deviceGroupsRef,
+  hideSearch = false,
+}: Props) => {
+  const {
+    data: paginationData,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<
+    DeviceGroupsTable_PaginationQuery,
+    DeviceGroupsTable_DeviceGroupFragment$key
+  >(DEVICE_GROUPS_TABLE_FRAGMENT, deviceGroupsRef);
+  const [searchText, setSearchText] = useState<string | null>(null);
+
+  const debounceRefetch = useMemo(
+    () =>
+      _.debounce((text: string) => {
+        if (text === "") {
+          refetch(
+            {
+              first: DEVICE_GROUPS_TO_LOAD_FIRST,
+            },
+            { fetchPolicy: "network-only" },
+          );
+        } else {
+          refetch(
+            {
+              first: DEVICE_GROUPS_TO_LOAD_FIRST,
+              filter: {
+                or: [
+                  { name: { ilike: `%${text}%` } },
+                  { handle: { ilike: `%${text}%` } },
+                  { selector: { ilike: `%${text}%` } },
+                ],
+              },
+            },
+            { fetchPolicy: "network-only" },
+          );
+        }
+      }, 500),
+    [refetch],
   );
 
-  return <Table className={className} columns={columns} data={deviceGroups} />;
+  useEffect(() => {
+    if (searchText !== null) {
+      debounceRefetch(searchText);
+    }
+  }, [debounceRefetch, searchText]);
+
+  const loadNextDeviceGroups = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(DEVICE_GROUPS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const deviceGroups = useMemo(() => {
+    return (
+      paginationData.deviceGroups?.edges
+        ?.map((edge) => edge?.node)
+        .filter((node): node is TableRecord => node != null) ?? []
+    );
+  }, [paginationData]);
+
+  if (!paginationData.deviceGroups) {
+    return null;
+  }
+
+  return (
+    <InfiniteTable
+      className={className}
+      columns={columns}
+      data={deviceGroups}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextDeviceGroups : undefined}
+      setSearchText={setSearchText}
+      hideSearch={hideSearch}
+    />
+  );
 };
 
 export default DeviceGroupsTable;

--- a/frontend/src/components/DevicesGroupsTable.tsx
+++ b/frontend/src/components/DevicesGroupsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021 - 2025 SECO Mind Srl
+  Copyright 2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,72 +18,58 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, usePaginationFragment } from "react-relay/hooks";
-import _ from "lodash";
+import { graphql, useFragment } from "react-relay/hooks";
 
-import type { DevicesTable_PaginationQuery } from "api/__generated__/DevicesTable_PaginationQuery.graphql";
 import type {
-  DevicesTable_DeviceFragment$data,
-  DevicesTable_DeviceFragment$key,
-} from "api/__generated__/DevicesTable_DeviceFragment.graphql";
+  DevicesGroupsTable_DeviceFragment$data,
+  DevicesGroupsTable_DeviceFragment$key,
+} from "api/__generated__/DevicesGroupsTable_DeviceFragment.graphql";
 
-import ConnectionStatus from "components/ConnectionStatus";
-import { createColumnHelper } from "components/Table";
-import InfiniteTable from "./InfiniteTable";
 import LastSeen from "components/LastSeen";
-import { Link, Route } from "Navigation";
+import Table, { createColumnHelper } from "components/Table";
+import ConnectionStatus from "components/ConnectionStatus";
 import Tag from "components/Tag";
+import { Link, Route } from "Navigation";
 
-const DEVICES_TO_LOAD_FIRST = 40;
-const DEVICES_TO_LOAD_NEXT = 10;
+// TODO This component is being temporarily used in DeviceGroup.tsx
+// to display devices in a group. It should be removed once the
+// backend returns DeviceConnection objects in the group query.
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const DEVICES_TABLE_FRAGMENT = graphql`
-  fragment DevicesTable_DeviceFragment on RootQueryType
-  @refetchable(queryName: "DevicesTable_PaginationQuery")
-  @argumentDefinitions(filter: { type: "DeviceFilterInput" }) {
-    devices(first: $first, after: $after, filter: $filter)
-      @connection(key: "DevicesTable_devices") {
+  fragment DevicesGroupsTable_DeviceFragment on Device @relay(plural: true) {
+    id
+    deviceId
+    lastConnection
+    lastDisconnection
+    name
+    online
+    systemModel {
+      name
+      hardwareType {
+        name
+      }
+    }
+    tags {
       edges {
         node {
-          id
-          deviceId
-          lastConnection
-          lastDisconnection
           name
-          online
-          systemModel {
-            name
-            hardwareType {
-              name
-            }
-          }
-          tags {
-            edges {
-              node {
-                name
-              }
-            }
-          }
         }
       }
     }
   }
 `;
 
-type TableRecord = NonNullable<
-  NonNullable<DevicesTable_DeviceFragment$data["devices"]>["edges"]
->[number]["node"];
+type TableRecord = DevicesGroupsTable_DeviceFragment$data[0];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
   columnHelper.accessor("online", {
     header: () => (
       <FormattedMessage
-        id="components.DevicesTable.statusTitle"
+        id="components.DevicesGroupsTable.statusTitle"
         defaultMessage="Status"
         description="Title for the Status column of the devices table"
       />
@@ -94,7 +80,7 @@ const columns = [
   columnHelper.accessor("name", {
     header: () => (
       <FormattedMessage
-        id="components.DevicesTable.nameTitle"
+        id="components.DevicesGroupsTable.nameTitle"
         defaultMessage="Device Name"
         description="Title for the Name column of the devices table"
       />
@@ -108,7 +94,7 @@ const columns = [
   columnHelper.accessor("deviceId", {
     header: () => (
       <FormattedMessage
-        id="components.DevicesTable.deviceIdTitle"
+        id="components.DevicesGroupsTable.deviceIdTitle"
         defaultMessage="Device ID"
         description="Title for the Device ID column of the devices table"
       />
@@ -142,7 +128,7 @@ const columns = [
       id: "lastSeen",
       header: () => (
         <FormattedMessage
-          id="components.DevicesTable.lastSeenTitle"
+          id="components.DevicesGroupsTable.lastSeenTitle"
           defaultMessage="Last Seen"
           description="Title for the Last Seen column of the devices table"
         />
@@ -160,7 +146,7 @@ const columns = [
     enableSorting: false,
     header: () => (
       <FormattedMessage
-        id="components.DevicesTable.tagsTitle"
+        id="components.DevicesGroupsTable.tagsTitle"
         defaultMessage="Tags"
         description="Title for the Tags column of the devices table"
       />
@@ -179,85 +165,25 @@ const columns = [
 
 type Props = {
   className?: string;
-  devicesRef: DevicesTable_DeviceFragment$key;
+  devicesRef: DevicesGroupsTable_DeviceFragment$key;
+  hideSearch?: boolean;
 };
 
-const DevicesTable = ({ className, devicesRef }: Props) => {
-  const {
-    data: paginationData,
-    loadNext,
-    hasNext,
-    isLoadingNext,
-    refetch,
-  } = usePaginationFragment<
-    DevicesTable_PaginationQuery,
-    DevicesTable_DeviceFragment$key
-  >(DEVICES_TABLE_FRAGMENT, devicesRef);
-
-  const [searchText, setSearchText] = useState<string | null>(null);
-
-  const debounceRefetch = useMemo(
-    () =>
-      _.debounce((text: string) => {
-        if (text === "") {
-          refetch(
-            {
-              first: DEVICES_TO_LOAD_FIRST,
-            },
-            { fetchPolicy: "network-only" },
-          );
-        } else {
-          refetch(
-            {
-              first: DEVICES_TO_LOAD_FIRST,
-              filter: {
-                or: [
-                  { name: { ilike: `%${text}%` } },
-                  { deviceId: { ilike: `%${text}%` } },
-                ],
-              },
-            },
-            { fetchPolicy: "network-only" },
-          );
-        }
-      }, 500),
-    [refetch],
-  );
-
-  useEffect(() => {
-    if (searchText !== null) {
-      debounceRefetch(searchText);
-    }
-  }, [debounceRefetch, searchText]);
-
-  const loadNextDevices = useCallback(() => {
-    if (hasNext && !isLoadingNext) {
-      loadNext(DEVICES_TO_LOAD_NEXT);
-    }
-  }, [hasNext, isLoadingNext, loadNext]);
-
-  const devices = useMemo(() => {
-    return (
-      paginationData.devices?.edges
-        ?.map((edge) => edge?.node)
-        .filter((node): node is TableRecord => node != null) ?? []
-    );
-  }, [paginationData]);
-
-  if (!paginationData.devices) {
-    return null;
-  }
+const DevicesGroupsTable = ({
+  className,
+  devicesRef,
+  hideSearch = false,
+}: Props) => {
+  const devices = useFragment(DEVICES_TABLE_FRAGMENT, devicesRef);
 
   return (
-    <InfiniteTable
+    <Table
       className={className}
       columns={columns}
       data={devices}
-      loading={isLoadingNext}
-      onLoadMore={hasNext ? loadNextDevices : undefined}
-      setSearchText={setSearchText}
+      hideSearch={hideSearch}
     />
   );
 };
 
-export default DevicesTable;
+export default DevicesGroupsTable;

--- a/frontend/src/components/InfiniteScroll.tsx
+++ b/frontend/src/components/InfiniteScroll.tsx
@@ -1,0 +1,76 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { useEffect, useRef } from "react";
+
+import Spinner from "components/Spinner";
+
+// Set flex: 1 for the container together with a fixed flex-basis.
+// This will ensure the container will fill the available height of its parent
+// but also trigger an overflow condition if it spans more height.
+// The overflow can then be handled with an overflow: auto to hide excess
+// content and display the scroll bar.
+// For more details see: https://stackoverflow.com/a/52489012
+const containerStyle = { flex: "1 1 1px" };
+
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  loading?: boolean;
+  onLoadMore?: () => void;
+};
+
+const InfiniteScroll = ({
+  children,
+  className,
+  loading = false,
+  onLoadMore,
+}: Props) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!onLoadMore || !sentinel || !window.IntersectionObserver) {
+      return;
+    }
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        onLoadMore();
+      }
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [sentinelRef, onLoadMore]);
+
+  return (
+    <div className={`flex-grow-1 d-flex flex-column ${className}`}>
+      <div className="overflow-visible overflow-xl-auto" style={containerStyle}>
+        {children}
+        {(loading || onLoadMore) && (
+          <div className="text-center mt-3" ref={sentinelRef}>
+            <Spinner />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InfiniteScroll;

--- a/frontend/src/components/InfiniteTable.tsx
+++ b/frontend/src/components/InfiniteTable.tsx
@@ -1,0 +1,170 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { useMemo, useState } from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type {
+  FilterFnOption,
+  Row,
+  RowData,
+  SortingState,
+  TableOptions,
+} from "@tanstack/react-table";
+
+import InfiniteScroll from "components/InfiniteScroll";
+import Icon from "./Icon";
+import RBTable from "react-bootstrap/Table";
+import SearchBox from "./SearchBox";
+
+declare module "@tanstack/table-core" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+  }
+}
+
+type SortDirectionIndicatorProps = {
+  className?: string;
+  descending: boolean;
+};
+
+const SortDirectionIndicator = ({
+  className,
+  descending,
+}: SortDirectionIndicatorProps) => (
+  <span className={className}>
+    {descending ? <Icon icon="arrowDown" /> : <Icon icon="arrowUp" />}
+  </span>
+);
+
+type InfiniteTableProps<T extends RowData> = {
+  columns: TableOptions<T>["columns"];
+  data: T[];
+  className?: string;
+  loading?: boolean;
+  onLoadMore?: () => void;
+  hiddenColumns?: string[];
+  sortBy?: SortingState;
+  searchFunction?: FilterFnOption<T>;
+  hideSearch?: boolean;
+  getRowProps?: (row: Row<T>) => object;
+  setSearchText?: (value: string | null) => void;
+};
+
+const InfiniteTable = <T extends RowData>({
+  columns,
+  data,
+  className = "",
+  loading = false,
+  onLoadMore,
+  hiddenColumns = [],
+  sortBy = [],
+  searchFunction,
+  hideSearch = false,
+  getRowProps,
+  setSearchText,
+}: InfiniteTableProps<T>) => {
+  const [sorting, setSorting] = useState<SortingState>(sortBy);
+  const columnVisibility = useMemo(
+    () =>
+      hiddenColumns.reduce(
+        (acc, columnId) => ({ ...acc, [columnId]: false }),
+        {},
+      ),
+    [hiddenColumns],
+  );
+
+  const table = useReactTable<T>({
+    data: data, // TODO: remove when react-table narrows data type to readonly array
+    columns,
+    state: {
+      columnVisibility,
+      sorting,
+    },
+    globalFilterFn: searchFunction ?? "auto",
+    onSortingChange: setSorting,
+
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  return (
+    <div className={className}>
+      {hideSearch || (
+        <div className="py-2 mb-3">
+          <SearchBox onChange={(text) => setSearchText?.(text)} />
+        </div>
+      )}
+      <InfiniteScroll
+        className={className}
+        loading={loading}
+        onLoadMore={onLoadMore}
+      >
+        <RBTable responsive hover>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                    {header.column.getIsSorted() && (
+                      <SortDirectionIndicator
+                        className="ms-2"
+                        descending={header.column.getIsSorted() === "desc"}
+                      />
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr {...(getRowProps ? getRowProps(row) : {})} key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </RBTable>
+      </InfiniteScroll>
+    </div>
+  );
+};
+
+export default InfiniteTable;

--- a/frontend/src/components/UpdateCampaignsTable.tsx
+++ b/frontend/src/components/UpdateCampaignsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,43 +18,62 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
-import { Link, Route } from "Navigation";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import _ from "lodash";
 
+import type { UpdateCampaignsTable_PaginationQuery } from "api/__generated__/UpdateCampaignsTable_PaginationQuery.graphql";
 import type {
   UpdateCampaignsTable_UpdateCampaignFragment$data,
   UpdateCampaignsTable_UpdateCampaignFragment$key,
 } from "api/__generated__/UpdateCampaignsTable_UpdateCampaignFragment.graphql";
 
-import Table, { createColumnHelper } from "components/Table";
 import UpdateCampaignOutcome from "components/UpdateCampaignOutcome";
 import UpdateCampaignStatus from "components/UpdateCampaignStatus";
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "components/InfiniteTable";
+import { Link, Route } from "Navigation";
+
+const UPDATE_CAMPAIGNS_TO_LOAD_FIRST = 40;
+const UPDATE_CAMPAIGNS_TO_LOAD_NEXT = 10;
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const UPDATE_CAMPAIGNS_TABLE_FRAGMENT = graphql`
-  fragment UpdateCampaignsTable_UpdateCampaignFragment on UpdateCampaign
-  @relay(plural: true) {
-    id
-    name
-    status
-    ...UpdateCampaignStatus_UpdateCampaignStatusFragment
-    outcome
-    ...UpdateCampaignOutcome_UpdateCampaignOutcomeFragment
-    baseImage {
-      name
-      baseImageCollection {
-        name
+  fragment UpdateCampaignsTable_UpdateCampaignFragment on RootQueryType
+  @refetchable(queryName: "UpdateCampaignsTable_PaginationQuery")
+  @argumentDefinitions(filter: { type: "UpdateCampaignFilterInput" }) {
+    updateCampaigns(first: $first, after: $after, filter: $filter)
+      @connection(key: "UpdateCampaignsTable_updateCampaigns") {
+      edges {
+        node {
+          id
+          name
+          status
+          ...UpdateCampaignStatus_UpdateCampaignStatusFragment
+          outcome
+          ...UpdateCampaignOutcome_UpdateCampaignOutcomeFragment
+          baseImage {
+            name
+            baseImageCollection {
+              name
+            }
+          }
+          updateChannel {
+            name
+          }
+        }
       }
-    }
-    updateChannel {
-      name
     }
   }
 `;
 
-type TableRecord = UpdateCampaignsTable_UpdateCampaignFragment$data[number];
+type TableRecord = NonNullable<
+  NonNullable<
+    UpdateCampaignsTable_UpdateCampaignFragment$data["updateCampaigns"]
+  >["edges"]
+>[number]["node"];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
@@ -128,17 +147,113 @@ const columns = [
 
 type Props = {
   className?: string;
-  updateCampaignsRef: UpdateCampaignsTable_UpdateCampaignFragment$key;
+  updateCampaignsData: UpdateCampaignsTable_UpdateCampaignFragment$key;
 };
 
-const UpdateCampaignsTable = ({ className, updateCampaignsRef }: Props) => {
-  const updateCampaigns = useFragment(
-    UPDATE_CAMPAIGNS_TABLE_FRAGMENT,
-    updateCampaignsRef,
-  );
+const UpdateCampaignsTable = ({ className, updateCampaignsData }: Props) => {
+  const {
+    data: paginationData,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<
+    UpdateCampaignsTable_PaginationQuery,
+    UpdateCampaignsTable_UpdateCampaignFragment$key
+  >(UPDATE_CAMPAIGNS_TABLE_FRAGMENT, updateCampaignsData);
+  const [searchText, setSearchText] = useState<string | null>(null);
+
+  const debounceRefetch = useMemo(() => {
+    const enumStatuses = ["FINISHED", "IDLE", "IN_PROGRESS"] as const;
+    const enumOutcomes = ["FAILURE", "SUCCESS"] as const;
+
+    const findMatches = <T extends readonly string[]>(
+      enums: T,
+      searchText: string,
+    ): T[number][] =>
+      enums.filter((value) =>
+        value.toLowerCase().includes(searchText.toLowerCase()),
+      );
+
+    return _.debounce((text: string) => {
+      if (text === "") {
+        refetch(
+          {
+            first: UPDATE_CAMPAIGNS_TO_LOAD_FIRST,
+          },
+          { fetchPolicy: "network-only" },
+        );
+      } else {
+        // TODO : localizedReleaseDisplayNames is not part of BaseImageFilterInput
+        // in the GraphQL schema, so filtering by display names is not supported
+        // by the backend. Users can only search by version directly.
+        refetch(
+          {
+            first: UPDATE_CAMPAIGNS_TO_LOAD_FIRST,
+            filter: {
+              or: [
+                { name: { ilike: `%${text}%` } },
+                {
+                  baseImage: {
+                    version: { ilike: `%${text}%` },
+                    baseImageCollection: {
+                      name: { ilike: `%${text}%` },
+                    },
+                  },
+                },
+                {
+                  updateChannel: {
+                    name: { ilike: `%${text}%` },
+                  },
+                },
+                ...findMatches(enumStatuses, text).map((status) => ({
+                  status: { eq: status },
+                })),
+                ...findMatches(enumOutcomes, text).map((outcome) => ({
+                  outcome: { eq: outcome },
+                })),
+              ],
+            },
+          },
+          { fetchPolicy: "network-only" },
+        );
+      }
+    }, 500);
+  }, [refetch]);
+
+  useEffect(() => {
+    if (searchText !== null) {
+      debounceRefetch(searchText);
+    }
+  }, [debounceRefetch, searchText]);
+
+  const loadNextUpdateCampaigns = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(UPDATE_CAMPAIGNS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const updateCampaigns = useMemo(() => {
+    return (
+      paginationData.updateCampaigns?.edges
+        ?.map((edge) => edge?.node)
+        .filter((node): node is TableRecord => node != null) ?? []
+    );
+  }, [paginationData]);
+
+  if (!paginationData.updateCampaigns) {
+    return null;
+  }
 
   return (
-    <Table className={className} columns={columns} data={updateCampaigns} />
+    <InfiniteTable
+      className={className}
+      columns={columns}
+      data={updateCampaigns}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextUpdateCampaigns : undefined}
+      setSearchText={setSearchText}
+    />
   );
 };
 

--- a/frontend/src/components/UpdateChannelsTable.tsx
+++ b/frontend/src/components/UpdateChannelsTable.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,33 +18,55 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import _ from "lodash";
 
+import type { UpdateChannelsTable_PaginationQuery } from "api/__generated__/UpdateChannelsTable_PaginationQuery.graphql";
 import type {
   UpdateChannelsTable_UpdateChannelFragment$data,
   UpdateChannelsTable_UpdateChannelFragment$key,
 } from "api/__generated__/UpdateChannelsTable_UpdateChannelFragment.graphql";
 
-import Table, { createColumnHelper } from "components/Table";
-import Tag from "components/Tag";
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "./InfiniteTable";
 import { Link, Route } from "Navigation";
+import Tag from "components/Tag";
 
+const UPDATE_CHANNELS_TO_LOAD_FIRST = 40;
+const UPDATE_CHANNELS_TO_LOAD_NEXT = 10;
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
 const DEVICE_GROUPS_TABLE_FRAGMENT = graphql`
-  fragment UpdateChannelsTable_UpdateChannelFragment on UpdateChannel
-  @relay(plural: true) {
-    id
-    name
-    handle
-    targetGroups {
-      name
+  fragment UpdateChannelsTable_UpdateChannelFragment on RootQueryType
+  @refetchable(queryName: "UpdateChannelsTable_PaginationQuery")
+  @argumentDefinitions(filter: { type: "UpdateChannelFilterInput" }) {
+    updateChannels(first: $first, after: $after, filter: $filter)
+      @connection(key: "UpdateChannelsTable_updateChannels") {
+      edges {
+        node {
+          id
+          name
+          handle
+          targetGroups {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
     }
   }
 `;
 
-type TableRecord = UpdateChannelsTable_UpdateChannelFragment$data[0];
+type TableRecord = NonNullable<
+  NonNullable<
+    UpdateChannelsTable_UpdateChannelFragment$data["updateChannels"]
+  >["edges"]
+>[number]["node"];
 
 const columnHelper = createColumnHelper<TableRecord>();
 const columns = [
@@ -85,7 +107,7 @@ const columns = [
     ),
     cell: ({ getValue }) => (
       <>
-        {getValue().map((group) => (
+        {getValue().edges?.map(({ node: group }) => (
           <Tag key={group.name} className="me-2">
             {group.name}
           </Tag>
@@ -101,13 +123,86 @@ type Props = {
 };
 
 const UpdateChannelsTable = ({ className, updateChannelsRef }: Props) => {
-  const updateChannels = useFragment(
-    DEVICE_GROUPS_TABLE_FRAGMENT,
-    updateChannelsRef,
+  const {
+    data: paginationData,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<
+    UpdateChannelsTable_PaginationQuery,
+    UpdateChannelsTable_UpdateChannelFragment$key
+  >(DEVICE_GROUPS_TABLE_FRAGMENT, updateChannelsRef);
+  const [searchText, setSearchText] = useState<string | null>(null);
+
+  const debounceRefetch = useMemo(
+    () =>
+      _.debounce((text: string) => {
+        if (text === "") {
+          refetch(
+            {
+              first: UPDATE_CHANNELS_TO_LOAD_FIRST,
+            },
+            { fetchPolicy: "network-only" },
+          );
+        } else {
+          refetch(
+            {
+              first: UPDATE_CHANNELS_TO_LOAD_FIRST,
+              filter: {
+                or: [
+                  { name: { ilike: `%${text}%` } },
+                  { handle: { ilike: `%${text}%` } },
+                  {
+                    targetGroups: {
+                      name: {
+                        ilike: `%${text}%`,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            { fetchPolicy: "network-only" },
+          );
+        }
+      }, 500),
+    [refetch],
   );
 
+  useEffect(() => {
+    if (searchText !== null) {
+      debounceRefetch(searchText);
+    }
+  }, [debounceRefetch, searchText]);
+
+  const loadNextUpdateChannels = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(UPDATE_CHANNELS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const updateChannels = useMemo(() => {
+    return (
+      paginationData.updateChannels?.edges
+        ?.map((edge) => edge?.node)
+        .filter((node): node is TableRecord => node != null) ?? []
+    );
+  }, [paginationData]);
+
+  if (!paginationData.updateChannels) {
+    return null;
+  }
+
   return (
-    <Table className={className} columns={columns} data={updateChannels} />
+    <InfiniteTable
+      className={className}
+      columns={columns}
+      data={updateChannels}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextUpdateChannels : undefined}
+      setSearchText={setSearchText}
+    />
   );
 };
 

--- a/frontend/src/components/UpdateTargetsTable.tsx
+++ b/frontend/src/components/UpdateTargetsTable.tsx
@@ -29,8 +29,9 @@ import type {
 } from "api/__generated__/UpdateTargetsTable_UpdateTargetsFragment.graphql";
 
 import Icon from "components/Icon";
-import Table, { createColumnHelper } from "components/Table";
+import { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";
+import InfiniteTable from "./InfiniteTable";
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
@@ -297,12 +298,18 @@ type Props = {
   className?: string;
   hiddenColumns?: ColumnId[];
   updateTargetsRef: UpdateTargetsTable_UpdateTargetsFragment$key;
+  isLoadingNext: boolean;
+  hasNext: boolean;
+  loadNextUpdateTargets: () => void;
 };
 
 const UpdateTargetsTable = ({
   className,
   updateTargetsRef,
   hiddenColumns = [],
+  isLoadingNext,
+  hasNext,
+  loadNextUpdateTargets,
 }: Props) => {
   const updateTargets = useFragment(
     UPDATE_TARGETS_TABLE_FRAGMENT,
@@ -310,10 +317,12 @@ const UpdateTargetsTable = ({
   );
 
   return (
-    <Table
+    <InfiniteTable
       className={className}
       columns={columns}
-      data={updateTargets}
+      data={[...updateTargets]}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextUpdateTargets : undefined}
       hiddenColumns={hiddenColumns}
       hideSearch
     />

--- a/frontend/src/components/UpdateTargetsTabs.tsx
+++ b/frontend/src/components/UpdateTargetsTabs.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
-import { graphql, useFragment } from "react-relay/hooks";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
 
+import type { UpdateTargetsTabs_PaginationQuery } from "api/__generated__/UpdateTargetsTabs_PaginationQuery.graphql";
 import type {
   UpdateTargetStatus as UpdateTargetStatusType,
   UpdateTargetsTabs_UpdateTargetsFragment$key,
@@ -34,39 +35,39 @@ import UpdateTargetsTable, { columnIds } from "components/UpdateTargetsTable";
 import type { ColumnId } from "components/UpdateTargetsTable";
 import UpdateTargetStatus from "components/UpdateTargetStatus";
 
+const UPDATE_TARGETS_TO_LOAD_FIRST = 10;
+const UPDATE_TARGETS_TO_LOAD_NEXT = 10;
+
 const UPDATE_TARGETS_TABS_FRAGMENT = graphql`
-  fragment UpdateTargetsTabs_UpdateTargetsFragment on UpdateCampaign {
-    updateTargets {
-      status
-      ...UpdateTargetsTable_UpdateTargetsFragment
+  fragment UpdateTargetsTabs_UpdateTargetsFragment on UpdateCampaign
+  @refetchable(queryName: "UpdateTargetsTabs_PaginationQuery")
+  @argumentDefinitions(
+    first: { type: "Int" }
+    after: { type: "String" }
+    filter: { type: "UpdateTargetFilterInput" }
+  ) {
+    updateTargets(first: $first, after: $after, filter: $filter)
+      @connection(key: "UpdateTargetsTabs_updateTargets") {
+      edges {
+        node {
+          status
+          ...UpdateTargetsTable_UpdateTargetsFragment
+        }
+      }
     }
   }
 `;
 
-const getVisibleColumns = (status: UpdateTargetStatusType): ColumnId[] => {
-  switch (status) {
-    case "IDLE":
-      return ["deviceName"];
-
-    case "IN_PROGRESS":
-      return [
-        "deviceName",
-        "otaOperationStatus",
-        "otaOperationStatusProgress",
-        "latestAttempt",
-      ];
-
-    case "SUCCESSFUL":
-      return ["deviceName", "completionTimestamp"];
-
-    case "FAILED":
-      return ["deviceName", "otaOperationStatusCode", "completionTimestamp"];
-  }
-};
-
-const getHiddenColumns = (status: UpdateTargetStatusType): ColumnId[] => {
-  const visibleColumns = getVisibleColumns(status);
-  return columnIds.filter((column) => !visibleColumns.includes(column));
+const columnMap: Record<UpdateTargetStatusType, ColumnId[]> = {
+  IDLE: ["deviceName"],
+  IN_PROGRESS: [
+    "deviceName",
+    "otaOperationStatus",
+    "otaOperationStatusProgress",
+    "latestAttempt",
+  ],
+  SUCCESSFUL: ["deviceName", "completionTimestamp"],
+  FAILED: ["deviceName", "otaOperationStatusCode", "completionTimestamp"],
 };
 
 const updateTargetTabs: UpdateTargetStatusType[] = [
@@ -83,15 +84,47 @@ type Props = {
 const UpdateTargetsTabs = ({ updateCampaignRef }: Props) => {
   const [activeTab, setActiveTab] =
     useState<UpdateTargetStatusType>("SUCCESSFUL");
-  const { updateTargets } = useFragment(
-    UPDATE_TARGETS_TABS_FRAGMENT,
-    updateCampaignRef,
-  );
-  const visibleTargets = useMemo(
-    () => updateTargets.filter(({ status }) => status === activeTab),
-    [activeTab, updateTargets],
-  );
-  const hiddenColumns = useMemo(() => getHiddenColumns(activeTab), [activeTab]);
+
+  const { data, loadNext, hasNext, isLoadingNext, refetch } =
+    usePaginationFragment<
+      UpdateTargetsTabs_PaginationQuery,
+      UpdateTargetsTabs_UpdateTargetsFragment$key
+    >(UPDATE_TARGETS_TABS_FRAGMENT, updateCampaignRef);
+
+  const loadNextUpdateTargets = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(UPDATE_TARGETS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const updateTargets = useMemo(() => {
+    return data.updateTargets?.edges?.map((edge) => edge?.node) ?? [];
+  }, [data]);
+
+  const hiddenColumns = useMemo(() => {
+    const visible = columnMap[activeTab];
+    return columnIds.filter((c) => !visible.includes(c));
+  }, [activeTab]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      refetch(
+        {
+          first: UPDATE_TARGETS_TO_LOAD_FIRST,
+          filter: {
+            status: {
+              eq: activeTab,
+            },
+          },
+        },
+        { fetchPolicy: "network-only" },
+      );
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [activeTab, refetch]);
+
+  if (!data.updateTargets) return null;
 
   return (
     <div>
@@ -117,8 +150,11 @@ const UpdateTargetsTabs = ({ updateCampaignRef }: Props) => {
           ))}
         </Nav>
         <UpdateTargetsTable
-          updateTargetsRef={visibleTargets}
+          updateTargetsRef={updateTargets}
           hiddenColumns={hiddenColumns}
+          isLoadingNext={isLoadingNext}
+          hasNext={hasNext}
+          loadNextUpdateTargets={loadNextUpdateTargets}
         />
       </div>
     </div>

--- a/frontend/src/forms/CreateBaseImageCollection.tsx
+++ b/frontend/src/forms/CreateBaseImageCollection.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -37,8 +37,12 @@ import type { CreateBaseImageCollection_OptionsFragment$key } from "api/__genera
 const CREATE_BASE_IMAGE_COLLECTION_FRAGMENT = graphql`
   fragment CreateBaseImageCollection_OptionsFragment on RootQueryType {
     systemModels {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
   }
 `;
@@ -160,7 +164,7 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select a System Model",
               })}
             </option>
-            {systemModels.map((systemModel) => (
+            {systemModels?.edges?.map(({ node: systemModel }) => (
               <option key={systemModel.id} value={systemModel.id}>
                 {systemModel.name}
               </option>

--- a/frontend/src/forms/CreateSystemModel.tsx
+++ b/frontend/src/forms/CreateSystemModel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
+import type { CreateSystemModel_OptionsFragment$key } from "api/__generated__/CreateSystemModel_OptionsFragment.graphql";
+
 import Button from "components/Button";
 import CloseButton from "components/CloseButton";
 import Col from "components/Col";
@@ -35,13 +37,15 @@ import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { systemModelHandleSchema, messages, yup } from "forms";
 
-import type { CreateSystemModel_OptionsFragment$key } from "api/__generated__/CreateSystemModel_OptionsFragment.graphql";
-
 const CREATE_SYSTEM_MODEL_FRAGMENT = graphql`
   fragment CreateSystemModel_OptionsFragment on RootQueryType {
     hardwareTypes {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
     tenantInfo {
       defaultLocale
@@ -303,7 +307,7 @@ const CreateSystemModelForm = ({
                       defaultMessage: "Select a Hardware Type",
                     })}
                   </option>
-                  {hardwareTypes.map((hardwareType) => (
+                  {hardwareTypes?.edges?.map(({ node: hardwareType }) => (
                     <option key={hardwareType.id} value={hardwareType.id}>
                       {hardwareType.name}
                     </option>

--- a/frontend/src/forms/CreateUpdateCampaign.tsx
+++ b/frontend/src/forms/CreateUpdateCampaign.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -39,12 +39,20 @@ import type { CreateUpdateCampaign_OptionsFragment$key } from "api/__generated__
 const UPDATE_CAMPAIGN_OPTIONS_FRAGMENT = graphql`
   fragment CreateUpdateCampaign_OptionsFragment on RootQueryType {
     baseImageCollections {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
     updateChannels {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
   }
 `;
@@ -262,14 +270,16 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select a Base Image Collection",
               })}
             </option>
-            {baseImageCollections.map((baseImageCollection) => (
-              <option
-                key={baseImageCollection.id}
-                value={baseImageCollection.id}
-              >
-                {baseImageCollection.name}
-              </option>
-            ))}
+            {baseImageCollections?.edges?.map(
+              ({ node: baseImageCollection }) => (
+                <option
+                  key={baseImageCollection.id}
+                  value={baseImageCollection.id}
+                >
+                  {baseImageCollection.name}
+                </option>
+              ),
+            )}
           </Form.Select>
           <FormFeedback feedback={errors.baseImageCollectionId?.message} />
         </FormRow>
@@ -308,7 +318,7 @@ const CreateBaseImageCollectionForm = ({
                 defaultMessage: "Select an Update Channel",
               })}
             </option>
-            {updateChannels.map((updateChannel) => (
+            {updateChannels?.edges?.map(({ node: updateChannel }) => (
               <option key={updateChannel.id} value={updateChannel.id}>
                 {updateChannel.name}
               </option>

--- a/frontend/src/forms/CreateUpdateChannel.tsx
+++ b/frontend/src/forms/CreateUpdateChannel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import { useForm, Controller } from "react-hook-form";
 import { useIntl, FormattedMessage } from "react-intl";
 import { yupResolver } from "@hookform/resolvers/yup";
 
+import type { CreateUpdateChannel_OptionsFragment$key } from "api/__generated__/CreateUpdateChannel_OptionsFragment.graphql";
+
 import Button from "components/Button";
 import Col from "components/Col";
 import Form from "components/Form";
@@ -32,15 +34,18 @@ import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { updateChannelHandleSchema, yup, messages } from "forms";
 import { graphql, useFragment } from "react-relay/hooks";
-import type { CreateUpdateChannel_OptionsFragment$key } from "api/__generated__/CreateUpdateChannel_OptionsFragment.graphql";
 
 const CREATE_UPDATE_CHANNEL_OPTIONS_FRAGMENT = graphql`
   fragment CreateUpdateChannel_OptionsFragment on RootQueryType {
     deviceGroups {
-      id
-      name
-      updateChannel {
-        name
+      edges {
+        node {
+          id
+          name
+          updateChannel {
+            name
+          }
+        }
       }
     }
   }
@@ -179,18 +184,20 @@ const CreateUpdateChannel = ({
 
   const targetGroupOptions = useMemo(() => {
     // move disabled options to the end
-    return [...targetGroups].sort((group1, group2) => {
-      const group1Disabled = isTargetGroupUsedByOtherChannel(group1);
-      const group2Disabled = isTargetGroupUsedByOtherChannel(group2);
+    return [...(targetGroups?.edges?.map((edge) => edge.node) || [])].sort(
+      (group1, group2) => {
+        const group1Disabled = isTargetGroupUsedByOtherChannel(group1);
+        const group2Disabled = isTargetGroupUsedByOtherChannel(group2);
 
-      if (group1Disabled === group2Disabled) {
-        return 0;
-      }
-      if (group1Disabled) {
-        return 1;
-      }
-      return -1;
-    });
+        if (group1Disabled === group2Disabled) {
+          return 0;
+        }
+        if (group1Disabled) {
+          return 1;
+        }
+        return -1;
+      },
+    );
   }, [targetGroups]);
 
   const onFormSubmit = (data: FormData) => onSubmit(transformOutputData(data));

--- a/frontend/src/forms/UpdateHardwareType.tsx
+++ b/frontend/src/forms/UpdateHardwareType.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import { FormattedMessage } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 import { yupResolver } from "@hookform/resolvers/yup";
 
+import type { UpdateHardwareType_HardwareTypeFragment$key } from "api/__generated__/UpdateHardwareType_HardwareTypeFragment.graphql";
+
 import Button from "components/Button";
 import Col from "components/Col";
 import Form from "components/Form";
@@ -33,14 +35,17 @@ import Spinner from "components/Spinner";
 import Stack from "components/Stack";
 import { hardwareTypeHandleSchema, messages, yup } from "forms";
 
-import type { UpdateHardwareType_HardwareTypeFragment$key } from "api/__generated__/UpdateHardwareType_HardwareTypeFragment.graphql";
-
 const UPDATE_HARDWARE_TYPE_FRAGMENT = graphql`
   fragment UpdateHardwareType_HardwareTypeFragment on HardwareType {
     name
     handle
     partNumbers {
-      partNumber
+      count
+      edges {
+        node {
+          partNumber
+        }
+      }
     }
   }
 `;
@@ -127,10 +132,10 @@ const UpdateHardwareTypeForm = ({
       name: hardwareType.name,
       handle: hardwareType.handle,
       partNumbers:
-        hardwareType.partNumbers.length > 0
-          ? hardwareType.partNumbers.map(({ partNumber }) => ({
+        hardwareType.partNumbers?.count && hardwareType.partNumbers.count > 0
+          ? hardwareType.partNumbers.edges?.map(({ node: { partNumber } }) => ({
               value: partNumber,
-            }))
+            })) ?? []
           : [{ value: "" }], // default with at least one empty part number
     }),
     [hardwareType.name, hardwareType.handle, hardwareType.partNumbers],

--- a/frontend/src/forms/UpdateSystemModel.tsx
+++ b/frontend/src/forms/UpdateSystemModel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -56,7 +56,11 @@ const UPDATE_SYSTEM_MODEL_FRAGMENT = graphql`
       name
     }
     partNumbers {
-      partNumber
+      edges {
+        node {
+          partNumber
+        }
+      }
     }
     pictureUrl
   }
@@ -164,8 +168,10 @@ const transformInputData = (
     description,
     hardwareType: hardwareType?.name || "",
     partNumbers:
-      partNumbers.length > 0
-        ? data.partNumbers.map(({ partNumber }) => ({ value: partNumber }))
+      partNumbers.edges && partNumbers.edges.length > 0
+        ? data.partNumbers.edges?.map(({ node }) => ({
+            value: node.partNumber,
+          })) ?? []
         : [{ value: "" }], // default with at least one empty part number
   };
 };
@@ -202,7 +208,7 @@ const transformOutputData = (
 
   const partNumbers = data.partNumbers.map((pn) => pn.value);
   const systemModelPartNumbers = new Set(
-    systemModel.partNumbers.map(({ partNumber }) => partNumber),
+    systemModel.partNumbers.edges?.map(({ node }) => node.partNumber) || [],
   );
   const formPartNumbers = new Set(partNumbers);
   const partNumbersEqual =

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ const CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY = graphql`
   query BaseImageCollectionCreate_getOptions_Query {
     systemModels {
       __typename
+      count
     }
     ...CreateBaseImageCollection_OptionsFragment
   }
@@ -190,7 +191,7 @@ const BaseImageCollectionWrapper = ({
     getBaseImageCollectionOptionsQuery,
   );
   const { systemModels } = baseImageCollectionOptions;
-  if (systemModels.length === 0) {
+  if (systemModels?.count === 0) {
     return <NoSystemModels />;
   }
   return (

--- a/frontend/src/pages/BaseImageCollections.tsx
+++ b/frontend/src/pages/BaseImageCollections.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { BaseImageCollections_getBaseImageCollections_Query } from "api/__generated__/BaseImageCollections_getBaseImageCollections_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import BaseImageCollectionsTable from "components/BaseImageCollectionsTable";
@@ -32,11 +33,16 @@ import Page from "components/Page";
 import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
+const BASE_IMAGE_COLLECTIONS_TO_LOAD_FIRST = 40;
+
 const GET_BASE_IMAGE_COLLECTIONS_QUERY = graphql`
-  query BaseImageCollections_getBaseImageCollections_Query {
-    baseImageCollections {
-      ...BaseImageCollectionsTable_BaseImageCollectionFragment
-    }
+  query BaseImageCollections_getBaseImageCollections_Query(
+    $first: Int
+    $after: String
+    $filter: BaseImageCollectionFilterInput
+  ) {
+    ...BaseImageCollectionsTable_BaseImageCollectionFragment
+      @arguments(filter: $filter)
   }
 `;
 
@@ -47,7 +53,7 @@ interface BaseImageCollectionsContentProps {
 const BaseImageCollectionsContent = ({
   getBaseImageCollectionsQuery,
 }: BaseImageCollectionsContentProps) => {
-  const { baseImageCollections } = usePreloadedQuery(
+  const baseImageCollections = usePreloadedQuery(
     GET_BASE_IMAGE_COLLECTIONS_QUERY,
     getBaseImageCollectionsQuery,
   );
@@ -85,7 +91,11 @@ const BaseImageCollectionsPage = () => {
     );
 
   const fetchBaseImageCollections = useCallback(
-    () => getBaseImageCollections({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getBaseImageCollections(
+        { first: BASE_IMAGE_COLLECTIONS_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getBaseImageCollections],
   );
 

--- a/frontend/src/pages/DeviceGroups.tsx
+++ b/frontend/src/pages/DeviceGroups.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022-2024 SECO Mind Srl
+  Copyright 2022-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { DeviceGroups_getDeviceGroups_Query } from "api/__generated__/DeviceGroups_getDeviceGroups_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import DeviceGroupsTable from "components/DeviceGroupsTable";
@@ -32,11 +33,15 @@ import Page from "components/Page";
 import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
+const DEVICE_GROUPS_TO_LOAD_FIRST = 40;
+
 const GET_DEVICE_GROUPS_QUERY = graphql`
-  query DeviceGroups_getDeviceGroups_Query {
-    deviceGroups {
-      ...DeviceGroupsTable_DeviceGroupFragment
-    }
+  query DeviceGroups_getDeviceGroups_Query(
+    $first: Int
+    $after: String
+    $filter: DeviceGroupFilterInput
+  ) {
+    ...DeviceGroupsTable_DeviceGroupFragment @arguments(filter: $filter)
   }
 `;
 
@@ -47,7 +52,7 @@ interface DeviceGroupsContentProps {
 const DeviceGroupsContent = ({
   getDeviceGroupsQuery,
 }: DeviceGroupsContentProps) => {
-  const { deviceGroups } = usePreloadedQuery(
+  const deviceGroups = usePreloadedQuery(
     GET_DEVICE_GROUPS_QUERY,
     getDeviceGroupsQuery,
   );
@@ -81,7 +86,11 @@ const DevicesPage = () => {
     useQueryLoader<DeviceGroups_getDeviceGroups_Query>(GET_DEVICE_GROUPS_QUERY);
 
   const fetchDeviceGroups = useCallback(
-    () => getDeviceGroups({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getDeviceGroups(
+        { first: DEVICE_GROUPS_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getDeviceGroups],
   );
 

--- a/frontend/src/pages/HardwareType.tsx
+++ b/frontend/src/pages/HardwareType.tsx
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
+  ConnectionHandler,
   graphql,
   useMutation,
   usePreloadedQuery,
@@ -137,15 +138,16 @@ const HardwareTypeContent = ({ hardwareType }: HardwareTypeContentProps) => {
         }
 
         const root = store.getRoot();
-        const hardwareTypes = root.getLinkedRecords("hardwareTypes");
-        if (hardwareTypes) {
-          root.setLinkedRecords(
-            hardwareTypes.filter(
-              (hardwareType) => hardwareType.getDataID() !== hardwareTypeId,
-            ),
-            "hardwareTypes",
-          );
+
+        const connection = ConnectionHandler.getConnection(
+          root,
+          "HardwareTypesTable_hardwareTypes",
+        );
+
+        if (connection) {
+          ConnectionHandler.deleteNode(connection, hardwareTypeId);
         }
+
         store.delete(hardwareTypeId);
       },
     });

--- a/frontend/src/pages/HardwareTypes.tsx
+++ b/frontend/src/pages/HardwareTypes.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { HardwareTypes_getHardwareTypes_Query } from "api/__generated__/HardwareTypes_getHardwareTypes_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import HardwareTypesTable from "components/HardwareTypesTable";
@@ -33,11 +34,18 @@ import Result from "components/Result";
 import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
+const HARDWARE_TYPES_TO_LOAD_FIRST = 40;
+
 const GET_HARDWARE_TYPES_QUERY = graphql`
-  query HardwareTypes_getHardwareTypes_Query {
-    hardwareTypes {
-      ...HardwareTypesTable_HardwareTypesFragment
+  query HardwareTypes_getHardwareTypes_Query(
+    $first: Int
+    $after: String
+    $filter: HardwareTypeFilterInput
+  ) {
+    hardwareTypes(first: $first, after: $after, filter: $filter) {
+      count
     }
+    ...HardwareTypesTable_HardwareTypesFragment @arguments(filter: $filter)
   }
 `;
 
@@ -48,7 +56,7 @@ interface HardwareTypesContentProps {
 const HardwareTypesContent = ({
   getHardwareTypesQuery,
 }: HardwareTypesContentProps) => {
-  const { hardwareTypes } = usePreloadedQuery(
+  const hardwareTypes = usePreloadedQuery(
     GET_HARDWARE_TYPES_QUERY,
     getHardwareTypesQuery,
   );
@@ -71,7 +79,7 @@ const HardwareTypesContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        {hardwareTypes.length === 0 ? (
+        {hardwareTypes.hardwareTypes?.count === 0 ? (
           <Result.EmptyList
             title={
               <FormattedMessage
@@ -100,7 +108,11 @@ const HardwareTypesPage = () => {
     );
 
   const fetchHardwareTypes = useCallback(
-    () => getHardwareTypes({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getHardwareTypes(
+        { first: HARDWARE_TYPES_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getHardwareTypes],
   );
 

--- a/frontend/src/pages/SystemModel.tsx
+++ b/frontend/src/pages/SystemModel.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
+  ConnectionHandler,
   graphql,
   useMutation,
   usePreloadedQuery,
@@ -197,14 +198,13 @@ const SystemModelContent = ({
 
         const root = store.getRoot();
 
-        const systemModels = root.getLinkedRecords("systemModels");
-        if (systemModels) {
-          root.setLinkedRecords(
-            systemModels.filter(
-              (systemModel) => systemModel.getDataID() !== systemModelId,
-            ),
-            "systemModels",
-          );
+        const connection = ConnectionHandler.getConnection(
+          root,
+          "SystemModelsTable_systemModels",
+        );
+
+        if (connection) {
+          ConnectionHandler.deleteNode(connection, systemModelId);
         }
 
         root.getLinkedRecords("devices")?.forEach((device) => {

--- a/frontend/src/pages/SystemModelCreate.tsx
+++ b/frontend/src/pages/SystemModelCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,11 +28,13 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
+
 import type {
   SystemModelCreate_getOptions_Query,
   SystemModelCreate_getOptions_Query$data,
 } from "api/__generated__/SystemModelCreate_getOptions_Query.graphql";
 import type { SystemModelCreate_createSystemModel_Mutation } from "api/__generated__/SystemModelCreate_createSystemModel_Mutation.graphql";
+
 import Alert from "components/Alert";
 import Button from "components/Button";
 import Center from "components/Center";
@@ -47,6 +49,7 @@ const CREATE_SYSTEM_MODEL_PAGE_QUERY = graphql`
   query SystemModelCreate_getOptions_Query {
     hardwareTypes {
       __typename
+      count
     }
     ...CreateSystemModel_OptionsFragment
   }
@@ -190,7 +193,7 @@ const SystemModelWrapper = ({
     getCreateSystemModelOptionsQuery,
   );
   const { hardwareTypes } = systemModelOptions;
-  if (hardwareTypes.length === 0) {
+  if (hardwareTypes?.count === 0) {
     return <NoHardwareTypes />;
   }
   return <SystemModel systemModelOptions={systemModelOptions} />;

--- a/frontend/src/pages/SystemModels.tsx
+++ b/frontend/src/pages/SystemModels.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,11 +33,18 @@ import Result from "components/Result";
 import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
+const SYSTEM_MODELS_TO_LOAD_FIRST = 40;
+
 const GET_SYSTEM_MODELS_QUERY = graphql`
-  query SystemModels_getSystemModels_Query {
-    systemModels {
-      ...SystemModelsTable_SystemModelsFragment
+  query SystemModels_getSystemModels_Query(
+    $first: Int
+    $after: String
+    $filter: SystemModelFilterInput
+  ) {
+    systemModels(first: $first, after: $after, filter: $filter) {
+      count
     }
+    ...SystemModelsTable_SystemModelsFragment @arguments(filter: $filter)
   }
 `;
 
@@ -48,7 +55,7 @@ type SystemModelsContentProps = {
 const SystemModelsContent = ({
   getSystemModelsQuery,
 }: SystemModelsContentProps) => {
-  const { systemModels } = usePreloadedQuery(
+  const systemModels = usePreloadedQuery(
     GET_SYSTEM_MODELS_QUERY,
     getSystemModelsQuery,
   );
@@ -71,7 +78,7 @@ const SystemModelsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        {systemModels.length === 0 ? (
+        {systemModels.systemModels?.count === 0 ? (
           <Result.EmptyList
             title={
               <FormattedMessage
@@ -98,7 +105,11 @@ const SystemModelsPage = () => {
     useQueryLoader<SystemModels_getSystemModels_Query>(GET_SYSTEM_MODELS_QUERY);
 
   const fetchSystemModels = useCallback(
-    () => getSystemModels({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getSystemModels(
+        { first: SYSTEM_MODELS_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getSystemModels],
   );
 

--- a/frontend/src/pages/UpdateCampaign.tsx
+++ b/frontend/src/pages/UpdateCampaign.tsx
@@ -47,13 +47,21 @@ import UpdateTargetsTabs from "components/UpdateTargetsTabs";
 import UpdateCampaignForm from "forms/UpdateCampaignForm";
 import { Link, Route } from "Navigation";
 
+const UPDATE_TARGETS_TO_LOAD_FIRST = 15;
+
 const GET_UPDATE_CAMPAIGN_QUERY = graphql`
-  query UpdateCampaign_getUpdateCampaign_Query($updateCampaignId: ID!) {
+  query UpdateCampaign_getUpdateCampaign_Query(
+    $updateCampaignId: ID!
+    $first: Int
+    $after: String
+    $filter: UpdateTargetFilterInput
+  ) {
     updateCampaign(id: $updateCampaignId) {
       name
       ...UpdateCampaignForm_UpdateCampaignFragment
       ...UpdateCampaignStatsChart_UpdateCampaignStatsChartFragment
       ...UpdateTargetsTabs_UpdateTargetsFragment
+        @arguments(first: $first, after: $after, filter: $filter)
       ...UpdateCampaign_RefreshFragment
     }
   }
@@ -180,7 +188,10 @@ const UpdateCampaignPage = () => {
     );
 
   const fetchUpdateCampaign = useCallback(() => {
-    getUpdateCampaign({ updateCampaignId }, { fetchPolicy: "network-only" });
+    getUpdateCampaign(
+      { updateCampaignId, first: UPDATE_TARGETS_TO_LOAD_FIRST },
+      { fetchPolicy: "network-only" },
+    );
   }, [getUpdateCampaign, updateCampaignId]);
 
   useEffect(fetchUpdateCampaign, [fetchUpdateCampaign]);

--- a/frontend/src/pages/UpdateCampaignCreate.tsx
+++ b/frontend/src/pages/UpdateCampaignCreate.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import type {
   UpdateCampaignCreate_getOptions_Query$data,
 } from "api/__generated__/UpdateCampaignCreate_getOptions_Query.graphql";
 import type { UpdateCampaignCreate_createUpdateCampaign_Mutation } from "api/__generated__/UpdateCampaignCreate_createUpdateCampaign_Mutation.graphql";
+
 import Alert from "components/Alert";
 import Button from "components/Button";
 import Center from "components/Center";
@@ -49,9 +50,11 @@ const GET_CREATE_UPDATE_CAMPAIGN_OPTIONS_QUERY = graphql`
   query UpdateCampaignCreate_getOptions_Query {
     baseImageCollections {
       __typename
+      count
     }
     updateChannels {
       __typename
+      count
     }
     ...CreateUpdateCampaign_OptionsFragment
   }
@@ -214,10 +217,10 @@ const UpdateCampaignWrapper = ({
   );
   const { baseImageCollections, updateChannels } = updateCampaignOptions;
 
-  if (baseImageCollections.length === 0) {
+  if (baseImageCollections?.count === 0) {
     return <NoBaseImageCollections />;
   }
-  if (updateChannels.length === 0) {
+  if (updateChannels?.count === 0) {
     return <NoUpdateChannels />;
   }
 

--- a/frontend/src/pages/UpdateCampaigns.tsx
+++ b/frontend/src/pages/UpdateCampaigns.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { UpdateCampaigns_getUpdateCampaigns_Query } from "api/__generated__/UpdateCampaigns_getUpdateCampaigns_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import Page from "components/Page";
@@ -32,11 +33,15 @@ import Spinner from "components/Spinner";
 import UpdateCampaignsTable from "components/UpdateCampaignsTable";
 import { Link, Route } from "Navigation";
 
+const UPDATE_CAMPAIGNS_TO_LOAD_FIRST = 40;
+
 const GET_UPDATE_CAMPAIGNS_QUERY = graphql`
-  query UpdateCampaigns_getUpdateCampaigns_Query {
-    updateCampaigns {
-      ...UpdateCampaignsTable_UpdateCampaignFragment
-    }
+  query UpdateCampaigns_getUpdateCampaigns_Query(
+    $first: Int
+    $after: String
+    $filter: UpdateCampaignFilterInput
+  ) {
+    ...UpdateCampaignsTable_UpdateCampaignFragment @arguments(filter: $filter)
   }
 `;
 
@@ -47,7 +52,7 @@ type UpdateCampaignsContentProps = {
 const UpdateCampaignsContent = ({
   getUpdateCampaignsQuery,
 }: UpdateCampaignsContentProps) => {
-  const { updateCampaigns } = usePreloadedQuery(
+  const updateCampaignsData = usePreloadedQuery(
     GET_UPDATE_CAMPAIGNS_QUERY,
     getUpdateCampaignsQuery,
   );
@@ -70,7 +75,7 @@ const UpdateCampaignsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <UpdateCampaignsTable updateCampaignsRef={updateCampaigns} />
+        <UpdateCampaignsTable updateCampaignsData={updateCampaignsData} />
       </Page.Main>
     </Page>
   );
@@ -83,7 +88,11 @@ const UpdateCampaignsPage = () => {
     );
 
   const fetchUpdateCampaigns = useCallback(
-    () => getUpdateCampaigns({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getUpdateCampaigns(
+        { first: UPDATE_CAMPAIGNS_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getUpdateCampaigns],
   );
 

--- a/frontend/src/pages/UpdateChannels.tsx
+++ b/frontend/src/pages/UpdateChannels.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 
 import type { UpdateChannels_getUpdateChannels_Query } from "api/__generated__/UpdateChannels_getUpdateChannels_Query.graphql";
+
 import Button from "components/Button";
 import Center from "components/Center";
 import UpdateChannelsTable from "components/UpdateChannelsTable";
@@ -32,11 +33,15 @@ import Page from "components/Page";
 import Spinner from "components/Spinner";
 import { Link, Route } from "Navigation";
 
+const UPDATE_CHANNELS_TO_LOAD_FIRST = 40;
+
 const GET_UPDATE_CHANNELS_QUERY = graphql`
-  query UpdateChannels_getUpdateChannels_Query {
-    updateChannels {
-      ...UpdateChannelsTable_UpdateChannelFragment
-    }
+  query UpdateChannels_getUpdateChannels_Query(
+    $first: Int
+    $after: String
+    $filter: UpdateChannelFilterInput
+  ) {
+    ...UpdateChannelsTable_UpdateChannelFragment @arguments(filter: $filter)
   }
 `;
 
@@ -47,7 +52,7 @@ type UpdateChannelsContentProps = {
 const UpdateChannelsContent = ({
   getUpdateChannelsQuery,
 }: UpdateChannelsContentProps) => {
-  const { updateChannels } = usePreloadedQuery(
+  const updateChannels = usePreloadedQuery(
     GET_UPDATE_CHANNELS_QUERY,
     getUpdateChannelsQuery,
   );
@@ -83,7 +88,11 @@ const UpdateChannelsPage = () => {
     );
 
   const fetchUpdateChannels = useCallback(
-    () => getUpdateChannels({}, { fetchPolicy: "store-and-network" }),
+    () =>
+      getUpdateChannels(
+        { first: UPDATE_CHANNELS_TO_LOAD_FIRST },
+        { fetchPolicy: "store-and-network" },
+      ),
     [getUpdateChannels],
   );
 


### PR DESCRIPTION
Merge changes regarding server side pagination into the main branch.

In summary:
- GraphQL API that return unbounded lists now use Relay/keyset pagination.
- Edgehog's dashboard now relies on server-side pagination for queries and filtering, and uses tables with infinite scrolling instead of client-side paginated tables.

The [group → devices relationship](https://github.com/edgehog-device-manager/edgehog/blob/374c44e4c725e491e4692c1521e4d77ef2db8674/backend/lib/edgehog/groups/device_group/device_group.ex#L128) was left behind for now, as it is not trivial to paginate since it is based on dynamic group selectors.