### PR TITLE
fix(containers): remove usage of non-existing status_code deployment key

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
@@ -458,7 +458,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Executor do
   end
 
   def handle_event(:internal, {:deployment_failure, deployment}, state, data) do
-    Logger.notice("Device #{deployment.device_id} failed to update: #{deployment.status_code}")
+    Logger.notice("Device #{deployment.device_id} failed to update: #{deployment.last_error_message}")
 
     _ =
       data.tenant_id


### PR DESCRIPTION
A copy&paste error left a Logger line that tried to access the :status_code key of the deployment resource, which does not have such a field.
This change fixes the issue by using the :last_error_message field instead.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
