### PR TITLE
feat: add support for private Docker registry

### DIFF
--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -269,6 +269,39 @@ app_nginx_8081 =
     tenant: tenant
   )
 
+self_hosted_credentials =
+  Ash.create!(
+    ImageCredentials,
+    %{label: "Self-hosted registry credentials", username: "admin", password: "admin"},
+    tenant: tenant
+  )
+
+app_test_dev_self_hosted =
+  Ash.create!(
+    Application,
+    %{
+      name: "Self-hosted app",
+      description: "It was sample for self-hosted deployments.",
+      initial_release: %{
+        version: "0.0.1",
+        containers: [
+          %{
+            image: %{
+              reference: "registry.edgehog.localhost/test/http-echo:latest",
+              image_credentials_id: self_hosted_credentials.id
+            },
+            restart_policy: :unless_stopped,
+            hostname: "",
+            env: %{},
+            privileged: false,
+            port_bindings: ["5678:5678"]
+          }
+        ]
+      }
+    },
+    tenant: tenant
+  )
+
 image_credentials =
   Ash.create!(
     ImageCredentials,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,70 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2021-2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+services:
+  registry:
+    image: registry:2
+    restart: on-failure
+    environment:
+      REGISTRY_AUTH: htpasswd
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry-Realm
+      REGISTRY_AUTH_HTPASSWD_PATH: /auth/registry.passwd
+      REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY: /data
+    volumes:
+      - registry-auth:/auth
+      - registry-data:/var/lib/registry
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.edgehog-registry.rule=Host(`registry.${DOCKER_COMPOSE_EDGEHOG_BASE_DOMAIN}`)"
+    - "traefik.http.routers.edgehog-registry.entrypoints=web"
+    - "traefik.http.routers.edgehog-registry.service=edgehog-registry"
+    - "traefik.http.services.edgehog-registry.loadbalancer.server.port=5000"
+  registry-auth:
+    image: httpd:2.4
+    depends_on:
+      - registry
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "htpasswd -Bbn admin admin > /auth/registry.passwd"
+    volumes:
+      - registry-auth:/auth
+  registry-init:
+    image: docker:25.0.3-dind
+    depends_on:
+      - registry
+    privileged: true
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["
+      dockerd --insecure-registry registry:5000 &
+      echo 'Waiting for Docker daemon to be ready...' &&
+      until docker info >/dev/null 2>&1; do sleep 1; done &&
+      echo 'Docker daemon ready, signing in with registry...' &&
+      echo 'admin' | docker login registry:5000 -u admin --password-stdin &&
+      echo 'Signed in with registry, pulling sample images...' &&
+      docker pull hashicorp/http-echo &&
+      echo 'Tagging sample images...' &&
+      docker tag hashicorp/http-echo registry:5000/test/http-echo &&
+      echo 'Pushing sample images...' &&
+      docker push registry:5000/test/http-echo &&
+      echo 'Images preloaded.'"]
+
+volumes:
+  registry-auth:
+  registry-data:


### PR DESCRIPTION
This PR adds support for using a private Docker registry in the development environment.

Changes

- Modify `docker-compose.dev.yml` to use external Docker registry network
- Update service commands to work with the private registry
- Add login and push/pull steps for registry authentication
- Update `seeds.exs` to register application with private registry image

Command: 

```
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
```
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

[*] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
[*] Make sure to open your PR against the right branch: master / release-VERSION
[*] Make sure to sign-off all your commits
[*] GPG signing is appreciated
[*] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
