### PR TITLE
refactor: Extract `State` and `ResourcesState` from into separate components

### DIFF
--- a/frontend/src/components/ApplicationDevicesTable.tsx
+++ b/frontend/src/components/ApplicationDevicesTable.tsx
@@ -28,10 +28,9 @@ import type {
 } from "api/__generated__/ApplicationDevicesTable_ReleaseFragment.graphql";
 
 import ConnectionStatus from "components/ConnectionStatus";
-import {
-  DeploymentState,
-  DeploymentStateComponent,
-} from "components/DeployedApplicationsTable";
+import DeploymentStateComponent, {
+  type DeploymentState,
+} from "components/DeploymentState";
 import Table, { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";
 

--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -18,18 +18,14 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { graphql, useMutation, usePaginationFragment } from "react-relay/hooks";
 import { useCallback, useState, useMemo } from "react";
 import semver from "semver";
 import Select, { SingleValue } from "react-select";
 
 import type { DeployedApplicationsTable_PaginationQuery } from "api/__generated__/DeployedApplicationsTable_PaginationQuery.graphql";
-import type {
-  ApplicationDeploymentResourcesState,
-  ApplicationDeploymentState,
-  DeployedApplicationsTable_deployedApplications$key,
-} from "api/__generated__/DeployedApplicationsTable_deployedApplications.graphql";
+import type { DeployedApplicationsTable_deployedApplications$key } from "api/__generated__/DeployedApplicationsTable_deployedApplications.graphql";
 
 import type { DeployedApplicationsTable_startDeployment_Mutation } from "api/__generated__/DeployedApplicationsTable_startDeployment_Mutation.graphql";
 import type { DeployedApplicationsTable_stopDeployment_Mutation } from "api/__generated__/DeployedApplicationsTable_stopDeployment_Mutation.graphql";
@@ -39,9 +35,16 @@ import type { DeployedApplicationsTable_upgradeDeployment_Mutation } from "api/_
 import Icon from "components/Icon";
 import { Link, Route } from "Navigation";
 import Table, { createColumnHelper } from "components/Table";
-import Button from "./Button";
-import ConfirmModal from "./ConfirmModal";
-import DeleteModal from "./DeleteModal";
+import Button from "components/Button";
+import ConfirmModal from "components/ConfirmModal";
+import DeleteModal from "components/DeleteModal";
+import DeploymentStateComponent, {
+  type DeploymentState,
+  parseDeploymentState,
+} from "components/DeploymentState";
+import DeploymentResourcesStateComponent, {
+  parseDeploymentResourcesState,
+} from "components/DeploymentResourcesState";
 
 // We use graphql fields below in columns configuration
 /* eslint-disable relay/unused-fields */
@@ -125,204 +128,6 @@ const UPGRADE_DEPLOYMENT_MUTATION = graphql`
     }
   }
 `;
-
-type DeploymentState =
-  | "DEPLOYING"
-  | "PENDING"
-  | "SENT"
-  | "STARTING"
-  | "STARTED"
-  | "STOPPING"
-  | "STOPPED"
-  | "ERROR"
-  | "DELETING";
-
-type DeploymentResourcesState =
-  | "INITIAL"
-  | "CREATED_IMAGES"
-  | "CREATED_NETWORKS"
-  | "CREATED_VOLUMES"
-  | "CREATED_DEVICE_MAPPINGS"
-  | "CREATED_CONTAINERS"
-  | "READY";
-
-const parseDeploymentState = (
-  apiState?: ApplicationDeploymentState,
-): DeploymentState => {
-  switch (apiState) {
-    case "PENDING":
-      return "PENDING";
-    case "SENT":
-      return "SENT";
-    case "STARTED":
-      return "STARTED";
-    case "STARTING":
-      return "STARTING";
-    case "STOPPED":
-      return "STOPPED";
-    case "STOPPING":
-      return "STOPPING";
-    case "ERROR":
-      return "ERROR";
-    case "DELETING":
-      return "DELETING";
-    default:
-      return "DEPLOYING";
-  }
-};
-
-const parseDeploymentResourcesState = (
-  apiState?: ApplicationDeploymentResourcesState,
-): DeploymentResourcesState => {
-  switch (apiState) {
-    case "INITIAL":
-      return "INITIAL";
-    case "CREATED_IMAGES":
-      return "CREATED_IMAGES";
-    case "CREATED_NETWORKS":
-      return "CREATED_NETWORKS";
-    case "CREATED_VOLUMES":
-      return "CREATED_VOLUMES";
-    case "CREATED_DEVICE_MAPPINGS":
-      return "CREATED_DEVICE_MAPPINGS";
-    case "CREATED_CONTAINERS":
-      return "CREATED_CONTAINERS";
-    case "READY":
-      return "READY";
-    default:
-      return "INITIAL";
-  }
-};
-
-const stateColors: Record<DeploymentState, string> = {
-  PENDING: "text-success",
-  SENT: "text-success",
-  STARTING: "text-success",
-  STARTED: "text-success",
-  STOPPING: "text-warning",
-  STOPPED: "text-secondary",
-  ERROR: "text-danger",
-  DELETING: "text-danger",
-  DEPLOYING: "text-muted",
-};
-
-const resourcesStateColors: Record<DeploymentResourcesState, string> = {
-  INITIAL: "text-muted",
-  CREATED_IMAGES: "text-muted",
-  CREATED_NETWORKS: "text-muted",
-  CREATED_VOLUMES: "text-muted",
-  CREATED_DEVICE_MAPPINGS: "text-muted",
-  CREATED_CONTAINERS: "text-muted",
-  READY: "text-success",
-};
-
-// Define deployment state messages for localization
-const stateMessages = defineMessages<DeploymentState>({
-  PENDING: {
-    id: "components.DeployedApplicationsTable.pending",
-    defaultMessage: "Pending",
-  },
-  SENT: {
-    id: "components.DeployedApplicationsTable.sent",
-    defaultMessage: "Sent",
-  },
-  STARTING: {
-    id: "components.DeployedApplicationsTable.starting",
-    defaultMessage: "Starting",
-  },
-  STARTED: {
-    id: "components.DeployedApplicationsTable.started",
-    defaultMessage: "Started",
-  },
-  STOPPING: {
-    id: "components.DeployedApplicationsTable.stopping",
-    defaultMessage: "Stopping",
-  },
-  STOPPED: {
-    id: "components.DeployedApplicationsTable.stopped",
-    defaultMessage: "Stopped",
-  },
-  ERROR: {
-    id: "components.DeployedApplicationsTable.error",
-    defaultMessage: "Error",
-  },
-  DELETING: {
-    id: "components.DeployedApplicationsTable.deleting",
-    defaultMessage: "Deleting",
-  },
-  DEPLOYING: {
-    id: "components.DeployedApplicationsTable.deploying",
-    defaultMessage: "Deploying",
-  },
-});
-
-// Define deployment resources state messages for localization
-const resourcesStateMessages = defineMessages<DeploymentResourcesState>({
-  INITIAL: {
-    id: "components.DeployedApplicationsTable.initial",
-    defaultMessage: "Initial",
-  },
-  CREATED_IMAGES: {
-    id: "components.DeployedApplicationsTable.createdImages",
-    defaultMessage: "Created images",
-  },
-  CREATED_NETWORKS: {
-    id: "components.DeployedApplicationsTable.createdNetworks",
-    defaultMessage: "Created networks",
-  },
-  CREATED_VOLUMES: {
-    id: "components.DeployedApplicationsTable.createdVolumes",
-    defaultMessage: "Created volumes",
-  },
-  CREATED_DEVICE_MAPPINGS: {
-    id: "components.DeployedApplicationsTable.createdDeviceMappings",
-    defaultMessage: "Created device mappings",
-  },
-  CREATED_CONTAINERS: {
-    id: "components.DeployedApplicationsTable.createdContainers",
-    defaultMessage: "Created containers",
-  },
-  READY: {
-    id: "components.DeployedApplicationsTable.ready",
-    defaultMessage: "Ready",
-  },
-});
-
-// Component to render the deployment state with an icon and optional spin
-const DeploymentStateComponent = ({ state }: { state: DeploymentState }) => (
-  <div className="d-flex align-items-center">
-    <Icon
-      icon={
-        ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
-          ? "spinner"
-          : "circle"
-      }
-      className={`me-2 ${stateColors[state]} ${
-        ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
-          ? "fa-spin"
-          : ""
-      }`}
-    />
-    <FormattedMessage id={stateMessages[state].id} />
-  </div>
-);
-
-// Component to render the deployment resources state with an icon and optional spin
-const DeploymentResourcesStateComponent = ({
-  resourcesState,
-}: {
-  resourcesState: DeploymentResourcesState;
-}) => (
-  <div className="d-flex align-items-center">
-    <Icon
-      icon={resourcesState !== "READY" ? "spinner" : "circle"}
-      className={`me-2 ${resourcesStateColors[resourcesState]} ${
-        resourcesState !== "READY" ? "fa-spin" : ""
-      }`}
-    />
-    <FormattedMessage id={resourcesStateMessages[resourcesState].id} />
-  </div>
-);
 
 // Action buttons with play and stop icons
 const ActionButtons = ({
@@ -879,9 +684,6 @@ const DeployedApplicationsTable = ({
     </div>
   );
 };
-
-// TODO: Make dedicated files for these components
-export { DeploymentStateComponent, DeploymentResourcesStateComponent };
 
 export type { DeploymentTableProps, DeploymentState };
 export default DeployedApplicationsTable;

--- a/frontend/src/components/DeploymentResourcesState.tsx
+++ b/frontend/src/components/DeploymentResourcesState.tsx
@@ -1,0 +1,122 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { defineMessages, FormattedMessage } from "react-intl";
+
+import type { ApplicationDeploymentResourcesState } from "api/__generated__/DeployedApplicationsTable_deployedApplications.graphql";
+
+import Icon from "components/Icon";
+
+type DeploymentResourcesState =
+  | "INITIAL"
+  | "CREATED_IMAGES"
+  | "CREATED_NETWORKS"
+  | "CREATED_VOLUMES"
+  | "CREATED_DEVICE_MAPPINGS"
+  | "CREATED_CONTAINERS"
+  | "READY";
+
+const parseDeploymentResourcesState = (
+  apiState?: ApplicationDeploymentResourcesState,
+): DeploymentResourcesState => {
+  switch (apiState) {
+    case "INITIAL":
+      return "INITIAL";
+    case "CREATED_IMAGES":
+      return "CREATED_IMAGES";
+    case "CREATED_NETWORKS":
+      return "CREATED_NETWORKS";
+    case "CREATED_VOLUMES":
+      return "CREATED_VOLUMES";
+    case "CREATED_DEVICE_MAPPINGS":
+      return "CREATED_DEVICE_MAPPINGS";
+    case "CREATED_CONTAINERS":
+      return "CREATED_CONTAINERS";
+    case "READY":
+      return "READY";
+    default:
+      return "INITIAL";
+  }
+};
+
+const resourcesStateColors: Record<DeploymentResourcesState, string> = {
+  INITIAL: "text-muted",
+  CREATED_IMAGES: "text-muted",
+  CREATED_NETWORKS: "text-muted",
+  CREATED_VOLUMES: "text-muted",
+  CREATED_DEVICE_MAPPINGS: "text-muted",
+  CREATED_CONTAINERS: "text-muted",
+  READY: "text-success",
+};
+
+const resourcesStateMessages = defineMessages<DeploymentResourcesState>({
+  INITIAL: {
+    id: "components.DeploymentResourcesStateComponent.initial",
+    defaultMessage: "Initial",
+  },
+  CREATED_IMAGES: {
+    id: "components.DeploymentResourcesStateComponent.createdImages",
+    defaultMessage: "Created images",
+  },
+  CREATED_NETWORKS: {
+    id: "components.DeploymentResourcesStateComponent.createdNetworks",
+    defaultMessage: "Created networks",
+  },
+  CREATED_VOLUMES: {
+    id: "components.DeploymentResourcesStateComponent.createdVolumes",
+    defaultMessage: "Created volumes",
+  },
+  CREATED_DEVICE_MAPPINGS: {
+    id: "components.DeploymentResourcesStateComponent.createdDeviceMappings",
+    defaultMessage: "Created device mappings",
+  },
+  CREATED_CONTAINERS: {
+    id: "components.DeploymentResourcesStateComponent.createdContainers",
+    defaultMessage: "Created containers",
+  },
+  READY: {
+    id: "components.DeploymentResourcesStateComponent.ready",
+    defaultMessage: "Ready",
+  },
+});
+
+type DeploymentResourcesStateComponentProps = {
+  resourcesState: DeploymentResourcesState;
+};
+
+const DeploymentResourcesStateComponent = ({
+  resourcesState,
+}: DeploymentResourcesStateComponentProps) => {
+  return (
+    <div className="d-flex align-items-center">
+      <Icon
+        icon={resourcesState !== "READY" ? "spinner" : "circle"}
+        className={`me-2 ${resourcesStateColors[resourcesState]} ${
+          resourcesState !== "READY" ? "fa-spin" : ""
+        }`}
+      />
+      <FormattedMessage id={resourcesStateMessages[resourcesState].id} />
+    </div>
+  );
+};
+
+export type { DeploymentResourcesState };
+export { parseDeploymentResourcesState };
+export default DeploymentResourcesStateComponent;

--- a/frontend/src/components/DeploymentState.tsx
+++ b/frontend/src/components/DeploymentState.tsx
@@ -1,0 +1,140 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { defineMessages, FormattedMessage } from "react-intl";
+
+import type { ApplicationDeploymentState } from "api/__generated__/DeployedApplicationsTable_deployedApplications.graphql";
+
+import Icon from "components/Icon";
+
+type DeploymentState =
+  | "DEPLOYING"
+  | "PENDING"
+  | "SENT"
+  | "STARTING"
+  | "STARTED"
+  | "STOPPING"
+  | "STOPPED"
+  | "ERROR"
+  | "DELETING";
+
+const parseDeploymentState = (
+  apiState?: ApplicationDeploymentState,
+): DeploymentState => {
+  switch (apiState) {
+    case "PENDING":
+      return "PENDING";
+    case "SENT":
+      return "SENT";
+    case "STARTED":
+      return "STARTED";
+    case "STARTING":
+      return "STARTING";
+    case "STOPPED":
+      return "STOPPED";
+    case "STOPPING":
+      return "STOPPING";
+    case "ERROR":
+      return "ERROR";
+    case "DELETING":
+      return "DELETING";
+    default:
+      return "DEPLOYING";
+  }
+};
+
+const stateColors: Record<DeploymentState, string> = {
+  PENDING: "text-success",
+  SENT: "text-success",
+  STARTING: "text-success",
+  STARTED: "text-success",
+  STOPPING: "text-warning",
+  STOPPED: "text-secondary",
+  ERROR: "text-danger",
+  DELETING: "text-danger",
+  DEPLOYING: "text-muted",
+};
+
+const stateMessages = defineMessages<DeploymentState>({
+  PENDING: {
+    id: "components.DeploymentStateComponent.pending",
+    defaultMessage: "Pending",
+  },
+  SENT: {
+    id: "components.DeploymentStateComponent.sent",
+    defaultMessage: "Sent",
+  },
+  STARTING: {
+    id: "components.DeploymentStateComponent.starting",
+    defaultMessage: "Starting",
+  },
+  STARTED: {
+    id: "components.DeploymentStateComponent.started",
+    defaultMessage: "Started",
+  },
+  STOPPING: {
+    id: "components.DeploymentStateComponent.stopping",
+    defaultMessage: "Stopping",
+  },
+  STOPPED: {
+    id: "components.DeploymentStateComponent.stopped",
+    defaultMessage: "Stopped",
+  },
+  ERROR: {
+    id: "components.DeploymentStateComponent.error",
+    defaultMessage: "Error",
+  },
+  DELETING: {
+    id: "components.DeploymentStateComponent.deleting",
+    defaultMessage: "Deleting",
+  },
+  DEPLOYING: {
+    id: "components.DeploymentStateComponent.deploying",
+    defaultMessage: "Deploying",
+  },
+});
+
+type DeploymentStateComponentProps = {
+  state: DeploymentState;
+};
+
+const DeploymentStateComponent = ({ state }: DeploymentStateComponentProps) => {
+  return (
+    <div className="d-flex align-items-center">
+      <Icon
+        icon={
+          ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
+            ? "spinner"
+            : "circle"
+        }
+        className={`me-2 ${stateColors[state]} ${
+          ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
+            ? "fa-spin"
+            : ""
+        }`}
+      />
+      <FormattedMessage id={stateMessages[state].id} />
+    </div>
+  );
+};
+
+export type { DeploymentState };
+export { parseDeploymentState };
+export default DeploymentStateComponent;

--- a/frontend/src/components/DeploymentTargetsTable.tsx
+++ b/frontend/src/components/DeploymentTargetsTable.tsx
@@ -28,10 +28,8 @@ import type {
 
 import { createColumnHelper } from "components/Table";
 import InfiniteTable from "components/InfiniteTable";
-import {
-  DeploymentResourcesStateComponent,
-  DeploymentStateComponent,
-} from "components/DeployedApplicationsTable";
+import DeploymentStateComponent from "components/DeploymentState";
+import DeploymentResourcesStateComponent from "components/DeploymentResourcesState";
 import { Link, Route } from "Navigation";
 
 // We use graphql fields below in columns configuration

--- a/frontend/src/components/DeploymentsTable.tsx
+++ b/frontend/src/components/DeploymentsTable.tsx
@@ -29,10 +29,9 @@ import type {
 } from "api/__generated__/DeploymentsTable_DeploymentFragment.graphql";
 import type { DeploymentsTable_PaginationQuery } from "api/__generated__/DeploymentsTable_PaginationQuery.graphql";
 
-import {
-  DeploymentState,
-  DeploymentStateComponent,
-} from "components/DeployedApplicationsTable";
+import DeploymentStateComponent, {
+  type DeploymentState,
+} from "components/DeploymentState";
 import InfiniteTable from "components/InfiniteTable";
 import { createColumnHelper } from "components/Table";
 import { Link, Route } from "Navigation";

--- a/frontend/src/components/ReleaseDevicesTable.tsx
+++ b/frontend/src/components/ReleaseDevicesTable.tsx
@@ -29,10 +29,9 @@ import type {
 import type { ReleaseDevicesTable_PaginationQuery } from "api/__generated__/ReleaseDevicesTable_PaginationQuery.graphql";
 
 import ConnectionStatus from "components/ConnectionStatus";
-import {
-  DeploymentState,
-  DeploymentStateComponent,
-} from "components/DeployedApplicationsTable";
+import DeploymentStateComponent, {
+  type DeploymentState,
+} from "components/DeploymentState";
 import InfiniteScroll from "components/InfiniteScroll";
 import InfiniteTable from "components/InfiniteTable";
 import { createColumnHelper } from "components/Table";

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -528,21 +528,6 @@
   "components.DeployedApplicationsTable.confirmModal.title": {
     "defaultMessage": "Upgrade Deployment"
   },
-  "components.DeployedApplicationsTable.createdContainers": {
-    "defaultMessage": "Created containers"
-  },
-  "components.DeployedApplicationsTable.createdDeviceMappings": {
-    "defaultMessage": "Created device mappings"
-  },
-  "components.DeployedApplicationsTable.createdImages": {
-    "defaultMessage": "Created images"
-  },
-  "components.DeployedApplicationsTable.createdNetworks": {
-    "defaultMessage": "Created networks"
-  },
-  "components.DeployedApplicationsTable.createdVolumes": {
-    "defaultMessage": "Created volumes"
-  },
   "components.DeployedApplicationsTable.deleteModal.description": {
     "defaultMessage": "This action cannot be undone. This will permanently delete the deployment."
   },
@@ -552,20 +537,8 @@
   "components.DeployedApplicationsTable.deleteModal.title": {
     "defaultMessage": "Delete Deployment"
   },
-  "components.DeployedApplicationsTable.deleting": {
-    "defaultMessage": "Deleting"
-  },
   "components.DeployedApplicationsTable.deletionErrorFeedback": {
     "defaultMessage": "Could not delete the deployment, please try again."
-  },
-  "components.DeployedApplicationsTable.deploying": {
-    "defaultMessage": "Deploying"
-  },
-  "components.DeployedApplicationsTable.error": {
-    "defaultMessage": "Error"
-  },
-  "components.DeployedApplicationsTable.initial": {
-    "defaultMessage": "Initial"
   },
   "components.DeployedApplicationsTable.noDeployedApplications": {
     "defaultMessage": "No deployed applications"
@@ -576,12 +549,6 @@
   "components.DeployedApplicationsTable.noReleasesFoundMatching": {
     "defaultMessage": "No release versions found matching \"{inputValue}\""
   },
-  "components.DeployedApplicationsTable.pending": {
-    "defaultMessage": "Pending"
-  },
-  "components.DeployedApplicationsTable.ready": {
-    "defaultMessage": "Ready"
-  },
   "components.DeployedApplicationsTable.releaseVersion": {
     "defaultMessage": "Release Version"
   },
@@ -591,20 +558,11 @@
   "components.DeployedApplicationsTable.selectOption": {
     "defaultMessage": "Select a Release Version"
   },
-  "components.DeployedApplicationsTable.sent": {
-    "defaultMessage": "Sent"
-  },
   "components.DeployedApplicationsTable.startErrorFeedback": {
     "defaultMessage": "Could not Start the Deployed Application, please try again."
   },
   "components.DeployedApplicationsTable.startErrorOffline": {
     "defaultMessage": "The device is disconnected. You cannot start an application while it is offline."
-  },
-  "components.DeployedApplicationsTable.started": {
-    "defaultMessage": "Started"
-  },
-  "components.DeployedApplicationsTable.starting": {
-    "defaultMessage": "Starting"
   },
   "components.DeployedApplicationsTable.state": {
     "defaultMessage": "State"
@@ -614,12 +572,6 @@
   },
   "components.DeployedApplicationsTable.stopErrorOffline": {
     "defaultMessage": "The device is disconnected. You cannot stop an application while it is offline."
-  },
-  "components.DeployedApplicationsTable.stopped": {
-    "defaultMessage": "Stopped"
-  },
-  "components.DeployedApplicationsTable.stopping": {
-    "defaultMessage": "Stopping"
   },
   "components.DeployedApplicationsTable.upgradeErrorFeedback": {
     "defaultMessage": "Could not upgrade the deployment, please try again."
@@ -663,6 +615,54 @@
   },
   "components.DeploymentCampaignsTable.statusTitle": {
     "defaultMessage": "Status"
+  },
+  "components.DeploymentResourcesStateComponent.createdContainers": {
+    "defaultMessage": "Created containers"
+  },
+  "components.DeploymentResourcesStateComponent.createdDeviceMappings": {
+    "defaultMessage": "Created device mappings"
+  },
+  "components.DeploymentResourcesStateComponent.createdImages": {
+    "defaultMessage": "Created images"
+  },
+  "components.DeploymentResourcesStateComponent.createdNetworks": {
+    "defaultMessage": "Created networks"
+  },
+  "components.DeploymentResourcesStateComponent.createdVolumes": {
+    "defaultMessage": "Created volumes"
+  },
+  "components.DeploymentResourcesStateComponent.initial": {
+    "defaultMessage": "Initial"
+  },
+  "components.DeploymentResourcesStateComponent.ready": {
+    "defaultMessage": "Ready"
+  },
+  "components.DeploymentStateComponent.deleting": {
+    "defaultMessage": "Deleting"
+  },
+  "components.DeploymentStateComponent.deploying": {
+    "defaultMessage": "Deploying"
+  },
+  "components.DeploymentStateComponent.error": {
+    "defaultMessage": "Error"
+  },
+  "components.DeploymentStateComponent.pending": {
+    "defaultMessage": "Pending"
+  },
+  "components.DeploymentStateComponent.sent": {
+    "defaultMessage": "Sent"
+  },
+  "components.DeploymentStateComponent.started": {
+    "defaultMessage": "Started"
+  },
+  "components.DeploymentStateComponent.starting": {
+    "defaultMessage": "Starting"
+  },
+  "components.DeploymentStateComponent.stopped": {
+    "defaultMessage": "Stopped"
+  },
+  "components.DeploymentStateComponent.stopping": {
+    "defaultMessage": "Stopping"
   },
   "components.DeploymentTargetsTable.completionTimestampTitle": {
     "defaultMessage": "Completed at",


### PR DESCRIPTION
- Create dedicated DeploymentState.tsx with state logic, types and styling
- Create dedicated DeploymentResourcesState.tsx with resources state logic, types, and styling

This refactoring improves code organization and makes the deployment state components more reusable across the application.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
