### PR TITLE
fix: Eliminate unnecessary loading delays in campaign details 

### DIFF
--- a/frontend/src/components/DeploymentTargetsTabs.tsx
+++ b/frontend/src/components/DeploymentTargetsTabs.tsx
@@ -18,18 +18,18 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
 import Nav from "react-bootstrap/Nav";
 import NavItem from "react-bootstrap/NavItem";
 import NavLink from "react-bootstrap/NavLink";
 
-import type { DeploymentTargetsTabs_PaginationQuery } from "api/__generated__/DeploymentTargetsTabs_PaginationQuery.graphql";
-import type {
-  DeploymentTargetStatus as DeploymentTargetStatusType,
-  DeploymentTargetsTabs_DeploymentTargetsFragment$key,
-} from "api/__generated__/DeploymentTargetsTabs_DeploymentTargetsFragment.graphql";
+import type { DeploymentTargetStatus as DeploymentTargetStatusType } from "api/__generated__/DeploymentTargetsTabs_SuccessfulFragment.graphql";
+import type { DeploymentTargetsTabs_SuccessfulFragment$key } from "api/__generated__/DeploymentTargetsTabs_SuccessfulFragment.graphql";
+import type { DeploymentTargetsTabs_FailedFragment$key } from "api/__generated__/DeploymentTargetsTabs_FailedFragment.graphql";
+import type { DeploymentTargetsTabs_InProgressFragment$key } from "api/__generated__/DeploymentTargetsTabs_InProgressFragment.graphql";
+import type { DeploymentTargetsTabs_IdleFragment$key } from "api/__generated__/DeploymentTargetsTabs_IdleFragment.graphql";
 
 import DeploymentTargetsTable, {
   columnIds,
@@ -37,19 +37,74 @@ import DeploymentTargetsTable, {
 import type { ColumnId } from "components/DeploymentTargetsTable";
 import DeploymentTargetStatus from "components/DeploymentTargetStatus";
 
-const DEPLOYMENT_TARGETS_TO_LOAD_FIRST = 40;
 const DEPLOYMENT_TARGETS_TO_LOAD_NEXT = 10;
 
-const DEPLOYMENT_TARGETS_TABS_FRAGMENT = graphql`
-  fragment DeploymentTargetsTabs_DeploymentTargetsFragment on DeploymentCampaign
-  @refetchable(queryName: "DeploymentTargetsTabs_PaginationQuery")
-  @argumentDefinitions(
-    first: { type: "Int" }
-    after: { type: "String" }
-    filter: { type: "DeploymentTargetFilterInput" }
-  ) {
-    deploymentTargets(first: $first, after: $after, filter: $filter)
-      @connection(key: "DeploymentTargetsTabs_deploymentTargets") {
+const DEPLOYMENT_TARGETS_SUCCESSFUL_FRAGMENT = graphql`
+  fragment DeploymentTargetsTabs_SuccessfulFragment on DeploymentCampaign
+  @refetchable(queryName: "DeploymentTargetsTabs_SuccessfulPaginationQuery")
+  @argumentDefinitions(first: { type: "Int" }, after: { type: "String" }) {
+    successfulDeploymentTargets: deploymentTargets(
+      first: $first
+      after: $after
+      filter: { status: { eq: SUCCESSFUL } }
+    ) @connection(key: "DeploymentTargetsTabs_successfulDeploymentTargets") {
+      edges {
+        node {
+          status
+          ...DeploymentTargetsTable_DeploymentTargetsFragment
+        }
+      }
+    }
+  }
+`;
+
+const DEPLOYMENT_TARGETS_FAILED_FRAGMENT = graphql`
+  fragment DeploymentTargetsTabs_FailedFragment on DeploymentCampaign
+  @refetchable(queryName: "DeploymentTargetsTabs_FailedPaginationQuery")
+  @argumentDefinitions(first: { type: "Int" }, after: { type: "String" }) {
+    failedDeploymentTargets: deploymentTargets(
+      first: $first
+      after: $after
+      filter: { status: { eq: FAILED } }
+    ) @connection(key: "DeploymentTargetsTabs_failedDeploymentTargets") {
+      edges {
+        node {
+          status
+          ...DeploymentTargetsTable_DeploymentTargetsFragment
+        }
+      }
+    }
+  }
+`;
+
+const DEPLOYMENT_TARGETS_IN_PROGRESS_FRAGMENT = graphql`
+  fragment DeploymentTargetsTabs_InProgressFragment on DeploymentCampaign
+  @refetchable(queryName: "DeploymentTargetsTabs_InProgressPaginationQuery")
+  @argumentDefinitions(first: { type: "Int" }, after: { type: "String" }) {
+    inProgressDeploymentTargets: deploymentTargets(
+      first: $first
+      after: $after
+      filter: { status: { eq: IN_PROGRESS } }
+    ) @connection(key: "DeploymentTargetsTabs_inProgressDeploymentTargets") {
+      edges {
+        node {
+          status
+          ...DeploymentTargetsTable_DeploymentTargetsFragment
+        }
+      }
+    }
+  }
+`;
+
+const DEPLOYMENT_TARGETS_IDLE_FRAGMENT = graphql`
+  fragment DeploymentTargetsTabs_IdleFragment on DeploymentCampaign
+  @refetchable(queryName: "DeploymentTargetsTabs_IdlePaginationQuery")
+  @argumentDefinitions(first: { type: "Int" }, after: { type: "String" }) {
+    idleDeploymentTargets: deploymentTargets(
+      first: $first
+      after: $after
+      filter: { status: { eq: IDLE } }
+    ) @connection(key: "DeploymentTargetsTabs_idleDeploymentTargets") {
       edges {
         node {
           status
@@ -74,54 +129,90 @@ const deploymentTargetTabs: DeploymentTargetStatusType[] = [
   "IDLE",
 ];
 
+const tabConfig = {
+  SUCCESSFUL: {
+    fragment: DEPLOYMENT_TARGETS_SUCCESSFUL_FRAGMENT,
+    dataField: "successfulDeploymentTargets",
+  },
+  FAILED: {
+    fragment: DEPLOYMENT_TARGETS_FAILED_FRAGMENT,
+    dataField: "failedDeploymentTargets",
+  },
+  IN_PROGRESS: {
+    fragment: DEPLOYMENT_TARGETS_IN_PROGRESS_FRAGMENT,
+    dataField: "inProgressDeploymentTargets",
+  },
+  IDLE: {
+    fragment: DEPLOYMENT_TARGETS_IDLE_FRAGMENT,
+    dataField: "idleDeploymentTargets",
+  },
+} as const;
+
+const useActiveStatusPaginationFragment = (
+  activeTab: DeploymentTargetStatusType,
+  deploymentCampaignRef: any,
+  isVisited: boolean,
+) => {
+  const config = tabConfig[activeTab];
+  return usePaginationFragment(
+    config.fragment,
+    isVisited ? deploymentCampaignRef : null,
+  );
+};
+
 type Props = {
-  deploymentCampaignRef: DeploymentTargetsTabs_DeploymentTargetsFragment$key;
+  deploymentCampaignRef: DeploymentTargetsTabs_SuccessfulFragment$key &
+    DeploymentTargetsTabs_FailedFragment$key &
+    DeploymentTargetsTabs_InProgressFragment$key &
+    DeploymentTargetsTabs_IdleFragment$key;
 };
 
 const DeploymentTargetsTabs = ({ deploymentCampaignRef }: Props) => {
   const [activeTab, setActiveTab] =
     useState<DeploymentTargetStatusType>("SUCCESSFUL");
 
-  const { data, loadNext, hasNext, isLoadingNext, refetch } =
-    usePaginationFragment<
-      DeploymentTargetsTabs_PaginationQuery,
-      DeploymentTargetsTabs_DeploymentTargetsFragment$key
-    >(DEPLOYMENT_TARGETS_TABS_FRAGMENT, deploymentCampaignRef);
+  const [visitedTabs, setVisitedTabs] = useState<
+    Set<DeploymentTargetStatusType>
+  >(new Set(["SUCCESSFUL"]));
+
+  const handleTabChange = useCallback((newTab: DeploymentTargetStatusType) => {
+    setActiveTab(newTab);
+    setVisitedTabs((prev) => new Set([...prev, newTab]));
+  }, []);
+
+  // Only runs one fragment hook (for the active tab)
+  const currentTabFragment = useActiveStatusPaginationFragment(
+    activeTab,
+    deploymentCampaignRef,
+    visitedTabs.has(activeTab),
+  );
+
+  const isTabDataLoading =
+    !visitedTabs.has(activeTab) ||
+    (visitedTabs.has(activeTab) && !currentTabFragment?.data);
+
+  const visibleTargets = useMemo(() => {
+    const config = tabConfig[activeTab];
+    const deploymentTargetsField = currentTabFragment?.data?.[config.dataField];
+
+    if (!deploymentTargetsField?.edges) return [];
+    return deploymentTargetsField.edges
+      .map((edge: any) => edge?.node)
+      .filter(Boolean);
+  }, [currentTabFragment?.data, activeTab]);
 
   const loadNextDeploymentTargets = useCallback(() => {
-    if (hasNext && !isLoadingNext) {
-      loadNext(DEPLOYMENT_TARGETS_TO_LOAD_NEXT);
+    if (currentTabFragment?.hasNext && !currentTabFragment?.isLoadingNext) {
+      currentTabFragment.loadNext(DEPLOYMENT_TARGETS_TO_LOAD_NEXT);
     }
-  }, [hasNext, isLoadingNext, loadNext]);
-
-  const deploymentTargets = useMemo(() => {
-    return data.deploymentTargets?.edges?.map((edge) => edge?.node) ?? [];
-  }, [data]);
+  }, [currentTabFragment]);
 
   const hiddenColumns = useMemo(() => {
     const visible = columnMap[activeTab];
     return columnIds.filter((c) => !visible.includes(c));
   }, [activeTab]);
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      refetch(
-        {
-          first: DEPLOYMENT_TARGETS_TO_LOAD_FIRST,
-          filter: {
-            status: {
-              eq: activeTab,
-            },
-          },
-        },
-        { fetchPolicy: "network-only" },
-      );
-    }, 500);
-
-    return () => clearTimeout(timeout);
-  }, [activeTab, refetch]);
-
-  if (!data.deploymentTargets) return null;
+  if (!deploymentCampaignRef) return null;
 
   return (
     <div>
@@ -139,20 +230,27 @@ const DeploymentTargetsTabs = ({ deploymentCampaignRef }: Props) => {
                 as="button"
                 type="button"
                 active={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
+                onClick={() => handleTabChange(tab)}
               >
                 <DeploymentTargetStatus status={tab} />
               </NavLink>
             </NavItem>
           ))}
         </Nav>
-        <DeploymentTargetsTable
-          deploymentTargetsRef={deploymentTargets}
-          hiddenColumns={hiddenColumns}
-          isLoadingNext={isLoadingNext}
-          hasNext={hasNext}
-          loadNextDeploymentTargets={loadNextDeploymentTargets}
-        />
+
+        {isTabDataLoading ? (
+          <div className="d-flex justify-content-center p-4">
+            <div className="spinner-border" role="status"></div>
+          </div>
+        ) : (
+          <DeploymentTargetsTable
+            deploymentTargetsRef={visibleTargets}
+            hiddenColumns={hiddenColumns}
+            isLoadingNext={currentTabFragment?.isLoadingNext ?? false}
+            hasNext={currentTabFragment?.hasNext ?? false}
+            loadNextDeploymentTargets={loadNextDeploymentTargets}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/forms/DeploymentCampaignForm.tsx
+++ b/frontend/src/forms/DeploymentCampaignForm.tsx
@@ -213,7 +213,7 @@ const DeploymentCampaign = ({
               releaseId: release.id,
             }}
           >
-            {channel.name}
+            {release.version}
           </Link>
         </FormRow>
       </Col>

--- a/frontend/src/forms/DeploymentCampaignForm.tsx
+++ b/frontend/src/forms/DeploymentCampaignForm.tsx
@@ -46,7 +46,10 @@ const DEPLOYMENT_CAMPAIGN_FORM_FRAGMENT = graphql`
     release {
       id
       version
-      applicationId
+      application {
+        id
+        name
+      }
     }
     deploymentMechanism {
       __typename
@@ -189,15 +192,21 @@ const DeploymentCampaign = ({
         <FormRow
           label={
             <FormattedMessage
-              id="forms.DeploymentCampaignForm.deploymentChannelLabel"
-              defaultMessage="Deployment Channel"
+              id="forms.DeploymentCampaignForm.applicationLabel"
+              defaultMessage="Application"
             />
           }
         >
-          <Link route={Route.channelsEdit} params={{ channelId: channel.id }}>
-            {channel.name}
+          <Link
+            route={Route.application}
+            params={{
+              applicationId: release.application?.id || "",
+            }}
+          >
+            {release.application?.name}
           </Link>
         </FormRow>
+
         <FormRow
           label={
             <FormattedMessage
@@ -209,11 +218,24 @@ const DeploymentCampaign = ({
           <Link
             route={Route.release}
             params={{
-              applicationId: release.applicationId || "",
+              applicationId: release.application?.id || "",
               releaseId: release.id,
             }}
           >
             {release.version}
+          </Link>
+        </FormRow>
+
+        <FormRow
+          label={
+            <FormattedMessage
+              id="forms.DeploymentCampaignForm.deploymentChannelLabel"
+              defaultMessage="Channel"
+            />
+          }
+        >
+          <Link route={Route.channelsEdit} params={{ channelId: channel.id }}>
+            {channel.name}
           </Link>
         </FormRow>
       </Col>

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1441,8 +1441,11 @@
   "forms.CreateUpdateCampaign.otaRequestTimeoutSecondsValidationLabel": {
     "defaultMessage": "Request Timeout"
   },
+  "forms.DeploymentCampaignForm.applicationLabel": {
+    "defaultMessage": "Application"
+  },
   "forms.DeploymentCampaignForm.deploymentChannelLabel": {
-    "defaultMessage": "Deployment Channel"
+    "defaultMessage": "Channel"
   },
   "forms.DeploymentCampaignForm.outcomeLabel": {
     "defaultMessage": "Outcome"

--- a/frontend/src/pages/DeploymentCampaign.tsx
+++ b/frontend/src/pages/DeploymentCampaign.tsx
@@ -47,16 +47,22 @@ import DeploymentCampaignForm from "forms/DeploymentCampaignForm";
 import { Link, Route } from "Navigation";
 import DeploymentTargetsTabs from "components/DeploymentTargetsTabs";
 
+const DEPLOYMENT_TARGETS_INITIAL_LOAD = 40;
+
 const GET_DEPLOYMENT_CAMPAIGN_QUERY = graphql`
   query DeploymentCampaign_getDeploymentCampaign_Query(
     $deploymentCampaignId: ID!
+    $first: Int!
   ) {
     deploymentCampaign(id: $deploymentCampaignId) {
       name
       ...DeploymentCampaignForm_DeploymentCampaignFragment
       ...DeploymentCampaignStatsChart_DeploymentCampaignStatsChartFragment
       ...DeploymentCampaign_RefreshFragment
-      ...DeploymentTargetsTabs_DeploymentTargetsFragment
+      ...DeploymentTargetsTabs_SuccessfulFragment @arguments(first: $first)
+      ...DeploymentTargetsTabs_FailedFragment @arguments(first: $first)
+      ...DeploymentTargetsTabs_InProgressFragment @arguments(first: $first)
+      ...DeploymentTargetsTabs_IdleFragment @arguments(first: $first)
     }
   }
 `;
@@ -100,7 +106,10 @@ const DeploymentCampaignRefresh = ({
       subscriptionRef.current = fetchQuery(
         relayEnvironment,
         GET_DEPLOYMENT_CAMPAIGN_QUERY,
-        { deploymentCampaignId: id },
+        {
+          deploymentCampaignId: id,
+          first: DEPLOYMENT_TARGETS_INITIAL_LOAD,
+        },
         { fetchPolicy: "network-only" },
       ).subscribe({
         complete: () => {
@@ -187,7 +196,10 @@ const DeploymentCampaignPage = () => {
 
   const fetchDeploymentCampaign = useCallback(() => {
     getDeploymentCampaign(
-      { deploymentCampaignId },
+      {
+        deploymentCampaignId,
+        first: DEPLOYMENT_TARGETS_INITIAL_LOAD,
+      },
       { fetchPolicy: "network-only" },
     );
   }, [getDeploymentCampaign, deploymentCampaignId]);


### PR DESCRIPTION
- The Link component for the release was incorrectly displaying the channel name instead of the release version.
- Replaced single refetchable fragment with dedicated fragments for each status tab (`SUCCESSFUL`, `FAILED`, `IN_PROGRESS`, `IDLE`).
- Ensured deployment target fragments load concurrently with the main query instead of being fetched afterward.
- Added lazy loading per tab, data is only fetched when a tab is visited, preventing redundant requests.

<details><summary>Delay Example</summary>
<p>

https://github.com/user-attachments/assets/91ebb96f-eee1-44fe-a113-f8d2ae938ee6

</p>
</details> 

<details><summary>Screenshots</summary>
<p>

Old:
<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/ce27939c-894e-47e3-a535-f42fd110a6e7" />


Updated:
<img width="1923" height="984" alt="image" src="https://github.com/user-attachments/assets/1cca527b-19b8-4a08-9875-68c97c5f6055" />

Reference:

<img width="1920" height="979" alt="image" src="https://github.com/user-attachments/assets/1dac5219-3b49-4c4f-ba46-8bcc53ab7332" />



</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
