### PR TITLE
feat: reconcile interfaces about container stats used by device runtime

### DIFF
--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerBlkio.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerBlkio.json
@@ -1,0 +1,36 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerBlkio",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "doc": "BlkioStats stores all IO service stats for data read and write.",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/name",
+      "type": "string",
+      "explicit_timestamp": true
+    },
+    {
+      "endpoint": "/%{container_id}/major",
+      "type": "longinteger",
+      "explicit_timestamp": true
+    },
+    {
+      "endpoint": "/%{container_id}/minor",
+      "type": "longinteger",
+      "explicit_timestamp": true
+    },
+    {
+      "endpoint": "/%{container_id}/op",
+      "type": "string",
+      "explicit_timestamp": true
+    },
+    {
+      "endpoint": "/%{container_id}/value",
+      "type": "longinteger",
+      "explicit_timestamp": true
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerCpu.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerCpu.json
@@ -1,0 +1,125 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerCpu",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "doc": "The precpu stats is the CPU statistic of the previous read, and is used to calculate the CPU usage percentage. It is not an exact copy of the cpu_stats field.",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/cpuUsageTotalUsage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Total CPU time consumed in nanoseconds",
+      "doc": "Total CPU time consumed by the container, in nanoseconds."
+    },
+    {
+      "endpoint": "/%{container_id}/cpuUsagePercpuUsage",
+      "type": "longintegerarray",
+      "explicit_timestamp": true,
+      "description": "Total CPU time (in nanoseconds) consumed per core",
+      "doc": "This field is Linux-specific when using cgroups v1."
+    },
+    {
+      "endpoint": "/%{container_id}/cpuUsageUsageInKernelmode",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Time (in nanoseconds) spent by tasks of the cgroup in kernel mode",
+      "doc": "CPU time spent in kernel mode by the container's tasks, in nanoseconds."
+    },
+    {
+      "endpoint": "/%{container_id}/cpuUsageUsageInUsermode",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Time (in nanoseconds) spent by tasks of the cgroup in user mode"
+    },
+    {
+      "endpoint": "/%{container_id}/systemCpuUsage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "System Usage."
+    },
+    {
+      "endpoint": "/%{container_id}/onlineCpus",
+      "type": "integer",
+      "explicit_timestamp": true,
+      "description": "Number of online CPUs."
+    },
+    {
+      "endpoint": "/%{container_id}/throttlingDataPeriods",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Number of periods with throttling active."
+    },
+    {
+      "endpoint": "/%{container_id}/throttlingDataThrottledPeriods",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Number of periods when the container hit its throttling limit."
+    },
+    {
+      "endpoint": "/%{container_id}/throttlingDataThrottledTime",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Aggregated time (in nanoseconds) the container was throttled for."
+    },
+    {
+      "endpoint": "/%{container_id}/preCpuUsageTotalUsage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Total CPU time consumed in nanoseconds",
+      "doc": "Total CPU time consumed by the container, in nanoseconds."
+    },
+    {
+      "endpoint": "/%{container_id}/preCpuUsagePercpuUsage",
+      "type": "longintegerarray",
+      "explicit_timestamp": true,
+      "description": "Total CPU time (in nanoseconds) consumed per core",
+      "doc": "This field is Linux-specific when using cgroups v1."
+    },
+    {
+      "endpoint": "/%{container_id}/preCpuUsageUsageInKernelmode",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Time (in nanoseconds) spent by tasks of the cgroup in kernel mode",
+      "doc": "CPU time spent in kernel mode by the container's tasks, in nanoseconds."
+    },
+    {
+      "endpoint": "/%{container_id}/preCpuUsageUsageInUsermode",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Time (in nanoseconds) spent by tasks of the cgroup in user mode"
+    },
+    {
+      "endpoint": "/%{container_id}/preSystemCpuUsage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "System Usage."
+    },
+    {
+      "endpoint": "/%{container_id}/preOnlineCpus",
+      "type": "integer",
+      "explicit_timestamp": true,
+      "description": "Number of online CPUs."
+    },
+    {
+      "endpoint": "/%{container_id}/preThrottlingDataPeriods",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Number of periods with throttling active."
+    },
+    {
+      "endpoint": "/%{container_id}/preThrottlingDataThrottledPeriods",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Number of periods when the container hit its throttling limit."
+    },
+    {
+      "endpoint": "/%{container_id}/preThrottlingDataThrottledTime",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Aggregated time (in nanoseconds) the container was throttled for."
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemory.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemory.json
@@ -1,0 +1,38 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerMemory",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/usage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Current res_counter usage for memory.",
+      "doc": "Current total memory usage (RAM + swap) of the container, in bytes."
+    },
+    {
+      "endpoint": "/%{container_id}/maxUsage",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Maximum usage ever recorded.",
+      "doc": "The maximum memory usage recorded since the container's start, in bytes."
+    },
+    {
+      "endpoint": "/%{container_id}/failcnt",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Number of times memory usage hits limits.",
+      "doc": "The number of times the memory limit has been reached."
+    },
+    {
+      "endpoint": "/%{container_id}/limit",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Memory usage limit",
+      "doc": "The memory usage limit for the container"
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemoryStats.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemoryStats.json
@@ -1,0 +1,23 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerMemoryStats",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "doc": "All the stats exported via memory.stat. when using cgroups v2.",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/name",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Name of the stat"
+    },
+    {
+      "endpoint": "/%{container_id}/value",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Value of the stat"
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerNetworks.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerNetworks.json
@@ -1,0 +1,74 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerNetworks",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "doc": "Network statistics for the container per interface.",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/interface",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Network interface name",
+      "doc": "Name of the network for which the statistics are provided."
+    },
+    {
+      "endpoint": "/%{container_id}/rxBytes",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Bytes received.",
+      "doc": "Total number of bytes received on the interface."
+    },
+    {
+      "endpoint": "/%{container_id}/rxPackets",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Packets received.",
+      "doc": "Total number of packets successfully received on the interface."
+    },
+    {
+      "endpoint": "/%{container_id}/rxDropped",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Incoming packets dropped.",
+      "doc": "Total number of incoming packets that were dropped."
+    },
+    {
+      "endpoint": "/%{container_id}/rxErrors",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Received errors.",
+      "doc": "Total number of errors that occurred while receiving."
+    },
+    {
+      "endpoint": "/%{container_id}/txBytes",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Bytes sent.",
+      "doc": "Total number of bytes transmitted on the interface."
+    },
+    {
+      "endpoint": "/%{container_id}/txPackets",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Packets sent.",
+      "doc": "Total number of packets successfully transmitted on the interface."
+    },
+    {
+      "endpoint": "/%{container_id}/txErrors",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Sent errors.",
+      "doc": "Total number of errors that occurred while transmitting."
+    },
+    {
+      "endpoint": "/%{container_id}/txDropped",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Outgoing packets dropped.",
+      "doc": "Total number of outgoing packets that were dropped."
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerProcesses.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.ContainerProcesses.json
@@ -1,0 +1,23 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.ContainerProcesses",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "description": "PidsStats contains Linux-specific stats of a container's process-IDs (PIDs).",
+  "mappings": [
+    {
+      "endpoint": "/%{container_id}/current",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Current is the number of PIDs in the cgroup."
+    },
+    {
+      "endpoint": "/%{container_id}/limit",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Limit is the hard limit on the number of pids in the cgroup."
+    }
+  ]
+}

