### PR TITLE
feat(containers): Add Deployment Targets Table to Campaign Page 

### DIFF
--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -880,6 +880,8 @@ const DeployedApplicationsTable = ({
   );
 };
 
+// TODO: Make dedicated files for these components
+export { DeploymentStateComponent, DeploymentResourcesStateComponent };
+
 export type { DeploymentTableProps, DeploymentState };
-export { DeploymentStateComponent };
 export default DeployedApplicationsTable;

--- a/frontend/src/components/DeploymentTargetsTable.tsx
+++ b/frontend/src/components/DeploymentTargetsTable.tsx
@@ -1,0 +1,229 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { FormattedDate, FormattedMessage } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
+
+import type {
+  DeploymentTargetsTable_DeploymentTargetsFragment$data,
+  DeploymentTargetsTable_DeploymentTargetsFragment$key,
+} from "api/__generated__/DeploymentTargetsTable_DeploymentTargetsFragment.graphql";
+
+import { createColumnHelper } from "components/Table";
+import InfiniteTable from "components/InfiniteTable";
+import {
+  DeploymentResourcesStateComponent,
+  DeploymentStateComponent,
+} from "components/DeployedApplicationsTable";
+import { Link, Route } from "Navigation";
+
+// We use graphql fields below in columns configuration
+/* eslint-disable relay/unused-fields */
+const DEPLOYMENT_TARGETS_TABLE_FRAGMENT = graphql`
+  fragment DeploymentTargetsTable_DeploymentTargetsFragment on DeploymentTarget
+  @relay(plural: true) {
+    device {
+      id
+      name
+    }
+    latestAttempt
+    completionTimestamp
+    deployment {
+      state
+      resourcesState
+      lastErrorMessage
+    }
+  }
+`;
+
+type TableRecord =
+  DeploymentTargetsTable_DeploymentTargetsFragment$data[number];
+const columnIds = [
+  "deviceName",
+  "state",
+  "resourcesState",
+  "lastErrorMessage",
+  "latestAttempt",
+  "completionTimestamp",
+] as const;
+type ColumnId = (typeof columnIds)[number];
+
+const columnHelper = createColumnHelper<TableRecord>();
+const columns = [
+  columnHelper.accessor("device.name", {
+    id: "deviceName",
+    header: () => (
+      <FormattedMessage
+        id="components.DeploymentTargetsTable.deviceNameTitle"
+        defaultMessage="Device Name"
+        description="Title for the Device Name column of the Deployment Targets table"
+      />
+    ),
+    cell: ({ row, getValue }) => (
+      <Link
+        route={Route.devicesEdit}
+        params={{ deviceId: row.original.device.id }}
+      >
+        {getValue()}
+      </Link>
+    ),
+  }),
+  columnHelper.accessor(
+    (deploymentTarget) => deploymentTarget.deployment?.state ?? null,
+    {
+      id: "state",
+      header: () => (
+        <FormattedMessage
+          id="components.DeploymentTargetsTable.stateTitle"
+          defaultMessage="State"
+          description="Title for the State column of the Deployment Targets table"
+        />
+      ),
+      cell: ({ getValue }) => {
+        const state = getValue();
+        return state && <DeploymentStateComponent state={state} />;
+      },
+    },
+  ),
+  columnHelper.accessor(
+    (deploymentTarget) => deploymentTarget.deployment?.resourcesState ?? null,
+    {
+      id: "resourcesState",
+      header: () => (
+        <FormattedMessage
+          id="components.DeploymentTargetsTable.resourcesStateTitle"
+          defaultMessage="Resources state"
+          description="Title for the Resources state column of the Deployment Targets table"
+        />
+      ),
+      cell: ({ getValue }) => {
+        const resourcesState = getValue();
+        return (
+          resourcesState && (
+            <DeploymentResourcesStateComponent
+              resourcesState={resourcesState}
+            />
+          )
+        );
+      },
+    },
+  ),
+  columnHelper.accessor(
+    (deploymentTarget) => deploymentTarget.deployment?.lastErrorMessage ?? null,
+    {
+      id: "lastErrorMessage",
+      header: () => (
+        <FormattedMessage
+          id="components.DeploymentTargetsTable.lastErrorMessageTitle"
+          defaultMessage="Failure Reason"
+          description="Title for the Last Error Message column of the Deployment Targets table"
+        />
+      ),
+      cell: ({ getValue }) => getValue(),
+    },
+  ),
+  columnHelper.accessor("latestAttempt", {
+    header: () => (
+      <FormattedMessage
+        id="components.DeploymentTargetsTable.latestAttemptTitle"
+        defaultMessage="Latest attempt at"
+        description="Title for the Latest attempt at column of the Deployment Targets table"
+      />
+    ),
+    cell: ({ getValue }) => {
+      const latestAttempt = getValue();
+      return (
+        latestAttempt && (
+          <FormattedDate
+            value={latestAttempt}
+            year="numeric"
+            month="long"
+            day="numeric"
+            hour="numeric"
+            minute="numeric"
+          />
+        )
+      );
+    },
+  }),
+  columnHelper.accessor("completionTimestamp", {
+    header: () => (
+      <FormattedMessage
+        id="components.DeploymentTargetsTable.completionTimestampTitle"
+        defaultMessage="Completed at"
+        description="Title for the Completed at column of the Deployment Targets table"
+      />
+    ),
+    cell: ({ getValue }) => {
+      const latestAttempt = getValue();
+      return (
+        latestAttempt && (
+          <FormattedDate
+            value={latestAttempt}
+            year="numeric"
+            month="long"
+            day="numeric"
+            hour="numeric"
+            minute="numeric"
+          />
+        )
+      );
+    },
+  }),
+];
+
+type Props = {
+  className?: string;
+  hiddenColumns?: ColumnId[];
+  deploymentTargetsRef: DeploymentTargetsTable_DeploymentTargetsFragment$key;
+  isLoadingNext: boolean;
+  hasNext: boolean;
+  loadNextDeploymentTargets: () => void;
+};
+
+const DeploymentTargetsTable = ({
+  className,
+  deploymentTargetsRef,
+  hiddenColumns = [],
+  isLoadingNext,
+  hasNext,
+  loadNextDeploymentTargets,
+}: Props) => {
+  const deploymentTargets = useFragment(
+    DEPLOYMENT_TARGETS_TABLE_FRAGMENT,
+    deploymentTargetsRef,
+  );
+
+  return (
+    <InfiniteTable
+      className={className}
+      columns={columns}
+      data={[...deploymentTargets]}
+      loading={isLoadingNext}
+      onLoadMore={hasNext ? loadNextDeploymentTargets : undefined}
+      hiddenColumns={hiddenColumns}
+      hideSearch
+    />
+  );
+};
+
+export default DeploymentTargetsTable;
+export { columnIds };
+export type { ColumnId };

