### PR TITLE
feat(containers): use delivery policy on all Astarte triggers

### DIFF
--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-containers.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-containers.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-deployments.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-deployments.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-images.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-images.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-networks.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-networks.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-volumes.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-volumes.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-deployment-event.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-deployment-event.json.eex
@@ -16,4 +16,7 @@
             "value_match_operator": "*"
         }
     ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
 }


### PR DESCRIPTION
Ensure that all triggers that need to deliver messages from Astarte to Edgehog employ the delivery policy defined by Edgehog. This ensures that delivery of messages is retried in case of errors in receiving them.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
