### PR TITLE
feat(containers): handle Astarte triggers on available device mappings

### DIFF
--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -274,6 +274,7 @@ defmodule Edgehog.Containers do
 
       define :mark_device_mapping_deployment_as_sent, action: :mark_as_sent
       define :mark_device_mapping_deployment_as_present, action: :mark_as_present
+      define :mark_device_mapping_deployment_as_not_present, action: :mark_as_not_present
 
       define :mark_device_mapping_deployment_as_errored,
         action: :mark_as_errored,

--- a/backend/lib/edgehog/containers/device_mapping/deployment.ex
+++ b/backend/lib/edgehog/containers/device_mapping/deployment.ex
@@ -70,6 +70,10 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
       change set_attribute(:state, :present)
     end
 
+    update :mark_as_not_present do
+      change set_attribute(:state, :not_present)
+    end
+
     update :mark_as_errored do
       argument :message, :string do
         allow_nil? false
@@ -87,7 +91,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
 
     attribute :state, :atom,
       constraints: [
-        one_of: [:created, :sent, :present, :error]
+        one_of: [:created, :sent, :present, :not_present, :error]
       ]
 
     timestamps()
@@ -102,7 +106,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
   end
 
   calculations do
-    calculate :ready?, :boolean, expr(state == :present)
+    calculate :ready?, :boolean, expr(state in [:present, :not_present])
   end
 
   identities do

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-available-device-mappings.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-available-device-mappings.json.eex
@@ -1,0 +1,22 @@
+{
+    "name": "edgehog-available-device-mappings",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "http_method": "post",
+        "http_static_headers": {},
+        "ignore_ssl_errors": false
+    },
+    "simple_triggers": [
+        {
+            "type": "data_trigger",
+            "interface_name": "io.edgehog.devicemanager.apps.AvailableDeviceMappings",
+            "interface_major": 0,
+            "on": "incoming_data",
+            "match_path": "/*",
+            "value_match_operator": "*"
+        }
+    ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
+}


### PR DESCRIPTION
Add support for handling incoming trigger events about device mappings when the device acknowledges their definition and assert whether each device mapping is present or not.

This change also adds the Astarte trigger template that Edgehog will automatically installs in Astarte to ensure that trigger events are delivered to Edgehog.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
