### PR TITLE
feat(containers): UI to support mounting device files on containers

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -298,6 +298,9 @@
   "components.ContainersTable.cpuRealtimeRuntimeLabel": {
     "defaultMessage": "CPU Realtime Runtime (in microseconds)"
   },
+  "components.ContainersTable.deviceMappingsLabel": {
+    "defaultMessage": "Device Mappings"
+  },
   "components.ContainersTable.envLabel": {
     "defaultMessage": "Environment (JSON String)"
   },
@@ -348,6 +351,9 @@
   },
   "components.ContainersTable.noContainers": {
     "defaultMessage": "No containers available."
+  },
+  "components.ContainersTable.noDeviceMappings": {
+    "defaultMessage": "No device mappings assigned."
   },
   "components.ContainersTable.noNetworks": {
     "defaultMessage": "No networks assigned."
@@ -1173,6 +1179,9 @@
   "forms.CreateRelease.addContainerButton": {
     "defaultMessage": "Add Container"
   },
+  "forms.CreateRelease.addDeviceMappingButton": {
+    "defaultMessage": "Add Device Mapping"
+  },
   "forms.CreateRelease.addExtraHostButton": {
     "defaultMessage": "Add Extra Host"
   },
@@ -1184,6 +1193,9 @@
   },
   "forms.CreateRelease.capDropLabel": {
     "defaultMessage": "Cap Drop"
+  },
+  "forms.CreateRelease.cgroupPermissionsLabel": {
+    "defaultMessage": "Container Group Permissions"
   },
   "forms.CreateRelease.confirmButton": {
     "defaultMessage": "Confirm"
@@ -1208,6 +1220,9 @@
   },
   "forms.CreateRelease.cpuRealtimeRuntimeLabel": {
     "defaultMessage": "CPU Real-Time Runtime (microseconds)"
+  },
+  "forms.CreateRelease.deviceMappingsLabel": {
+    "defaultMessage": "Device Mappings"
   },
   "forms.CreateRelease.envLabel": {
     "defaultMessage": "Environment (JSON String)"
@@ -1247,6 +1262,12 @@
   },
   "forms.CreateRelease.noVolumesMessage": {
     "defaultMessage": "No volumes available"
+  },
+  "forms.CreateRelease.pathInContainerLabel": {
+    "defaultMessage": "Path In Container"
+  },
+  "forms.CreateRelease.pathOnHostLabel": {
+    "defaultMessage": "Path On Host"
   },
   "forms.CreateRelease.portBindingsLabel": {
     "defaultMessage": "Port Bindings"


### PR DESCRIPTION
From Edgehog's UI, when creating a release, it is possible to optionally specify device files that need to be mounted on a container. The files are displayed under `Device mappings` section.

<details>
<summary>
Screenshots
</summary>

<img width="1894" height="902" alt="Screenshot from 2025-09-15 09-36-21" src="https://github.com/user-attachments/assets/a43d33c7-e3a8-416b-ac79-5034cfdc937e" />

<img width="1890" height="948" alt="Screenshot from 2025-09-15 09-37-10" src="https://github.com/user-attachments/assets/2d5ce171-0e7a-40be-b24a-bf36d33a192e" />

<img width="1890" height="948" alt="Screenshot from 2025-09-15 09-36-45" src="https://github.com/user-attachments/assets/a909ce36-7a4d-4161-bc23-5fa4d20cb6c3" />

</details>