--- a/frontend/src/components/DeploymentTargetsTabs.tsx
+++ b/frontend/src/components/DeploymentTargetsTabs.tsx
@@ -1,0 +1,161 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { FormattedMessage } from "react-intl";
+import { graphql, usePaginationFragment } from "react-relay/hooks";
+import Nav from "react-bootstrap/Nav";
+import NavItem from "react-bootstrap/NavItem";
+import NavLink from "react-bootstrap/NavLink";
+
+import type { DeploymentTargetsTabs_PaginationQuery } from "api/__generated__/DeploymentTargetsTabs_PaginationQuery.graphql";
+import type {
+  DeploymentTargetStatus as DeploymentTargetStatusType,
+  DeploymentTargetsTabs_DeploymentTargetsFragment$key,
+} from "api/__generated__/DeploymentTargetsTabs_DeploymentTargetsFragment.graphql";
+
+import DeploymentTargetsTable, {
+  columnIds,
+} from "components/DeploymentTargetsTable";
+import type { ColumnId } from "components/DeploymentTargetsTable";
+import DeploymentTargetStatus from "components/DeploymentTargetStatus";
+
+const DEPLOYMENT_TARGETS_TO_LOAD_FIRST = 40;
+const DEPLOYMENT_TARGETS_TO_LOAD_NEXT = 10;
+
+const DEPLOYMENT_TARGETS_TABS_FRAGMENT = graphql`
+  fragment DeploymentTargetsTabs_DeploymentTargetsFragment on DeploymentCampaign
+  @refetchable(queryName: "DeploymentTargetsTabs_PaginationQuery")
+  @argumentDefinitions(
+    first: { type: "Int" }
+    after: { type: "String" }
+    filter: { type: "DeploymentTargetFilterInput" }
+  ) {
+    deploymentTargets(first: $first, after: $after, filter: $filter)
+      @connection(key: "DeploymentTargetsTabs_deploymentTargets") {
+      edges {
+        node {
+          status
+          ...DeploymentTargetsTable_DeploymentTargetsFragment
+        }
+      }
+    }
+  }
+`;
+
+const columnMap: Record<DeploymentTargetStatusType, ColumnId[]> = {
+  IDLE: ["deviceName"],
+  IN_PROGRESS: ["deviceName", "state", "resourcesState", "latestAttempt"],
+  SUCCESSFUL: ["deviceName", "completionTimestamp"],
+  FAILED: ["deviceName", "lastErrorMessage", "completionTimestamp"],
+};
+
+const deploymentTargetTabs: DeploymentTargetStatusType[] = [
+  "SUCCESSFUL",
+  "FAILED",
+  "IN_PROGRESS",
+  "IDLE",
+];
+
+type Props = {
+  deploymentCampaignRef: DeploymentTargetsTabs_DeploymentTargetsFragment$key;
+};
+
+const DeploymentTargetsTabs = ({ deploymentCampaignRef }: Props) => {
+  const [activeTab, setActiveTab] =
+    useState<DeploymentTargetStatusType>("SUCCESSFUL");
+
+  const { data, loadNext, hasNext, isLoadingNext, refetch } =
+    usePaginationFragment<
+      DeploymentTargetsTabs_PaginationQuery,
+      DeploymentTargetsTabs_DeploymentTargetsFragment$key
+    >(DEPLOYMENT_TARGETS_TABS_FRAGMENT, deploymentCampaignRef);
+
+  const loadNextDeploymentTargets = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(DEPLOYMENT_TARGETS_TO_LOAD_NEXT);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const deploymentTargets = useMemo(() => {
+    return data.deploymentTargets?.edges?.map((edge) => edge?.node) ?? [];
+  }, [data]);
+
+  const hiddenColumns = useMemo(() => {
+    const visible = columnMap[activeTab];
+    return columnIds.filter((c) => !visible.includes(c));
+  }, [activeTab]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      refetch(
+        {
+          first: DEPLOYMENT_TARGETS_TO_LOAD_FIRST,
+          filter: {
+            status: {
+              eq: activeTab,
+            },
+          },
+        },
+        { fetchPolicy: "network-only" },
+      );
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [activeTab, refetch]);
+
+  if (!data.deploymentTargets) return null;
+
+  return (
+    <div>
+      <h3>
+        <FormattedMessage
+          id="components.DeploymentTargetsTabs.deploymentTargetsLabel"
+          defaultMessage="Devices"
+        />
+      </h3>
+      <div>
+        <Nav role="tablist" as="ul" className="nav-tabs">
+          {deploymentTargetTabs.map((tab) => (
+            <NavItem key={tab} as="li" role="presentation">
+              <NavLink
+                as="button"
+                type="button"
+                active={activeTab === tab}
+                onClick={() => setActiveTab(tab)}
+              >
+                <DeploymentTargetStatus status={tab} />
+              </NavLink>
+            </NavItem>
+          ))}
+        </Nav>
+        <DeploymentTargetsTable
+          deploymentTargetsRef={deploymentTargets}
+          hiddenColumns={hiddenColumns}
+          isLoadingNext={isLoadingNext}
+          hasNext={hasNext}
+          loadNextDeploymentTargets={loadNextDeploymentTargets}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DeploymentTargetsTabs;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -664,6 +664,33 @@
   "components.DeploymentCampaignsTable.statusTitle": {
     "defaultMessage": "Status"
   },
+  "components.DeploymentTargetsTable.completionTimestampTitle": {
+    "defaultMessage": "Completed at",
+    "description": "Title for the Completed at column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTable.deviceNameTitle": {
+    "defaultMessage": "Device Name",
+    "description": "Title for the Device Name column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTable.lastErrorMessageTitle": {
+    "defaultMessage": "Failure Reason",
+    "description": "Title for the Last Error Message column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTable.latestAttemptTitle": {
+    "defaultMessage": "Latest attempt at",
+    "description": "Title for the Latest attempt at column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTable.resourcesStateTitle": {
+    "defaultMessage": "Resources state",
+    "description": "Title for the Resources state column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTable.stateTitle": {
+    "defaultMessage": "State",
+    "description": "Title for the State column of the Deployment Targets table"
+  },
+  "components.DeploymentTargetsTabs.deploymentTargetsLabel": {
+    "defaultMessage": "Devices"
+  },
   "components.DeploymentsTable.applicationNameTitle": {
     "defaultMessage": "Application Name",
     "description": "Title for the Application Name column of the deployments table"

--- a/frontend/src/pages/DeploymentCampaign.tsx
+++ b/frontend/src/pages/DeploymentCampaign.tsx
@@ -45,6 +45,7 @@ import Spinner from "components/Spinner";
 import DeploymentCampaignStatsChart from "components/DeploymentCampaignStatsChart";
 import DeploymentCampaignForm from "forms/DeploymentCampaignForm";
 import { Link, Route } from "Navigation";
+import DeploymentTargetsTabs from "components/DeploymentTargetsTabs";
 
 const GET_DEPLOYMENT_CAMPAIGN_QUERY = graphql`
   query DeploymentCampaign_getDeploymentCampaign_Query(
@@ -55,6 +56,7 @@ const GET_DEPLOYMENT_CAMPAIGN_QUERY = graphql`
       ...DeploymentCampaignForm_DeploymentCampaignFragment
       ...DeploymentCampaignStatsChart_DeploymentCampaignStatsChartFragment
       ...DeploymentCampaign_RefreshFragment
+      ...DeploymentTargetsTabs_DeploymentTargetsFragment
     }
   }
 `;
@@ -168,6 +170,8 @@ const DeploymentCampaignContent = ({
             />
           </Col>
         </Row>
+        <hr className="bg-secondary border-2 border-top border-secondary" />
+        <DeploymentTargetsTabs deploymentCampaignRef={deploymentCampaign} />
       </Page.Main>
     </Page>
   );


### PR DESCRIPTION
- Implemented Deployment Targets Table with Deployment Targets Tabs within the Deployment Campaign Page

<details><summary>Screenshots</summary>
<p>

<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/4892d752-62c8-41c7-8e5c-1f7443ed2213" />
<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/73e9ce83-7022-46a0-a9b4-47b1eae82971" />
<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/5713e54c-4145-498d-8b4f-7931fb31aad0" />
<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/33fb3460-a3ba-48c3-aa18-bcba21fcb575" />


</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
