### PR TITLE
Add navigation routes for Deployment Campaigns

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021 - 2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ import Networks from "pages/Networks";
 import Network from "pages/Network";
 import NetworkCreatePage from "pages/NetworkCreate";
 import DeploymentsPage from "pages/Deployments";
+import DeploymentCampaignsPage from "pages/DeploymentCampaigns";
 
 import { bugs, repository, version } from "../package.json";
 
@@ -120,6 +121,7 @@ const authenticatedRoutes: RouterRule[] = [
   { path: Route.networksEdit, element: <Network /> },
   { path: Route.networksNew, element: <NetworkCreatePage /> },
   { path: Route.deployments, element: <DeploymentsPage /> },
+  { path: Route.deploymentCampaigns, element: <DeploymentCampaignsPage /> },
   { path: Route.logout, element: <Logout /> },
   { path: "*", element: <Navigate to={Route.devices} replace /> },
 ];

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -68,6 +68,9 @@ enum Route {
   networksEdit = "/networks/:networkId",
   networksNew = "/networks/new",
   deployments = "/deployments",
+  deploymentCampaigns = "/deployment-campaigns",
+  deploymentCampaignsNew = "/deployment-campaigns/new",
+  deploymentCampaignsEdit = "/deployment-campaigns/:deploymentCampaignId",
   login = "/login",
   logout = "/logout",
 }
@@ -123,6 +126,9 @@ const matchingParametricRoute = (
     case Route.networks:
     case Route.networksNew:
     case Route.deployments:
+    case Route.deploymentCampaigns:
+    case Route.deploymentCampaignsNew:
+    case Route.deploymentCampaignsEdit:
     case Route.login:
     case Route.logout:
       return { route } as ParametricRoute;
@@ -453,6 +459,18 @@ const routeTitles: Record<Route, MessageDescriptor> = defineMessages({
   [Route.deployments]: {
     id: "navigation.routeTitle.Deployments",
     defaultMessage: "Deployments",
+  },
+  [Route.deploymentCampaigns]: {
+    id: "navigation.routeTitle.DeploymentCampaigns",
+    defaultMessage: "Campaigns",
+  },
+  [Route.deploymentCampaignsNew]: {
+    id: "navigation.routeTitle.DeploymentCampaignsNew",
+    defaultMessage: "Create Campaign",
+  },
+  [Route.deploymentCampaignsEdit]: {
+    id: "navigation.routeTitle.DeploymentCampaignsEdit",
+    defaultMessage: "Edit Campaign",
   },
 });
 

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2024 SECO Mind Srl
+  Copyright 2021 - 2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -94,6 +94,7 @@ const useBreadcrumbItems = (): BreadcrumbItem[] => {
       case Route.volumes:
       case Route.networks:
       case Route.deployments:
+      case Route.deploymentCampaigns:
       case Route.login:
       case Route.logout:
         return [currentRoute];

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021-2023 SECO Mind Srl
+  Copyright 2021 - 2025 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -273,6 +273,20 @@ const Sidebar = () => (
         }
         route={Route.deployments}
         activeRoutes={[Route.deployments]}
+      />
+      <SidebarItem
+        label={
+          <FormattedMessage
+            id="components.Sidebar.applications.campaignsLabel"
+            defaultMessage="Campaigns"
+          />
+        }
+        route={Route.deploymentCampaigns}
+        activeRoutes={[
+          Route.deploymentCampaigns,
+          Route.deploymentCampaignsEdit,
+          Route.deploymentCampaignsNew,
+        ]}
       />
     </SidebarItemGroup>
   </Navbar>

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -845,6 +845,9 @@
   "components.Sidebar.applications.applicationsLabel": {
     "defaultMessage": "Applications"
   },
+  "components.Sidebar.applications.campaignsLabel": {
+    "defaultMessage": "Campaigns"
+  },
   "components.Sidebar.applications.credentialsLabel": {
     "defaultMessage": "Image Credentials"
   },
@@ -1543,6 +1546,15 @@
   "navigation.routeTitle.BaseImagesNew": {
     "defaultMessage": "Create Base Image"
   },
+  "navigation.routeTitle.DeploymentCampaigns": {
+    "defaultMessage": "Campaigns"
+  },
+  "navigation.routeTitle.DeploymentCampaignsEdit": {
+    "defaultMessage": "Edit Campaign"
+  },
+  "navigation.routeTitle.DeploymentCampaignsNew": {
+    "defaultMessage": "Create Campaign"
+  },
   "navigation.routeTitle.Deployments": {
     "defaultMessage": "Deployments"
   },
@@ -1747,6 +1759,9 @@
   },
   "pages.BaseImageCreate.title": {
     "defaultMessage": "Create Base Image"
+  },
+  "pages.Campaigns.title": {
+    "defaultMessage": "Campaigns"
   },
   "pages.Deployments.title": {
     "defaultMessage": "Deployments"

--- a/frontend/src/pages/DeploymentCampaigns.tsx
+++ b/frontend/src/pages/DeploymentCampaigns.tsx
@@ -1,0 +1,66 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { FormattedMessage } from "react-intl";
+
+import Center from "components/Center";
+import Page from "components/Page";
+import Spinner from "components/Spinner";
+
+const DeploymentCampaignsContent = () => {
+  return (
+    <Page>
+      <Page.Header
+        title={
+          <FormattedMessage
+            id="pages.Campaigns.title"
+            defaultMessage="Campaigns"
+          />
+        }
+      />
+    </Page>
+  );
+};
+
+const DeploymentCampaignsPage = () => {
+  return (
+    <Suspense
+      fallback={
+        <Center data-testid="page-loading">
+          <Spinner />
+        </Center>
+      }
+    >
+      <ErrorBoundary
+        FallbackComponent={(props) => (
+          <Center data-testid="page-error">
+            <Page.LoadingError onRetry={props.resetErrorBoundary} />
+          </Center>
+        )}
+      >
+        <DeploymentCampaignsContent />
+      </ErrorBoundary>
+    </Suspense>
+  );
+};
+
+export default DeploymentCampaignsPage;


### PR DESCRIPTION
- Added routes in `Navigation.tsx`:

  - `deploymentCampaigns = "/deployment-campaigns"`,
  - `deploymentCampaignsNew = "/deployment-campaigns/new"`, 
  - `deploymentCampaignsEdit = "/deployment-campaigns/:deploymentCampaignId"`

- Added new Campaigns menu item in the Applications sidebar section

<img width="1919" height="777" alt="image" src="https://github.com/user-attachments/assets/1efea9e2-f480-407a-b9f1-ac5451028660" />

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
