### PR TITLE
feat(containers): update reuse release functionality

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1205,14 +1205,14 @@
   "forms.CreateRelease.restartPolicyOption": {
     "defaultMessage": "Select a Restart Policy"
   },
-  "forms.CreateRelease.reuseResourcesButton": {
-    "defaultMessage": "Reuse Containers"
+  "forms.CreateRelease.reuseReleaseButton": {
+    "defaultMessage": "Reuse Release"
+  },
+  "forms.CreateRelease.reuseReleaseTitleButton": {
+    "defaultMessage": "Copy configuration from an existing release"
   },
   "forms.CreateRelease.reuseResourcesModalTitle": {
     "defaultMessage": "Reuse Resources Modal"
-  },
-  "forms.CreateRelease.reuseResourcesTitleButton": {
-    "defaultMessage": "Copy containers and their configurations from an existing release"
   },
   "forms.CreateRelease.selectApplication": {
     "defaultMessage": "Select Application"


### PR DESCRIPTION
- Moved the "Reuse Containers" button to make it clear the entire release is being reused.
- Renamed the button to "Reuse Release".
- Updated reuse functionality to copy newly added container fields
<img width="1856" height="993" alt="image" src="https://github.com/user-attachments/assets/a91ce724-0df7-4aaf-b3f0-ff064e663e24" />

