### PR TITLE
feat(containers): Add searchable selection in Deployment Campaigns

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1211,13 +1211,13 @@
     "defaultMessage": "Application"
   },
   "forms.CreateDeploymentCampaign.applicationOption": {
-    "defaultMessage": "Select an Application"
+    "defaultMessage": "Search or select an application..."
   },
   "forms.CreateDeploymentCampaign.channelLabel": {
     "defaultMessage": "Channel"
   },
   "forms.CreateDeploymentCampaign.channelOption": {
-    "defaultMessage": "Select a Channel"
+    "defaultMessage": "Search or select a channel..."
   },
   "forms.CreateDeploymentCampaign.createRequestRetriesLabel": {
     "defaultMessage": "Request Retries"
@@ -1234,11 +1234,29 @@
   "forms.CreateDeploymentCampaign.nameLabel": {
     "defaultMessage": "Name"
   },
+  "forms.CreateDeploymentCampaign.noApplicationsAvailable": {
+    "defaultMessage": "No applications available"
+  },
+  "forms.CreateDeploymentCampaign.noApplicationsFoundMatching": {
+    "defaultMessage": "No applications found matching \"{inputValue}\""
+  },
+  "forms.CreateDeploymentCampaign.noChannelsAvailable": {
+    "defaultMessage": "No channels available"
+  },
+  "forms.CreateDeploymentCampaign.noChannelsFoundMatching": {
+    "defaultMessage": "No channels found matching \"{inputValue}\""
+  },
+  "forms.CreateDeploymentCampaign.noReleasesAvailable": {
+    "defaultMessage": "No releases available"
+  },
+  "forms.CreateDeploymentCampaign.noReleasesFoundMatching": {
+    "defaultMessage": "No releases found matching \"{inputValue}\""
+  },
   "forms.CreateDeploymentCampaign.releaseLabel": {
     "defaultMessage": "Release"
   },
   "forms.CreateDeploymentCampaign.releaseOption": {
-    "defaultMessage": "Select a Release"
+    "defaultMessage": "Search or select a release..."
   },
   "forms.CreateDeploymentCampaign.requestTimeoutSecondsLabel": {
     "defaultMessage": "Request Timeout <muted>(seconds)</muted>"


### PR DESCRIPTION
- Enabled search functionality for application, release, and channel fields when creating a new deployment campaign
- Added the option to clear selected values

<details><summary>Screenshots</summary>
<p>

<img width="1919" height="785" alt="image" src="https://github.com/user-attachments/assets/05e53bd6-92af-46b1-a9b2-b30f64fb5da4" />
<img width="1919" height="785" alt="image" src="https://github.com/user-attachments/assets/ebef75c4-d407-4ffc-bd5f-aa944d6ef441" />
<img width="1919" height="785" alt="image" src="https://github.com/user-attachments/assets/e7be0bf6-6104-48d5-91a6-fc1a81538856" />
<img width="1919" height="785" alt="image" src="https://github.com/user-attachments/assets/7a0bf87b-5f04-41c3-88c7-d61e7b40a89d" />



</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
