### PR TITLE
feat(containers): Add deployment campaign creation page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,6 +67,7 @@ import NetworkCreatePage from "pages/NetworkCreate";
 import DeploymentsPage from "pages/Deployments";
 import DeploymentCampaignsPage from "pages/DeploymentCampaigns";
 import DeploymentCampaign from "pages/DeploymentCampaign";
+import DeploymentCampaignCreate from "pages/DeploymentCampaignCreate";
 
 import { bugs, repository, version } from "../package.json";
 
@@ -123,6 +124,7 @@ const authenticatedRoutes: RouterRule[] = [
   { path: Route.networksNew, element: <NetworkCreatePage /> },
   { path: Route.deployments, element: <DeploymentsPage /> },
   { path: Route.deploymentCampaigns, element: <DeploymentCampaignsPage /> },
+  { path: Route.deploymentCampaignsNew, element: <DeploymentCampaignCreate /> },
   { path: Route.deploymentCampaignsEdit, element: <DeploymentCampaign /> },
   { path: Route.logout, element: <Logout /> },
   { path: "*", element: <Navigate to={Route.devices} replace /> },

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -168,6 +168,7 @@ const useBreadcrumbItems = (): BreadcrumbItem[] => {
         return [{ route: Route.networks }, currentRoute];
 
       case Route.deploymentCampaignsEdit:
+      case Route.deploymentCampaignsNew:
         return [{ route: Route.deploymentCampaigns }, currentRoute];
       default:
         return [];

--- a/frontend/src/forms/CreateDeploymentCampaign.tsx
+++ b/frontend/src/forms/CreateDeploymentCampaign.tsx
@@ -1,0 +1,432 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import type { ReactNode } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+
+import type { CreateDeploymentCampaign_OptionsFragment$key } from "api/__generated__/CreateDeploymentCampaign_OptionsFragment.graphql";
+
+import Button from "components/Button";
+import Col from "components/Col";
+import Form from "components/Form";
+import Row from "components/Row";
+import Spinner from "components/Spinner";
+import Stack from "components/Stack";
+import { numberSchema, yup } from "forms";
+import FormFeedback from "forms/FormFeedback";
+
+const DEPLOYMENT_CAMPAIGN_OPTIONS_FRAGMENT = graphql`
+  fragment CreateDeploymentCampaign_OptionsFragment on RootQueryType {
+    applications {
+      edges {
+        node {
+          id
+          name
+          releases {
+            edges {
+              node {
+                id
+                version
+              }
+            }
+          }
+        }
+      }
+    }
+    channels {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const FormRow = ({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label?: ReactNode;
+  children: ReactNode;
+}) => (
+  <Form.Group as={Row} controlId={id}>
+    <Form.Label column sm={3}>
+      {label}
+    </Form.Label>
+    <Col sm={9}>{children}</Col>
+  </Form.Group>
+);
+
+type DeploymentCampaignData = {
+  channelId: string;
+  releaseId: string;
+  name: string;
+  deploymentMechanism: {
+    lazy: {
+      maxFailurePercentage: number;
+      maxInProgressDeployments: number;
+      createRequestRetries: number;
+      requestTimeoutSeconds: number;
+    };
+  };
+};
+
+type FormData = {
+  name: string;
+  channelId: string;
+  applicationId: string;
+  releaseId: string;
+  maxFailurePercentage: number | string;
+  maxInProgressDeployments: number | string;
+  createRequestRetries: number;
+  requestTimeoutSeconds: number;
+};
+
+const initialData: FormData = {
+  name: "",
+  channelId: "",
+  applicationId: "",
+  releaseId: "",
+  maxFailurePercentage: "",
+  maxInProgressDeployments: "",
+  createRequestRetries: 3,
+  requestTimeoutSeconds: 300,
+};
+
+const transformOutputData = (data: FormData): DeploymentCampaignData => {
+  const {
+    name,
+    channelId,
+    releaseId,
+    maxFailurePercentage,
+    maxInProgressDeployments,
+    createRequestRetries,
+    requestTimeoutSeconds,
+  } = data;
+
+  return {
+    name,
+    channelId,
+    releaseId,
+    deploymentMechanism: {
+      lazy: {
+        maxFailurePercentage:
+          typeof maxFailurePercentage === "string"
+            ? parseFloat(maxFailurePercentage)
+            : maxFailurePercentage,
+        maxInProgressDeployments:
+          typeof maxInProgressDeployments === "string"
+            ? parseInt(maxInProgressDeployments)
+            : maxInProgressDeployments,
+        createRequestRetries,
+        requestTimeoutSeconds,
+      },
+    },
+  };
+};
+
+type Props = {
+  deploymentCampaignOptionsRef: CreateDeploymentCampaign_OptionsFragment$key;
+  isLoading?: boolean;
+  onSubmit: (data: DeploymentCampaignData) => void;
+};
+
+const CreateDeploymentCampaignForm = ({
+  deploymentCampaignOptionsRef,
+  isLoading = false,
+  onSubmit,
+}: Props) => {
+  const intl = useIntl();
+
+  const deploymentCampaignSchema = yup
+    .object({
+      name: yup.string().required(),
+      applicationId: yup.string().required(),
+      releaseId: yup.string().required(),
+      channelId: yup.string().required(),
+      maxInProgressDeployments: numberSchema
+        .integer()
+        .positive()
+        .label(
+          intl.formatMessage({
+            id: "forms.CreateDeploymentCampaign.maxInProgressDeploymentsLabel",
+            defaultMessage: "Max Pending Operations",
+          }),
+        ),
+      maxFailurePercentage: numberSchema
+        .min(0)
+        .max(100)
+        .label(
+          intl.formatMessage({
+            id: "forms.CreateDeploymentCampaign.maxFailurePercentageValidationLabel",
+            defaultMessage: "Max Failures",
+          }),
+        ),
+      requestTimeoutSeconds: numberSchema
+        .positive()
+        .integer()
+        .min(30)
+        .label(
+          intl.formatMessage({
+            id: "forms.CreateDeploymentCampaign.requestTimeoutSecondsValidationLabel",
+            defaultMessage: "Request Timeout",
+          }),
+        ),
+      createRequestRetries: numberSchema
+        .integer()
+        .min(0)
+        .label(
+          intl.formatMessage({
+            id: "forms.CreateDeploymentCampaign.createRequestRetriesLabel",
+            defaultMessage: "Request Retries",
+          }),
+        ),
+    })
+    .required();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    resetField,
+  } = useForm<FormData>({
+    mode: "onTouched",
+    defaultValues: initialData,
+    resolver: yupResolver(deploymentCampaignSchema),
+  });
+
+  const { applications, channels } = useFragment(
+    DEPLOYMENT_CAMPAIGN_OPTIONS_FRAGMENT,
+    deploymentCampaignOptionsRef,
+  );
+
+  const selectedApplicationId = watch("applicationId");
+  const selectedApplication = applications?.edges?.find(
+    ({ node }) => node.id === selectedApplicationId,
+  )?.node;
+
+  const onFormSubmit = (data: FormData) => onSubmit(transformOutputData(data));
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)}>
+      <Stack gap={3}>
+        <FormRow
+          id="create-deployment-campaign-form-name"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.nameLabel"
+              defaultMessage="Name"
+            />
+          }
+        >
+          <Form.Control {...register("name")} isInvalid={!!errors.name} />
+          <FormFeedback feedback={errors.name?.message} />
+        </FormRow>
+
+        <FormRow
+          id="create-deployment-campaign-form-application"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.applicationLabel"
+              defaultMessage="Application"
+            />
+          }
+        >
+          <Form.Select
+            {...register("applicationId", {
+              onChange: () => resetField("releaseId"),
+            })}
+            isInvalid={!!errors.applicationId}
+          >
+            <option value="" disabled>
+              {intl.formatMessage({
+                id: "forms.CreateDeploymentCampaign.applicationOption",
+                defaultMessage: "Select an Application",
+              })}
+            </option>
+            {applications?.edges?.map(({ node: app }) => (
+              <option key={app.id} value={app.id}>
+                {app.name ?? app.id}
+              </option>
+            ))}
+          </Form.Select>
+          <FormFeedback feedback={errors.applicationId?.message} />
+        </FormRow>
+
+        <FormRow
+          id="create-deployment-campaign-form-release"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.releaseLabel"
+              defaultMessage="Release"
+            />
+          }
+        >
+          <Form.Select
+            {...register("releaseId")}
+            disabled={!selectedApplication}
+            isInvalid={!!errors.releaseId}
+          >
+            <option value="" disabled>
+              {intl.formatMessage({
+                id: "forms.CreateDeploymentCampaign.releaseOption",
+                defaultMessage: "Select a Release",
+              })}
+            </option>
+            {selectedApplication?.releases?.edges?.map(({ node: release }) => (
+              <option key={release.id} value={release.id}>
+                {release.version ?? release.id}
+              </option>
+            ))}
+          </Form.Select>
+          <FormFeedback feedback={errors.releaseId?.message} />
+        </FormRow>
+        <FormRow
+          id="create-deployment-campaign-form-channel"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.channelLabel"
+              defaultMessage="Channel"
+            />
+          }
+        >
+          <Form.Select
+            {...register("channelId")}
+            isInvalid={!!errors.channelId}
+          >
+            <option value="" disabled>
+              {intl.formatMessage({
+                id: "forms.CreateDeploymentCampaign.channelOption",
+                defaultMessage: "Select a Channel",
+              })}
+            </option>
+            {channels?.edges?.map(({ node: channel }) => (
+              <option key={channel.id} value={channel.id}>
+                {channel.name}
+              </option>
+            ))}
+          </Form.Select>
+          <FormFeedback feedback={errors.channelId?.message} />
+        </FormRow>
+        <FormRow
+          id="create-deployment-campaign-form-max-in-progress-updates"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.maxInProgressDeploymentsLabel"
+              defaultMessage="Max Pending Operations"
+            />
+          }
+        >
+          <Form.Control
+            {...register("maxInProgressDeployments")}
+            type="number"
+            min="1"
+            isInvalid={!!errors.maxInProgressDeployments}
+          />
+          <FormFeedback feedback={errors.maxInProgressDeployments?.message} />
+        </FormRow>
+        <FormRow
+          id="create-deployment-campaign-form-max-failure-percentage"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.maxFailurePercentageLabel"
+              defaultMessage="Max Failures <muted>(%)</muted>"
+              values={{
+                muted: (chunks: React.ReactNode) => (
+                  <span className="small text-muted">{chunks}</span>
+                ),
+              }}
+            />
+          }
+        >
+          <Form.Control
+            {...register("maxFailurePercentage")}
+            type="number"
+            min="0"
+            max="100"
+            isInvalid={!!errors.maxFailurePercentage}
+          />
+          <FormFeedback feedback={errors.maxFailurePercentage?.message} />
+        </FormRow>
+        <FormRow
+          id="create-deployment-campaign-form-ota-request-timeout"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.requestTimeoutSecondsLabel"
+              defaultMessage="Request Timeout <muted>(seconds)</muted>"
+              values={{
+                muted: (chunks: React.ReactNode) => (
+                  <span className="small text-muted">{chunks}</span>
+                ),
+              }}
+            />
+          }
+        >
+          <Form.Control
+            {...register("requestTimeoutSeconds")}
+            type="number"
+            min="30"
+            isInvalid={!!errors.requestTimeoutSeconds}
+          />
+          <FormFeedback feedback={errors.requestTimeoutSeconds?.message} />
+        </FormRow>
+        <FormRow
+          id="create-deployment-campaign-form-ota-request-retries"
+          label={
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.createRequestRetriesLabel"
+              defaultMessage="Request Retries"
+            />
+          }
+        >
+          <Form.Control
+            {...register("createRequestRetries")}
+            type="number"
+            min="0"
+            isInvalid={!!errors.createRequestRetries}
+          />
+          <FormFeedback feedback={errors.createRequestRetries?.message} />
+        </FormRow>
+
+        <div className="d-flex justify-content-end align-items-center">
+          <Button variant="primary" type="submit" disabled={isLoading}>
+            {isLoading && <Spinner size="sm" className="me-2" />}
+            <FormattedMessage
+              id="forms.CreateDeploymentCampaign.submitButton"
+              defaultMessage="Create"
+            />
+          </Button>
+        </div>
+      </Stack>
+    </form>
+  );
+};
+
+export type { DeploymentCampaignData };
+
+export default CreateDeploymentCampaignForm;

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1207,6 +1207,48 @@
   "forms.CreateChannel.targetGroupsLabel": {
     "defaultMessage": "Target Groups"
   },
+  "forms.CreateDeploymentCampaign.applicationLabel": {
+    "defaultMessage": "Application"
+  },
+  "forms.CreateDeploymentCampaign.applicationOption": {
+    "defaultMessage": "Select an Application"
+  },
+  "forms.CreateDeploymentCampaign.channelLabel": {
+    "defaultMessage": "Channel"
+  },
+  "forms.CreateDeploymentCampaign.channelOption": {
+    "defaultMessage": "Select a Channel"
+  },
+  "forms.CreateDeploymentCampaign.createRequestRetriesLabel": {
+    "defaultMessage": "Request Retries"
+  },
+  "forms.CreateDeploymentCampaign.maxFailurePercentageLabel": {
+    "defaultMessage": "Max Failures <muted>(%)</muted>"
+  },
+  "forms.CreateDeploymentCampaign.maxFailurePercentageValidationLabel": {
+    "defaultMessage": "Max Failures"
+  },
+  "forms.CreateDeploymentCampaign.maxInProgressDeploymentsLabel": {
+    "defaultMessage": "Max Pending Operations"
+  },
+  "forms.CreateDeploymentCampaign.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "forms.CreateDeploymentCampaign.releaseLabel": {
+    "defaultMessage": "Release"
+  },
+  "forms.CreateDeploymentCampaign.releaseOption": {
+    "defaultMessage": "Select a Release"
+  },
+  "forms.CreateDeploymentCampaign.requestTimeoutSecondsLabel": {
+    "defaultMessage": "Request Timeout <muted>(seconds)</muted>"
+  },
+  "forms.CreateDeploymentCampaign.requestTimeoutSecondsValidationLabel": {
+    "defaultMessage": "Request Timeout"
+  },
+  "forms.CreateDeploymentCampaign.submitButton": {
+    "defaultMessage": "Create"
+  },
   "forms.CreateRelease.addContainerButton": {
     "defaultMessage": "Add Container"
   },
@@ -1916,11 +1958,35 @@
   "pages.Channels.title": {
     "defaultMessage": "Channels"
   },
+  "pages.DeploymentApplication.noApplication.createButton": {
+    "defaultMessage": "Create Application"
+  },
   "pages.DeploymentCampaign.deploymentCampaignNotFound.message": {
     "defaultMessage": "Return to the Deployment Campaign list."
   },
   "pages.DeploymentCampaign.deploymentCampaignNotFound.title": {
     "defaultMessage": "Deployment Campaign not found."
+  },
+  "pages.DeploymentCampaignCreate.creationErrorFeedback": {
+    "defaultMessage": "Could not create the Deployment Campaign, please try again."
+  },
+  "pages.DeploymentCampaignCreate.noApplication.message": {
+    "defaultMessage": "You need at least one Application with Release to create a Deployment Campaign"
+  },
+  "pages.DeploymentCampaignCreate.noApplication.title": {
+    "defaultMessage": "You haven't created any Application yet"
+  },
+  "pages.DeploymentCampaignCreate.noChannel.createButton": {
+    "defaultMessage": "Create Channel"
+  },
+  "pages.DeploymentCampaignCreate.noChannel.message": {
+    "defaultMessage": "You need at least one Channel to create a Deployment Campaign"
+  },
+  "pages.DeploymentCampaignCreate.noChannel.title": {
+    "defaultMessage": "You haven't created any Channel yet"
+  },
+  "pages.DeploymentCampaignCreate.title": {
+    "defaultMessage": "Create Deployment Campaign"
   },
   "pages.DeploymentCampaigns.createButton": {
     "defaultMessage": "Create Campaign"

--- a/frontend/src/pages/DeploymentCampaignCreate.tsx
+++ b/frontend/src/pages/DeploymentCampaignCreate.tsx
@@ -1,0 +1,296 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Suspense, useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
+import { ErrorBoundary } from "react-error-boundary";
+import {
+  graphql,
+  useMutation,
+  usePreloadedQuery,
+  useQueryLoader,
+} from "react-relay/hooks";
+import type { PreloadedQuery } from "react-relay/hooks";
+
+import type {
+  DeploymentCampaignCreate_getOptions_Query,
+  DeploymentCampaignCreate_getOptions_Query$data,
+} from "api/__generated__/DeploymentCampaignCreate_getOptions_Query.graphql";
+import type { DeploymentCampaignCreate_CreateDeploymentCampaign_Mutation } from "api/__generated__/DeploymentCampaignCreate_CreateDeploymentCampaign_Mutation.graphql";
+
+import Alert from "components/Alert";
+import Button from "components/Button";
+import Center from "components/Center";
+import Page from "components/Page";
+import Result from "components/Result";
+import Spinner from "components/Spinner";
+import CreateDeploymentCampaignForm from "forms/CreateDeploymentCampaign";
+import type { DeploymentCampaignData } from "forms/CreateDeploymentCampaign";
+import { Link, Route, useNavigate } from "Navigation";
+
+const GET_CREATE_DEPLOYMENT_CAMPAIGN_OPTIONS_QUERY = graphql`
+  query DeploymentCampaignCreate_getOptions_Query {
+    applications {
+      __typename
+      count
+    }
+    channels {
+      __typename
+      count
+    }
+    ...CreateDeploymentCampaign_OptionsFragment
+  }
+`;
+
+const CREATE_DEPLOYMENT_CAMPAIGN_MUTATION = graphql`
+  mutation DeploymentCampaignCreate_CreateDeploymentCampaign_Mutation(
+    $input: CreateDeploymentCampaignInput!
+  ) {
+    createDeploymentCampaign(input: $input) {
+      result {
+        id
+      }
+    }
+  }
+`;
+
+type DeploymentCampaignProps = {
+  deploymentCampaignOptions: DeploymentCampaignCreate_getOptions_Query$data;
+};
+
+const DeploymentCampaign = ({
+  deploymentCampaignOptions,
+}: DeploymentCampaignProps) => {
+  const navigate = useNavigate();
+  const [errorFeedback, setErrorFeedback] = useState<ReactNode>(null);
+
+  const [CreateDeploymentCampaign, isCreatingDeploymentCampaign] =
+    useMutation<DeploymentCampaignCreate_CreateDeploymentCampaign_Mutation>(
+      CREATE_DEPLOYMENT_CAMPAIGN_MUTATION,
+    );
+
+  const handleCreateDeploymentCampaign = useCallback(
+    (deploymentCampaign: DeploymentCampaignData) => {
+      CreateDeploymentCampaign({
+        variables: { input: deploymentCampaign },
+        onCompleted(data, errors) {
+          if (data.createDeploymentCampaign?.result) {
+            const deploymentCampaignId =
+              data.createDeploymentCampaign.result.id;
+            navigate({
+              route: Route.deploymentCampaignsEdit,
+              params: { deploymentCampaignId },
+            });
+          }
+          if (errors) {
+            const errorFeedback = errors
+              .map(({ fields, message }) =>
+                fields.length ? `${fields.join(" ")} ${message}` : message,
+              )
+              .join(". \n");
+            return setErrorFeedback(errorFeedback);
+          }
+        },
+        onError() {
+          setErrorFeedback(
+            <FormattedMessage
+              id="pages.DeploymentCampaignCreate.creationErrorFeedback"
+              defaultMessage="Could not create the Deployment Campaign, please try again."
+            />,
+          );
+        },
+        updater(store, data) {
+          if (!data?.createDeploymentCampaign?.result) {
+            return;
+          }
+
+          const deploymentCampaign = store
+            .getRootField("createDeploymentCampaign")
+            .getLinkedRecord("result");
+          const root = store.getRoot();
+
+          const deploymentCampaigns = root.getLinkedRecords(
+            "deploymentCampaigns",
+          );
+          if (deploymentCampaigns) {
+            root.setLinkedRecords(
+              [...deploymentCampaigns, deploymentCampaign],
+              "deploymentCampaigns",
+            );
+          }
+        },
+      });
+    },
+    [CreateDeploymentCampaign, navigate],
+  );
+
+  return (
+    <>
+      <Alert
+        show={!!errorFeedback}
+        variant="danger"
+        onClose={() => setErrorFeedback(null)}
+        dismissible
+      >
+        {errorFeedback}
+      </Alert>
+      <CreateDeploymentCampaignForm
+        deploymentCampaignOptionsRef={deploymentCampaignOptions}
+        onSubmit={handleCreateDeploymentCampaign}
+        isLoading={isCreatingDeploymentCampaign}
+      />
+    </>
+  );
+};
+
+const NoApplications = () => (
+  <Result.EmptyList
+    title={
+      <FormattedMessage
+        id="pages.DeploymentCampaignCreate.noApplication.title"
+        defaultMessage="You haven't created any Application yet"
+      />
+    }
+  >
+    <p>
+      <FormattedMessage
+        id="pages.DeploymentCampaignCreate.noApplication.message"
+        defaultMessage="You need at least one Application with Release to create a Deployment Campaign"
+      />
+    </p>
+    <Button as={Link} route={Route.applicationNew}>
+      <FormattedMessage
+        id="pages.DeploymentApplication.noApplication.createButton"
+        defaultMessage="Create Application"
+      />
+    </Button>
+  </Result.EmptyList>
+);
+
+const NoChannels = () => (
+  <Result.EmptyList
+    title={
+      <FormattedMessage
+        id="pages.DeploymentCampaignCreate.noChannel.title"
+        defaultMessage="You haven't created any Channel yet"
+      />
+    }
+  >
+    <p>
+      <FormattedMessage
+        id="pages.DeploymentCampaignCreate.noChannel.message"
+        defaultMessage="You need at least one Channel to create a Deployment Campaign"
+      />
+    </p>
+    <Button as={Link} route={Route.channelsNew}>
+      <FormattedMessage
+        id="pages.DeploymentCampaignCreate.noChannel.createButton"
+        defaultMessage="Create Channel"
+      />
+    </Button>
+  </Result.EmptyList>
+);
+
+type DeploymentCampaignWrapperProps = {
+  getCreateDeploymentCampaignOptionsQuery: PreloadedQuery<DeploymentCampaignCreate_getOptions_Query>;
+};
+
+const DeploymentCampaignWrapper = ({
+  getCreateDeploymentCampaignOptionsQuery,
+}: DeploymentCampaignWrapperProps) => {
+  const deploymentCampaignOptions = usePreloadedQuery(
+    GET_CREATE_DEPLOYMENT_CAMPAIGN_OPTIONS_QUERY,
+    getCreateDeploymentCampaignOptionsQuery,
+  );
+  const { channels, applications } = deploymentCampaignOptions;
+
+  if (applications?.count === 0) {
+    return <NoApplications />;
+  }
+
+  if (channels?.count === 0) {
+    return <NoChannels />;
+  }
+
+  return (
+    <DeploymentCampaign deploymentCampaignOptions={deploymentCampaignOptions} />
+  );
+};
+
+const DeploymentCampaignCreatePage = () => {
+  const [
+    getCreateDeploymentCampaignOptionsQuery,
+    getCreateDeploymentCampaignOptions,
+  ] = useQueryLoader<DeploymentCampaignCreate_getOptions_Query>(
+    GET_CREATE_DEPLOYMENT_CAMPAIGN_OPTIONS_QUERY,
+  );
+
+  const fetchCreateDeploymentCampaignOptions = useCallback(
+    () =>
+      getCreateDeploymentCampaignOptions({}, { fetchPolicy: "network-only" }),
+    [getCreateDeploymentCampaignOptions],
+  );
+
+  useEffect(fetchCreateDeploymentCampaignOptions, [
+    fetchCreateDeploymentCampaignOptions,
+  ]);
+
+  return (
+    <Suspense
+      fallback={
+        <Center data-testid="page-loading">
+          <Spinner />
+        </Center>
+      }
+    >
+      <ErrorBoundary
+        FallbackComponent={(props) => (
+          <Center data-testid="page-error">
+            <Page.LoadingError onRetry={props.resetErrorBoundary} />
+          </Center>
+        )}
+        onReset={fetchCreateDeploymentCampaignOptions}
+      >
+        {getCreateDeploymentCampaignOptionsQuery && (
+          <Page>
+            <Page.Header
+              title={
+                <FormattedMessage
+                  id="pages.DeploymentCampaignCreate.title"
+                  defaultMessage="Create Deployment Campaign"
+                />
+              }
+            />
+            <Page.Main>
+              <DeploymentCampaignWrapper
+                getCreateDeploymentCampaignOptionsQuery={
+                  getCreateDeploymentCampaignOptionsQuery
+                }
+              />
+            </Page.Main>
+          </Page>
+        )}
+      </ErrorBoundary>
+    </Suspense>
+  );
+};
+
+export default DeploymentCampaignCreatePage;


### PR DESCRIPTION
Added a deployment campaign creation page with input form with all necessary fields

<img width="1919" height="771" alt="image" src="https://github.com/user-attachments/assets/d1731753-602c-4888-a87c-a58f8e1d43cc" />
<img width="1919" height="771" alt="image" src="https://github.com/user-attachments/assets/d6ebaee5-3cfa-4ee8-bb66-74ffd8928313" />


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