--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.VolumeUsage.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.apps.stats.VolumeUsage.json
@@ -1,0 +1,41 @@
+{
+  "interface_name": "io.edgehog.devicemanager.apps.stats.VolumeUsage",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "doc": "Statistics on the volumes",
+  "mappings": [
+    {
+      "endpoint": "/%{volume_id}/driver",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Name of the volume driver used by the volume."
+    },
+    {
+      "endpoint": "/%{volume_id}/mountpoint",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Mount path of the volume on the host."
+    },
+    {
+      "endpoint": "/%{volume_id}/createdAt",
+      "type": "datetime",
+      "explicit_timestamp": true,
+      "description": "Date/Time the volume was created."
+    },
+    {
+      "endpoint": "/%{volume_id}/usageDataSize",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Amount of disk space used by the volume (in bytes)."
+    },
+    {
+      "endpoint": "/%{volume_id}/usageDataRefCount",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "The number of containers referencing this volume."
+    }
+  ]
+}


### PR DESCRIPTION
Add the definitions of the Astarte interfaces that the Edgehog Device Runtime uses for publishing statistics about containers. This change ensures that Edgehog installs these interfaces on each managed Astarte realm, so that devices using the Edgehog Device Runtime can correctly connect to Astarte and publish data using those interfaces.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
