### PR TITLE
feat(containers): allow adding/dropping container capabilities in UI

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -36,6 +36,7 @@ import Col from "components/Col";
 import Form from "components/Form";
 import Row from "components/Row";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
+import MultiSelect from "./MultiSelect";
 
 const FormRow = ({
   id,
@@ -80,6 +81,8 @@ const CONTAINERS_TABLE_FRAGMENT = graphql`
           tmpfs
           storageOpt
           readOnlyRootfs
+          capAdd
+          capDrop
           image {
             reference
             credentials {
@@ -711,6 +714,54 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
           readonly={true}
           initialLines={1}
         />
+      </FormRow>
+
+      <FormRow
+        id={`containers-${index}-capAdd`}
+        label={
+          <FormattedMessage
+            id="components.ContainersTable.capAdd"
+            defaultMessage="Cap Add"
+          />
+        }
+      >
+        {(container.capAdd || []).length > 0 ? (
+          <MultiSelect
+            value={(container.capAdd || []).map((cap) => ({
+              id: cap,
+              name: cap,
+            }))}
+            getOptionValue={(option) => option.id}
+            getOptionLabel={(option) => option.name}
+            disabled={true}
+          />
+        ) : (
+          <div className="text-muted fst-italic">None</div>
+        )}
+      </FormRow>
+
+      <FormRow
+        id={`containers-${index}-capDrop`}
+        label={
+          <FormattedMessage
+            id="components.ContainersTable.capDrop"
+            defaultMessage="Cap Drop"
+          />
+        }
+      >
+        {(container.capDrop || []).length > 0 ? (
+          <MultiSelect
+            value={(container.capDrop || []).map((cap) => ({
+              id: cap,
+              name: cap,
+            }))}
+            getOptionValue={(option) => option.id}
+            getOptionLabel={(option) => option.name}
+            disabled={true}
+          />
+        ) : (
+          <div className="text-muted fst-italic">None</div>
+        )}
       </FormRow>
 
       <NetworkDetails networks={container.networks} containerIndex={index} />


### PR DESCRIPTION
Enable users to manage container Linux capabilities via the UI:
- Cap Drop: remove capabilities that are enabled by default.
- Cap Add: grant capabilities that are not allowed by default.

 <details>
<summary>
Screenshots
</summary>
<img width="1797" height="964" alt="cap-add-drop" src="https://github.com/user-attachments/assets/1fc3973c-ac82-4296-bd07-5c693c9ade3d" />



<img width="1879" height="958" alt="Screenshot from 2025-09-01 14-09-17" src="https://github.com/user-attachments/assets/9046741e-831e-4e7d-aa01-db42cae9cce0" />
</details>



