### PR TITLE
feat(containers): device mappings form input component

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -38,7 +38,7 @@ import Row from "components/Row";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import MultiSelect from "./MultiSelect";
 import InfiniteScroll from "./InfiniteScroll";
-import Icon from "components/Icon";
+import DeviceMappingsFormInput from "components/DeviceMappingsFormInput";
 
 const CONTAINERS_TO_LOAD_NEXT = 5;
 
@@ -458,30 +458,13 @@ type DeviceMappingDetailsProps = {
   deviceMappings: NonNullable<
     ContainersTable_ContainerFragment$data["containers"]["edges"]
   >[number]["node"]["deviceMappings"];
-  containerIndex: number;
+  containerIndex?: number;
 };
 
 const DeviceMappingDetails = ({
   deviceMappings,
-  containerIndex,
 }: DeviceMappingDetailsProps) => {
-  const [openDeviceMappingIndexes, setOpenDeviceMappingIndexes] = useState<
-    number[]
-  >(deviceMappings.edges?.map((_, index) => index) ?? []);
-
-  const toggleDeviceMapping = (index: number) => {
-    setOpenDeviceMappingIndexes((current) =>
-      current.includes(index)
-        ? current.filter((i) => i !== index)
-        : [...current, index],
-    );
-  };
-
-  const lastPathElement = (path: string) => {
-    const pathElements = path.split("/");
-    return pathElements[pathElements.length - 1];
-  };
-
+  const dmFormInputProps = { deviceMappings: deviceMappings };
   return (
     <div className="mt-3">
       <h5>
@@ -499,70 +482,13 @@ const DeviceMappingDetails = ({
           />
         </p>
       ) : (
-        deviceMappings.edges.map((deviceMappingEdge, dmIndex) => {
-          const dmNode = deviceMappingEdge.node;
-          const isOpen = openDeviceMappingIndexes.includes(dmIndex);
-
-          return (
-            <div
-              key={dmNode?.id ?? dmIndex}
-              className="mb-2 border rounded bg-light"
-            >
-              <Button
-                variant="light"
-                className="w-100 d-flex align-items-center fw-bold"
-                onClick={() => toggleDeviceMapping(dmIndex)}
-                aria-expanded={isOpen}
-              >
-                {lastPathElement(dmNode?.pathInContainer)}
-                <Icon
-                  icon={isOpen ? "caretUp" : "caretDown"}
-                  className="ms-auto"
-                />
-              </Button>
-
-              <Collapse in={isOpen}>
-                <div className="p-2 border-top">
-                  <FormRow
-                    id={`containers-${containerIndex}-deviceMapping-${dmIndex}-pathInContainer`}
-                    label={
-                      <FormattedMessage
-                        id="forms.CreateRelease.pathInContainerLabel"
-                        defaultMessage="Path In Container"
-                      />
-                    }
-                  >
-                    <Form.Control value={dmNode.pathInContainer} readOnly />
-                  </FormRow>
-
-                  <FormRow
-                    id={`containers-${containerIndex}-deviceMapping-${dmIndex}-pathOnHost`}
-                    label={
-                      <FormattedMessage
-                        id="forms.CreateRelease.pathOnHostLabel"
-                        defaultMessage="Path On Host"
-                      />
-                    }
-                  >
-                    <Form.Control value={dmNode.pathOnHost} readOnly />
-                  </FormRow>
-
-                  <FormRow
-                    id={`containers-${containerIndex}-deviceMapping-${dmIndex}-cgroupPermissions`}
-                    label={
-                      <FormattedMessage
-                        id="forms.CreateRelease.cgroupPermissionsLabel"
-                        defaultMessage="Container Group Permissions"
-                      />
-                    }
-                  >
-                    <Form.Control value={dmNode.cgroupPermissions} readOnly />
-                  </FormRow>
-                </div>
-              </Collapse>
-            </div>
-          );
-        })
+        <div className="p-2 mb-2 border rounded bg-light">
+          <DeviceMappingsFormInput
+            readOnly={true}
+            readOnlyProps={dmFormInputProps}
+            editableProps={null}
+          />
+        </div>
       )}
     </div>
   );
@@ -910,10 +836,7 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
         containerVolumes={container.containerVolumes}
         containerIndex={index}
       />
-      <DeviceMappingDetails
-        deviceMappings={container.deviceMappings}
-        containerIndex={index}
-      />
+      <DeviceMappingDetails deviceMappings={container.deviceMappings} />
     </div>
   );
 };

