### PR TITLE
feat: log outcome for successful or failed OTA operations

### DIFF
--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -120,7 +120,7 @@ config :ex_aws,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:module, :function, :request_id, :tag, :tenant, :realm]
+  metadata: [:module, :function, :request_id, :tag, :tenant_id]
 
 config :mime, :extensions, %{
   "json" => "application/vnd.api+json"

--- a/backend/lib/edgehog/os_management/ota_operation/changes/log_ota_operation_outcome.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/changes/log_ota_operation_outcome.ex
@@ -1,0 +1,60 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.OSManagement.OTAOperation.Changes.LogOtaOperationOutcome do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def change(%Ash.Changeset{valid?: false} = changeset, _opts, _context), do: changeset
+
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_transaction(changeset, &log_ota_operation_outcome/2)
+  end
+
+  defp log_ota_operation_outcome(changeset, {:ok, ota_operation} = result) do
+    tenant_id = changeset.to_tenant
+
+    case ota_operation.status do
+      :success ->
+        Logger.info(
+          "OTA operation #{ota_operation.id} on device #{ota_operation.device_id} completed successfully with status code #{ota_operation.status_code} and message: #{ota_operation.message}",
+          tenant_id: tenant_id
+        )
+
+      :failure ->
+        Logger.info(
+          "OTA operation #{ota_operation.id} on device #{ota_operation.device_id} failed with status code #{ota_operation.status_code} and message: #{ota_operation.message}",
+          tenant_id: tenant_id
+        )
+
+      _ ->
+        :ok
+    end
+
+    result
+  end
+
+  defp log_ota_operation_outcome(_changeset, result) do
+    result
+  end
+end

--- a/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
@@ -109,6 +109,10 @@ defmodule Edgehog.OSManagement.OTAOperation do
       change Changes.HandleEphemeralImageDeletion do
         where attribute_equals(:manual?, true)
       end
+
+      change Changes.LogOtaOperationOutcome do
+        where [attribute_in(:status, @terminal_statuses)]
+      end
     end
 
     update :update_status do
@@ -121,6 +125,10 @@ defmodule Edgehog.OSManagement.OTAOperation do
 
       change Changes.HandleEphemeralImageDeletion do
         where [attribute_equals(:manual?, true), attribute_in(:status, @terminal_statuses)]
+      end
+
+      change Changes.LogOtaOperationOutcome do
+        where [attribute_in(:status, @terminal_statuses)]
       end
     end
 


### PR DESCRIPTION
Add a line of logs when an OTA operation reaches its terminal state, either with success or failure, regardless or whether the operation was manual or managed, i.e. run automatically by an Update Campaign.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
