### PR TITLE
fix: resolve validation errors on optional number fields in forms

### DIFF
--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -54,14 +54,14 @@ import {
   tmpfsOptSchema,
   storageOptSchema,
   extraHostsSchema,
-  numberSchema,
-} from "./index";
+  optionalNumberSchema,
+} from "forms/index";
 import MultiSelect from "components/MultiSelect";
 import Select, { SingleValue } from "react-select";
 import Icon from "components/Icon";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import ConfirmModal from "components/ConfirmModal";
-import FormFeedback from "./FormFeedback";
+import FormFeedback from "forms/FormFeedback";
 
 const IMAGE_CREDENTIALS_OPTIONS_FRAGMENT = graphql`
   fragment CreateRelease_ImageCredentialsOptionsFragment on RootQueryType {
@@ -375,7 +375,7 @@ const applicationSchema = (intl: any) =>
               .nullable()
               .transform((value) => value?.trim()),
             portBindings: portBindingsSchema,
-            memory: numberSchema
+            memory: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -385,7 +385,7 @@ const applicationSchema = (intl: any) =>
                 }),
               ),
 
-            memoryReservation: numberSchema
+            memoryReservation: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -394,7 +394,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "Memory Reservation (bytes)",
                 }),
               ),
-            memorySwap: numberSchema
+            memorySwap: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -403,7 +403,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "Memory Swap (bytes)",
                 }),
               ),
-            memorySwappiness: numberSchema
+            memorySwappiness: optionalNumberSchema
               .integer()
               .min(0)
               .max(100)
@@ -414,7 +414,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "Memory Swappiness (0-100)",
                 }),
               ),
-            cpuPeriod: numberSchema
+            cpuPeriod: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -423,7 +423,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "CPU Period (microseconds)",
                 }),
               ),
-            cpuQuota: numberSchema
+            cpuQuota: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -432,7 +432,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "CPU Quota (microseconds)",
                 }),
               ),
-            cpuRealtimePeriod: numberSchema
+            cpuRealtimePeriod: optionalNumberSchema
               .integer()
               .nullable()
               .label(
@@ -441,7 +441,7 @@ const applicationSchema = (intl: any) =>
                   defaultMessage: "CPU Real-Time Period (microseconds)",
                 }),
               ),
-            cpuRealtimeRuntime: numberSchema
+            cpuRealtimeRuntime: optionalNumberSchema
               .integer()
               .nullable()
               .label(

--- a/frontend/src/forms/index.ts
+++ b/frontend/src/forms/index.ts
@@ -156,6 +156,16 @@ const numberSchema = yup
   .number()
   .typeError((values) => ({ messageId: messages.number.id, values }));
 
+const optionalNumberSchema = yup
+  .number()
+  .transform((value, originalValue) => {
+    if (originalValue === "" || originalValue == null || Number.isNaN(value)) {
+      return undefined;
+    }
+    return value;
+  })
+  .typeError((values) => ({ messageId: messages.number.id, values }));
+
 const isValidJson = (value: string) => {
   try {
     JSON.parse(value);
@@ -293,4 +303,5 @@ export {
   yup,
   tmpfsOptSchema,
   storageOptSchema,
+  optionalNumberSchema,
 };


### PR DESCRIPTION
When users clicked on optional number input fields (memory, CPU settings, etc.) and left them empty, they would incorrectly show validation error messages even though these fields are marked as optional with nullable() validation.

The issue occurred because:
1. React Hook Form's valueAsNumber: true converts empty strings to NaN
2. Yup's number() schema would trigger typeError on NaN values
3. The transform function wasn't handling NaN values properly

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
