### PR TITLE
chore: use astarte 1.3 in development

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ _init-astarte:
     #!/usr/bin/env bash
     echo "🌟 Initializing Astarte..."
     if [ ! -d astarte ]; then
-        git clone --depth=1 https://github.com/astarte-platform/astarte.git -b v1.2.0
+        git clone --depth=1 https://github.com/astarte-platform/astarte.git -b release-1.3
         ( cd astarte && echo '*' > .gitignore )
         ( cd astarte && docker run --rm --user $(id -u):$(id -g) -v "$(pwd)/compose:/compose:z" astarte/docker-compose-initializer:1.2.0 )
     fi


### PR DESCRIPTION
This allows better compatibility with SELinux compliant systems and uses latest astarte developments to the flow.

It also does not remove volumes by default, so that devices and other data can persist in between provisions.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
