### PR TITLE
feat(containers): Add UI to specify extra hosts

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -64,6 +64,7 @@ const CONTAINERS_TABLE_FRAGMENT = graphql`
         node {
           id
           env
+          extraHosts
           hostname
           networkMode
           portBindings
@@ -464,6 +465,18 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
           readonly={true}
           initialLines={1}
         />
+      </FormRow>
+
+      <FormRow
+        id={`containers-${index}-extraHosts`}
+        label={
+          <FormattedMessage
+            id="components.ContainersTable.extraHostsLabel"
+            defaultMessage="Extra Hosts"
+          />
+        }
+      >
+        <Form.Control value={container.extraHosts?.join(", ") ?? ""} readOnly />
       </FormRow>
 
       <FormRow

--- a/frontend/src/forms/index.ts
+++ b/frontend/src/forms/index.ts
@@ -83,6 +83,10 @@ const messages = defineMessages({
     defaultMessage:
       "Port Bindings must be comma-separated values like '8080:80, 443:443'.",
   },
+  extraHostsFormat: {
+    id: "validation.extraHosts.format",
+    defaultMessage: "Must be in the form hostname:IP (e.g., myhost:127.0.0.1)",
+  },
 });
 
 yup.setLocale({
@@ -199,6 +203,25 @@ const storageTmpfsOptSchema = yup
     },
   });
 
+const extraHostsSchema = yup
+  .array()
+  .nullable()
+  .of(
+    yup
+      .string()
+      .required()
+      .test({
+        name: "is-valid-extra-host",
+        message: messages.extraHostsFormat.id,
+        test: (value) => {
+          if (!value) return true;
+          const regex =
+            /^(?!-)[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63})*:(?:\d{1,3}\.){3}\d{1,3}$/;
+          return regex.test(value.trim());
+        },
+      }),
+  );
+
 export {
   deviceGroupHandleSchema,
   systemModelHandleSchema,
@@ -211,6 +234,7 @@ export {
   numberSchema,
   envSchema,
   portBindingsSchema,
+  extraHostsSchema,
   messages,
   yup,
   storageTmpfsOptSchema,

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -286,6 +286,9 @@
   "components.ContainersTable.envLabel": {
     "defaultMessage": "Environment (JSON String)"
   },
+  "components.ContainersTable.extraHostsLabel": {
+    "defaultMessage": "Extra Hosts"
+  },
   "components.ContainersTable.hostnameLabel": {
     "defaultMessage": "Hostname"
   },
@@ -454,6 +457,9 @@
   "components.CreateRelease.addContainerButton": {
     "defaultMessage": "Add Container"
   },
+  "components.CreateRelease.addExtraHostButton": {
+    "defaultMessage": "Add Extra Host"
+  },
   "components.CreateRelease.confirmButton": {
     "defaultMessage": "Confirm"
   },
@@ -480,6 +486,9 @@
   },
   "components.CreateRelease.envLabel": {
     "defaultMessage": "Environment (JSON String)"
+  },
+  "components.CreateRelease.extraHostsLabel": {
+    "defaultMessage": "Extra Hosts"
   },
   "components.CreateRelease.hostnameLabel": {
     "defaultMessage": "Hostname"
@@ -531,6 +540,21 @@
   },
   "components.CreateRelease.restartPolicyOption": {
     "defaultMessage": "Select a Restart Policy"
+  },
+  "components.CreateRelease.reuseResourcesButton": {
+    "defaultMessage": "Reuse Containers"
+  },
+  "components.CreateRelease.reuseResourcesModalTitle": {
+    "defaultMessage": "Reuse Resources Modal"
+  },
+  "components.CreateRelease.reuseResourcesTitleButton": {
+    "defaultMessage": "Copy containers and their configurations from an existing release"
+  },
+  "components.CreateRelease.selectApplication": {
+    "defaultMessage": "Select Application"
+  },
+  "components.CreateRelease.selectRelease": {
+    "defaultMessage": "Select Release"
   },
   "components.CreateRelease.storageOptLabel": {
     "defaultMessage": "Storage Options"
@@ -738,6 +762,26 @@
   "components.DeviceGroupsTable.selectorTitle": {
     "defaultMessage": "Selector",
     "description": "Title for the Selector column of the device groups table"
+  },
+  "components.DevicesGroupsTable.deviceIdTitle": {
+    "defaultMessage": "Device ID",
+    "description": "Title for the Device ID column of the devices table"
+  },
+  "components.DevicesGroupsTable.lastSeenTitle": {
+    "defaultMessage": "Last Seen",
+    "description": "Title for the Last Seen column of the devices table"
+  },
+  "components.DevicesGroupsTable.nameTitle": {
+    "defaultMessage": "Device Name",
+    "description": "Title for the Name column of the devices table"
+  },
+  "components.DevicesGroupsTable.statusTitle": {
+    "defaultMessage": "Status",
+    "description": "Title for the Status column of the devices table"
+  },
+  "components.DevicesGroupsTable.tagsTitle": {
+    "defaultMessage": "Tags",
+    "description": "Title for the Tags column of the devices table"
   },
   "components.DevicesTable.deviceIdTitle": {
     "defaultMessage": "Device ID",
@@ -1577,9 +1621,6 @@
   "pages.Application.releases": {
     "defaultMessage": "Releases"
   },
-  "pages.Application.systemModel": {
-    "defaultMessage": "System Model"
-  },
   "pages.ApplicationCreate.creationErrorFeedback": {
     "defaultMessage": "Could not create the application, please try again."
   },
@@ -2094,6 +2135,9 @@
   },
   "validation.env.invalidJson": {
     "defaultMessage": "Must be a valid JSON string."
+  },
+  "validation.extraHosts.format": {
+    "defaultMessage": "Must be in the form hostname:IP (e.g., myhost:127.0.0.1)"
   },
   "validation.handle.format": {
     "defaultMessage": "The handle must start with a letter and only contain lower case characters, numbers or the hyphen symbol -"


### PR DESCRIPTION
- Now Edgehog UI supports to optionally specify extra hosts when defining a container

<details>
<summary>
Screenshots
</summary>

<img width="1843" height="993" alt="Screenshot from 2025-08-29 09-04-04" src="https://github.com/user-attachments/assets/e0f8d630-9a63-41ab-8aa1-822ad6797f3e" />
<img width="1843" height="993" alt="Screenshot from 2025-08-29 09-08-49" src="https://github.com/user-attachments/assets/f873ad12-9453-4e2b-85dd-a02eb8107189" />

</details>