### PR TITLE
feat(pagination): Deployments infinite scroll table

### DIFF
--- a/frontend/src/pages/Deployments.tsx
+++ b/frontend/src/pages/Deployments.tsx
@@ -31,11 +31,15 @@ import DeploymentsTable from "components/DeploymentsTable";
 import Page from "components/Page";
 import Spinner from "components/Spinner";
 
-const DEPLOYMENTS_TO_LOAD_FIRST = 10_000;
+const DEPLOYMENTS_TO_LOAD_FIRST = 40;
 
 const GET_DEPLOYMENTS_QUERY = graphql`
-  query Deployments_getDeployments_Query($first: Int, $after: String) {
-    ...DeploymentsTable_DeploymentFragment
+  query Deployments_getDeployments_Query(
+    $first: Int
+    $after: String
+    $filter: DeploymentFilterInput
+  ) {
+    ...DeploymentsTable_DeploymentFragment @arguments(filter: $filter)
   }
 `;
 


### PR DESCRIPTION
Load data page by page with infinite scrolling.
Filter deployments by app, release, device.

<details>
<summary>
Screenshots
</summary>

<img width="1836" height="920" alt="Screenshot from 2025-09-10 09-33-57" src="https://github.com/user-attachments/assets/90ee910d-6473-4e02-b574-82c97fbe6804" />

<img width="1836" height="920" alt="image" src="https://github.com/user-attachments/assets/49cbc84d-e2af-4cf6-bc1e-c3ec1db6c073" />


<img width="1836" height="920" alt="Screenshot from 2025-09-10 09-34-17" src="https://github.com/user-attachments/assets/3aca7c73-fad3-4cbd-941d-333e5428e5ad" />

<img width="1836" height="920" alt="Screenshot from 2025-09-10 09-37-17" src="https://github.com/user-attachments/assets/1bf78b9c-109f-4b8a-a174-ae1220e6b83f" />

</details>