### PR TITLE
chore(containers): update Astarte interfaces

### DIFF
--- a/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
+++ b/backend/lib/edgehog/astarte/device/create_container_request/request_data.ex
@@ -21,9 +21,6 @@
 defmodule Edgehog.Astarte.Device.CreateContainerRequest.RequestData do
   @moduledoc false
 
-  # TODO the interface for now has the :image key, this is a device
-  # problem, once solved it should be removed
-
   defstruct [
     :id,
     :deploymentId,

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -274,9 +274,19 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
           |> Containers.mark_deployment_as_starting!(tenant: tenant)
           |> Containers.deployment_update_resources_state(tenant: tenant)
 
+        "Started" ->
+          deployment
+          |> Containers.mark_deployment_as_started!(tenant: tenant)
+          |> Containers.deployment_update_resources_state(tenant: tenant)
+
         "Stopping" ->
           deployment
           |> Containers.mark_deployment_as_stopping!(tenant: tenant)
+          |> Containers.deployment_update_resources_state(tenant: tenant)
+
+        "Stopped" ->
+          deployment
+          |> Containers.mark_deployment_as_stopped!(tenant: tenant)
           |> Containers.deployment_update_resources_state(tenant: tenant)
 
         "Error" ->

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.AvailableDeviceMappings.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.AvailableDeviceMappings.json
@@ -1,0 +1,15 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.AvailableDeviceMappings",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "mappings": [
+    {
+      "allow_unset": true,
+      "endpoint": "/%{device_mapping_id}/present",
+      "type": "boolean",
+      "description": "The device is present on the host"
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -130,7 +130,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "A list of kernel capabilities to add to the container.",
-      "doc": "A list of kernel capabilities to add to the container. Conflicts with option 'Capabilities'."
+      "doc": "A list of kernel capabilities to add to the container."
     },
     {
       "endpoint": "/container/capDrop",
@@ -139,7 +139,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "A list of kernel capabilities to drop from the container.",
-      "doc": "A list of kernel capabilities to drop from the container. Conflicts with option 'Capabilities'."
+      "doc": "A list of kernel capabilities to drop from the container."
     },
     {
       "endpoint": "/container/cpuPeriod",
@@ -187,7 +187,7 @@
       "doc": "Memory limit in bytes. Default to 0 for unlimited. Unset if the value is -1 (or negative)."
     },
     {
-      "endpoint": "/container/memoryReservetion",
+      "endpoint": "/container/memoryReservation",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container."
     },
     {
+      "endpoint": "/deviceMapping/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the device mapping",
+      "doc": "The deployment in which the device mapping is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/deviceMapping/pathOnHost",
       "type": "string",
       "database_retention_policy": "use_ttl",
@@ -30,7 +39,8 @@
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
-      "description": "Path in the container for the device"
+      "description": "Path in the container for the device",
+      "doc": "Path in the container for the device, for example '/dev/deviceName'"
     },
     {
       "endpoint": "/deviceMapping/cGroupPermissions",

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateImageRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateImageRequest.json
@@ -24,7 +24,7 @@
       "database_retention_ttl": 600,
       "reliability": "guaranteed",
       "description": "Reference to a Deployment using the image",
-      "doc": "The deployment in which the image is used, so the device can send deployment events to Astarte for te create request"
+      "doc": "The deployment in which the image is used, so the device can send deployment events to Astarte for the create request"
     },
     {
       "endpoint": "/image/reference",

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -58,7 +58,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver options",
-      "doc": "An array of key=value options. The key cannot contain `=`. to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -40,7 +40,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver options",
-      "doc": "An array of key=value options. The key cannot contain `=`. to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.DeploymentEvent.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.DeploymentEvent.json
@@ -11,14 +11,16 @@
       "type": "string",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
+      "explicit_timestamp": true,
       "description": "Deployment status",
-      "doc": "Possible values: [Starting, Stopping, Updating, Deleting, Error]"
+      "doc": "Possible values: [Starting, Started, Stopping, Stopped, Updating, Deleting, Error]"
     },
     {
       "endpoint": "/%{deployment_id}/message",
       "type": "string",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
+      "explicit_timestamp": true,
       "description": "Optional message for the event"
     }
   ]


### PR DESCRIPTION
- Update the Astarte interfaces used by Edgehog to their latest versions.
- Correctly handle updates on the `io.edgehog.devicemanager.apps.DeploymentEvent` Astarte interface about deployments that become Started or Stopped, a couple of new states that can now be published via the interface. Upon these events, the corresponding deployment is marked to report the correct status and resources state.