--- a/frontend/src/components/DeviceMappingsFormInput.tsx
+++ b/frontend/src/components/DeviceMappingsFormInput.tsx
@@ -1,0 +1,218 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Col, Container, Row } from "react-bootstrap";
+import {
+  FieldErrors,
+  UseFieldArrayReturn,
+  UseFormRegister,
+} from "react-hook-form";
+import { FormattedMessage } from "react-intl";
+
+import { ContainersTable_ContainerFragment$data } from "api/__generated__/ContainersTable_ContainerFragment.graphql";
+
+import Button from "components/Button";
+import Form from "components/Form";
+import Icon from "components/Icon";
+import { ReleaseInputData } from "forms/CreateRelease";
+
+type DeviceMappingsData = NonNullable<
+  ContainersTable_ContainerFragment$data["containers"]["edges"]
+>[number]["node"]["deviceMappings"];
+
+type ReadOnlyFormInputProps = {
+  deviceMappings: DeviceMappingsData;
+};
+
+type EditableFormInputProps = {
+  containerIndex: number;
+  deviceMappingsForm: UseFieldArrayReturn<
+    ReleaseInputData,
+    `containers.${number}.deviceMappings`,
+    "id"
+  >;
+  canAddDeviceMapping: boolean;
+  errorFeedback: FieldErrors<ReleaseInputData>;
+  register: UseFormRegister<ReleaseInputData>;
+  removeDeviceMapping: (dmIndex: number) => void;
+};
+
+type DeviceMappingsFormInputProps = {
+  readOnly?: boolean;
+  editableProps: EditableFormInputProps | null;
+  readOnlyProps: ReadOnlyFormInputProps | null;
+};
+
+const DeviceMappingsFormInput = ({
+  readOnly = false,
+  editableProps,
+  readOnlyProps,
+}: DeviceMappingsFormInputProps) => {
+  const otherFormControlFields = (
+    dmProp: "pathInContainer" | "pathOnHost" | "cgroupPermissions",
+    dmIndex: number,
+    value?: string,
+  ) => {
+    return readOnly
+      ? {
+          value: value ?? "",
+        }
+      : {
+          ...editableProps?.register(
+            `containers.${editableProps.containerIndex}.deviceMappings.${dmIndex}.${dmProp}` as const,
+          ),
+        };
+  };
+
+  const data = readOnly
+    ? readOnlyProps?.deviceMappings.edges?.map((edge) => edge.node)
+    : editableProps?.deviceMappingsForm?.fields;
+
+  return (
+    <>
+      <Container fluid>
+        {(editableProps?.deviceMappingsForm?.fields?.length ||
+          readOnlyProps?.deviceMappings?.edges?.length) && (
+          <Row className="mb-3">
+            <Col>
+              <FormattedMessage
+                id="forms.CreateRelease.pathInContainerLabel"
+                defaultMessage="Path In Container"
+              />
+            </Col>
+            <Col>
+              <FormattedMessage
+                id="forms.CreateRelease.pathOnHostLabel"
+                defaultMessage="Path On Host"
+              />
+            </Col>
+            <Col>
+              <FormattedMessage
+                id="forms.CreateRelease.cgroupPermissionsLabel"
+                defaultMessage="Container Group Permissions"
+              />
+            </Col>
+            {!readOnly && <Col></Col>}
+          </Row>
+        )}
+
+        {data?.map((deviceMapping, dmIndex) => {
+          const fieldErrors = readOnly
+            ? null
+            : editableProps?.errorFeedback?.containers?.[
+                editableProps?.containerIndex
+              ]?.deviceMappings?.[dmIndex];
+
+          return (
+            <Row className="mb-3" key={`deviceMapping-${dmIndex}`}>
+              <Col>
+                <Form.Control
+                  {...otherFormControlFields(
+                    "pathInContainer",
+                    dmIndex,
+                    deviceMapping?.pathInContainer,
+                  )}
+                  placeholder="e.g., /dev/net/1"
+                  isInvalid={!!fieldErrors?.pathInContainer}
+                  readOnly={readOnly}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {fieldErrors?.pathInContainer?.message && (
+                    <FormattedMessage
+                      id={fieldErrors.pathInContainer.message}
+                    />
+                  )}
+                </Form.Control.Feedback>
+              </Col>
+              <Col>
+                <Form.Control
+                  {...otherFormControlFields(
+                    "pathOnHost",
+                    dmIndex,
+                    deviceMapping?.pathOnHost,
+                  )}
+                  placeholder="e.g., /dev/net/1"
+                  isInvalid={!!fieldErrors?.pathOnHost}
+                  readOnly={readOnly}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {fieldErrors?.pathOnHost?.message && (
+                    <FormattedMessage id={fieldErrors.pathOnHost.message} />
+                  )}
+                </Form.Control.Feedback>
+              </Col>
+              <Col>
+                <Form.Control
+                  {...otherFormControlFields(
+                    "cgroupPermissions",
+                    dmIndex,
+                    deviceMapping?.cgroupPermissions,
+                  )}
+                  placeholder="e.g., mrw"
+                  isInvalid={!!fieldErrors?.cgroupPermissions}
+                  readOnly={readOnly}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {fieldErrors?.cgroupPermissions?.message && (
+                    <FormattedMessage
+                      id={fieldErrors.cgroupPermissions.message}
+                    />
+                  )}
+                </Form.Control.Feedback>
+              </Col>
+              {!readOnly && (
+                <Col>
+                  <Button
+                    variant="shadow-danger"
+                    type="button"
+                    onClick={() => editableProps?.removeDeviceMapping(dmIndex)}
+                  >
+                    <Icon className="text-danger" icon={"delete"} />
+                  </Button>
+                </Col>
+              )}
+            </Row>
+          );
+        })}
+      </Container>
+
+      {!readOnly && (
+        <Button
+          variant="outline-primary"
+          onClick={() =>
+            editableProps?.deviceMappingsForm?.append({
+              pathOnHost: "",
+              pathInContainer: "",
+              cgroupPermissions: "",
+            })
+          }
+          disabled={!editableProps?.canAddDeviceMapping}
+        >
+          <FormattedMessage
+            id="forms.CreateRelease.addDeviceMappingButton"
+            defaultMessage="Add Device Mapping"
+          />
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default DeviceMappingsFormInput;

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -62,6 +62,7 @@ import Icon from "components/Icon";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import ConfirmModal from "components/ConfirmModal";
 import FormFeedback from "forms/FormFeedback";
+import DeviceMappingsFormInput from "components/DeviceMappingsFormInput";
 
 const IMAGE_CREDENTIALS_OPTIONS_FRAGMENT = graphql`
   fragment CreateRelease_ImageCredentialsOptionsFragment on RootQueryType {
@@ -283,7 +284,7 @@ type ContainerInput = {
   deviceMappings?: ContainerCreateWithNestedDeviceMappingsInput[];
 };
 
-type ReleaseInputData = {
+export type ReleaseInputData = {
   version: string;
   containers?: ContainerInput[] | null;
   requiredSystemModels: ReleaseCreateRequiredSystemModelsInput[];
@@ -597,6 +598,16 @@ const ContainerForm = ({
       dm.pathOnHost?.trim() &&
       dm.cgroupPermissions?.trim(),
   );
+
+  const dmFormInputProps = {
+    containerIndex: index,
+    deviceMappingsForm: deviceMappingsForm,
+    canAddDeviceMapping: canAddDeviceMapping,
+    errorFeedback: errors,
+    register: register,
+    removeDeviceMapping: (dmIndex: number) =>
+      deviceMappingsForm.remove(dmIndex),
+  };
 
   return (
     <div className="border p-3 mb-3">
@@ -1463,117 +1474,10 @@ const ContainerForm = ({
           }
         >
           <div className="p-3 mb-3 bg-light border rounded">
-            <Stack gap={3}>
-              {deviceMappingsForm.fields.map((deviceMapping, dmIndex) => {
-                const fieldErrors =
-                  errors.containers?.[index]?.deviceMappings?.[dmIndex];
-
-                return (
-                  <Stack
-                    direction="horizontal"
-                    gap={3}
-                    key={`stack1-deviceMapping-${dmIndex}`}
-                    className="align-items-start"
-                  >
-                    <Form.Group id={`containers-${index}-pathInContainer`}>
-                      <Form.Label>
-                        <FormattedMessage
-                          id="forms.CreateRelease.pathInContainerLabel"
-                          defaultMessage="Path In Container"
-                        />
-                      </Form.Label>
-                      <Form.Control
-                        {...register(
-                          `containers.${index}.deviceMappings.${dmIndex}.pathInContainer` as const,
-                        )}
-                        placeholder="e.g., /dev/net/1"
-                        isInvalid={!!fieldErrors?.pathInContainer}
-                      />
-                      <Form.Control.Feedback type="invalid">
-                        {fieldErrors?.pathInContainer?.message && (
-                          <FormattedMessage
-                            id={fieldErrors.pathInContainer.message}
-                          />
-                        )}
-                      </Form.Control.Feedback>
-                    </Form.Group>
-
-                    <Form.Group id={`containers-${index}-pathOnHost`}>
-                      <Form.Label>
-                        <FormattedMessage
-                          id="forms.CreateRelease.pathOnHostLabel"
-                          defaultMessage="Path On Host"
-                        />
-                      </Form.Label>
-                      <Form.Control
-                        {...register(
-                          `containers.${index}.deviceMappings.${dmIndex}.pathOnHost` as const,
-                        )}
-                        placeholder="e.g., /dev/net/1"
-                        isInvalid={!!fieldErrors?.pathOnHost}
-                      />
-                      <Form.Control.Feedback type="invalid">
-                        {fieldErrors?.pathOnHost?.message && (
-                          <FormattedMessage
-                            id={fieldErrors.pathOnHost.message}
-                          />
-                        )}
-                      </Form.Control.Feedback>
-                    </Form.Group>
-
-                    <Form.Group id={`containers-${index}-cgroupPermissions`}>
-                      <Form.Label>
-                        <FormattedMessage
-                          id="forms.CreateRelease.cgroupPermissionsLabel"
-                          defaultMessage="Container Group Permissions"
-                        />
-                      </Form.Label>
-                      <Form.Control
-                        {...register(
-                          `containers.${index}.deviceMappings.${dmIndex}.cgroupPermissions` as const,
-                        )}
-                        placeholder="e.g., mrw"
-                        isInvalid={!!fieldErrors?.cgroupPermissions}
-                      />
-                      <Form.Control.Feedback type="invalid">
-                        {fieldErrors?.cgroupPermissions?.message && (
-                          <FormattedMessage
-                            id={fieldErrors.cgroupPermissions.message}
-                          />
-                        )}
-                      </Form.Control.Feedback>
-                    </Form.Group>
-
-                    <Button
-                      variant="shadow-danger"
-                      type="button"
-                      onClick={() => deviceMappingsForm.remove(dmIndex)}
-                    >
-                      <Icon className="text-danger" icon={"delete"} />
-                    </Button>
-                  </Stack>
-                );
-              })}
-
-              <div>
-                <Button
-                  variant="outline-primary"
-                  onClick={() =>
-                    deviceMappingsForm.append({
-                      pathOnHost: "",
-                      pathInContainer: "",
-                      cgroupPermissions: "",
-                    })
-                  }
-                  disabled={!canAddDeviceMapping}
-                >
-                  <FormattedMessage
-                    id="forms.CreateRelease.addDeviceMappingButton"
-                    defaultMessage="Add Device Mapping"
-                  />
-                </Button>
-              </div>
-            </Stack>
+            <DeviceMappingsFormInput
+              editableProps={dmFormInputProps}
+              readOnlyProps={null}
+            />
           </div>
         </FormRow>
 


### PR DESCRIPTION
Add unified component for display and input of device mappings.

<details>
<summary>
Screenshots
</summary>

<img width="1892" height="945" alt="Screenshot from 2025-09-19 15-59-09" src="https://github.com/user-attachments/assets/8e128648-1c61-46ce-9530-37e7e412e092" />

<img width="1892" height="945" alt="Screenshot from 2025-09-19 15-59-38" src="https://github.com/user-attachments/assets/386bac23-23e2-43e1-a315-430241a5c7f2" />

</details>