### PR TITLE
fix: double free of campaign slots

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -200,25 +200,34 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      minio:
-        image: minio/minio:latest
-        env:
-          MINIO_ROOT_USER: "minioadmin"
-          MINIO_ROOT_PASSWORD: "minioadmin"
-        command: server
-        ports:
-        - 9000:9000
-        options: >-
-         --name minio
-         --health-interval 10s
-         --health-timeout 5s
-         --health-retries 5
-         --health-cmd "curl http://localhost:9000/minio/health/live"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         show-progress: false
+
+    - name: Start MinIO
+      run: |
+        docker run -d \
+          --name minio \
+          -p 9000:9000 \
+          -p 9001:9001 \
+          -e MINIO_ROOT_USER=minioadmin \
+          -e MINIO_ROOT_PASSWORD=minioadmin \
+          minio/minio:latest \
+          server /data --console-address ":9001"
+
+    - name: Wait for MinIO to be ready
+      run: |
+        echo "Waiting for MinIO to start..."
+        for i in {1..30}; do
+          if curl -f http://localhost:9000/minio/health/live 2>/dev/null; then
+            echo "MinIO is ready!"
+            break
+          fi
+          echo "Attempt $i/30: MinIO not ready yet..."
+          sleep 2
+        done
 
     - name: Bucket setup
       run: |

--- a/backend/lib/edgehog/containers/container/changes/relate.ex
+++ b/backend/lib/edgehog/containers/container/changes/relate.ex
@@ -1,0 +1,102 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Container.Changes.Relate do
+  @moduledoc false
+
+  use Ash.Resource.Change
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, %{tenant: tenant}) do
+    with {:ok, container} <- Ash.Changeset.fetch_argument(changeset, :container),
+         {:ok, device} <- Ash.Changeset.fetch_argument(changeset, :device),
+         {:ok, deployment} <- Ash.Changeset.fetch_argument(changeset, :deployment),
+         {:ok, container} <-
+           Ash.load(container, [:image, :volumes, :networks, :device_mappings], tenant: tenant) do
+      image = container.image
+      networks = container.networks
+      volumes = container.volumes
+      device_mappings = container.device_mappings
+
+      image_input = %{
+        image: image,
+        device: device,
+        deployment: deployment,
+        image_id: image.id,
+        device_id: device.id
+      }
+
+      networks_input =
+        Enum.map(networks, fn network ->
+          %{
+            network: network,
+            device: device,
+            deployment: deployment,
+            network_id: network.id,
+            device_id: device.id
+          }
+        end)
+
+      volumes_input =
+        Enum.map(volumes, fn volume ->
+          %{
+            volume: volume,
+            device: device,
+            deployment: deployment,
+            volume_id: volume.id,
+            device_id: device.id
+          }
+        end)
+
+      device_mappings_input =
+        Enum.map(device_mappings, fn device_mapping ->
+          %{
+            device_mapping: device_mapping,
+            device: device,
+            deployment: deployment,
+            device_mapping_id: device_mapping.id,
+            device_id: device.id
+          }
+        end)
+
+      changeset
+      |> Ash.Changeset.manage_relationship(:image_deployment, image_input,
+        on_no_match: {:create, :deploy},
+        on_lookup: :relate,
+        use_identities: [:image_instance]
+      )
+      |> Ash.Changeset.manage_relationship(:network_deployments, networks_input,
+        on_no_match: {:create, :deploy},
+        on_lookup: :relate,
+        use_identities: [:network_instance]
+      )
+      |> Ash.Changeset.manage_relationship(:volume_deployments, volumes_input,
+        on_no_match: {:create, :deploy},
+        on_lookup: :relate,
+        use_identities: [:volume_instance]
+      )
+      |> Ash.Changeset.manage_relationship(:device_mapping_deployments, device_mappings_input,
+        on_no_match: {:create, :deploy},
+        on_lookup: :relate,
+        use_identities: [:device_mapping_instance]
+      )
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/container/deployment.ex
+++ b/backend/lib/edgehog/containers/container/deployment.ex
@@ -67,6 +67,22 @@ defmodule Edgehog.Containers.Container.Deployment do
       change set_attribute(:state, :created)
       change manage_relationship(:container, type: :append)
       change manage_relationship(:device, type: :append)
+      change Changes.Relate
+    end
+
+    update :send_deployment do
+      description """
+      Sends the deployment to the device.
+      Deploys the necessary resources and sends the deployment request.
+      """
+
+      argument :deployment, :struct do
+        constraints instance_of: Deployment
+        allow_nil? false
+      end
+
+      require_atomic? false
+
       change Changes.DeployContainerOnDevice
     end
 

--- a/backend/lib/edgehog/containers/containers.ex
+++ b/backend/lib/edgehog/containers/containers.ex
@@ -25,6 +25,7 @@ defmodule Edgehog.Containers do
 
   alias Edgehog.Containers.Application
   alias Edgehog.Containers.Deployment
+  alias Edgehog.Containers.DeploymentContainerDeployment
   alias Edgehog.Containers.DeploymentReadyAction
   alias Edgehog.Containers.DeploymentReadyAction.Upgrade
   alias Edgehog.Containers.ImageCredentials
@@ -188,7 +189,7 @@ defmodule Edgehog.Containers do
     end
 
     resource Edgehog.Containers.Container.Deployment do
-      define :deploy_container, action: :deploy, args: [:container, :device, :deployment]
+      define :deploy_container, action: :deploy, args: [:container, :device]
       define :destroy_container_deployment, action: :destroy
       define :fetch_container_deployment, action: :read, get_by_identity: :container_instance
       define :mark_container_deployment_as_sent, action: :mark_as_sent
@@ -209,6 +210,7 @@ defmodule Edgehog.Containers do
       define :deployment_by_identity, action: :read, get_by_identity: :release_instance
       define :run_ready_actions, action: :run_ready_actions
       define :set_deployment_state, action: :set_state
+      define :send_deployment, action: :send_deployment
 
       define :mark_deployment_as_sent, action: :mark_as_sent
       define :mark_deployment_as_deleting, action: :mark_as_deleting
@@ -225,7 +227,7 @@ defmodule Edgehog.Containers do
     end
 
     resource Edgehog.Containers.Image.Deployment do
-      define :deploy_image, action: :deploy, args: [:image, :device, :deployment]
+      define :deploy_image, action: :deploy, args: [:image, :device]
       define :destroy_image_deployment, action: :destroy
       define :fetch_image_deployment, action: :read, get_by_identity: :image_instance
       define :mark_image_deployment_as_sent, action: :mark_as_sent
@@ -252,7 +254,7 @@ defmodule Edgehog.Containers do
     resource Edgehog.Containers.Network
 
     resource Edgehog.Containers.Network.Deployment do
-      define :deploy_network, action: :deploy, args: [:network, :device, :deployment]
+      define :deploy_network, action: :deploy, args: [:network, :device]
       define :destroy_network_deployment, action: :destroy
       define :fetch_network_deployment, action: :read, get_by_identity: :network_instance
       define :mark_network_deployment_as_sent, action: :mark_as_sent
@@ -266,7 +268,7 @@ defmodule Edgehog.Containers do
     resource Edgehog.Containers.Volume
 
     resource Edgehog.Containers.Volume.Deployment do
-      define :deploy_volume, action: :deploy, args: [:volume, :device, :deployment]
+      define :deploy_volume, action: :deploy, args: [:volume, :device]
       define :destroy_volume_deployment, action: :destroy
       define :fetch_volume_deployment, action: :read, get_by_identity: :volume_instance
       define :mark_volume_deployment_as_sent, action: :mark_as_sent
@@ -282,7 +284,7 @@ defmodule Edgehog.Containers do
     resource Edgehog.Containers.DeviceMapping.Deployment do
       define :deploy_device_mapping,
         action: :deploy,
-        args: [:device_mapping, :device, :deployment]
+        args: [:device_mapping, :device]
 
       define :destroy_device_mapping_deployment, action: :destroy
 
@@ -301,7 +303,7 @@ defmodule Edgehog.Containers do
 
     resource Edgehog.Containers.ContainerDeploymentDeviceMappingDeployment
 
-    resource Edgehog.Containers.DeploymentContainerDeployment
+    resource DeploymentContainerDeployment
 
     resource DeploymentReadyAction
     resource Upgrade
@@ -323,5 +325,6 @@ defmodule Edgehog.Containers do
     end
 
     resource Upgrade
+    resource DeploymentContainerDeployment
   end
 end

--- a/backend/lib/edgehog/containers/deployment/changes/relate.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/relate.ex
@@ -1,0 +1,64 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.Relate do
+  @moduledoc """
+  Relates a deployment to underlying container deployments, by creating them when
+  needed.
+  """
+  use Ash.Resource.Change
+
+  alias Edgehog.Containers.Release
+  alias Edgehog.Devices.Device
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, %{tenant: tenant}) do
+    deployment = changeset.data
+
+    device_id = Ash.Changeset.get_argument(changeset, :device_id)
+    release_id = Ash.Changeset.get_attribute(changeset, :release_id)
+
+    release = Ash.get!(Release, release_id, load: :containers, tenant: tenant)
+    device = Ash.get!(Device, device_id, tenant: tenant)
+
+    containers = release.containers
+
+    inputs =
+      Enum.map(
+        containers,
+        &%{
+          container: &1,
+          device: device,
+          deployment: deployment,
+          container_id: &1.id,
+          device_id: device.id
+        }
+      )
+
+    Ash.Changeset.manage_relationship(
+      changeset,
+      :container_deployments,
+      inputs,
+      on_no_match: {:create, :deploy},
+      on_match: :ignore,
+      use_identities: [:container_instance]
+    )
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/send_deployment_to_device.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/send_deployment_to_device.ex
@@ -22,159 +22,31 @@ defmodule Edgehog.Containers.Deployment.Changes.SendDeploymentToDevice do
   @moduledoc false
   use Ash.Resource.Change
 
-  alias Edgehog.Containers
   alias Edgehog.Devices
 
   require Logger
 
   @impl Ash.Resource.Change
-  def change(changeset, _opts, _context) do
-    Ash.Changeset.after_transaction(changeset, &after_transaction/2)
+  def change(changeset, _opts, %{tenant: tenant}) do
+    Ash.Changeset.after_action(changeset, &after_action(&1, &2, tenant))
   end
 
-  defp after_transaction(_changeset, result) do
-    case result do
-      {:ok, deployment} ->
-        deploy_resources(deployment)
-
-      error ->
-        Logger.error("Failed to send deployment to device: #{inspect(error)}")
-        error
-    end
-  end
-
-  def deploy_resources(deployment, destroy_on_failure \\ false) do
-    tenant = deployment.tenant_id
-
+  defp after_action(_changeset, deployment, tenant) do
     with {:ok, deployment} <-
-           Ash.load(deployment,
-             device: [],
-             release: [containers: [:image, :networks, :volumes]]
-           ) do
-      device = deployment.device
+           Ash.load(deployment, [:container_deployments, :device], tenant: tenant) do
+      container_deployments = deployment.container_deployments
 
-      release = deployment.release
-      containers = release.containers
-      images = containers |> Enum.map(& &1.image) |> Enum.uniq()
+      Enum.each(container_deployments, &deploy_container(&1, deployment, tenant))
 
-      networks =
-        containers
-        |> Enum.flat_map(& &1.networks)
-        |> Enum.uniq_by(& &1.id)
-
-      volumes =
-        containers
-        |> Enum.flat_map(& &1.volumes)
-        |> Enum.uniq_by(& &1.id)
-
-      with :ok <- deploy_images(device, images, deployment),
-           :ok <- deploy_volumes(device, volumes, deployment),
-           :ok <- deploy_networks(device, networks, deployment),
-           :ok <- deploy_containers(device, containers, deployment) do
-        case Devices.send_create_deployment_request(device, deployment) do
-          {:ok, _device} ->
-            Containers.mark_deployment_as_sent(deployment, tenant: tenant)
-
-          {:error, reason} ->
-            Logger.warning("Failed to send deployment request: #{inspect(reason)}")
-
-            if destroy_on_failure do
-              :ok = Containers.destroy_deployment(deployment, tenant: tenant)
-            end
-
-            {:error, reason}
-        end
-      end
+      with {:ok, _device} <-
+             Devices.send_create_deployment_request(deployment.device, deployment, tenant: tenant),
+           do: {:ok, deployment}
     end
   end
 
-  defp deploy_networks(device, networks, deployment) do
-    networks =
-      networks
-      |> Enum.reject(&network_deployed?(&1, device))
-      |> Enum.uniq_by(& &1.id)
-
-    Enum.reduce_while(networks, :ok, fn network, _acc ->
-      case Containers.deploy_network(network, device, deployment, tenant: network.tenant_id) do
-        {:ok, _network_deployment} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  defp network_deployed?(network, device) do
-    case Containers.fetch_network_deployment(network.id, device.id, tenant: network.tenant_id) do
-      {:ok, _network_deployment} -> true
-      _ -> false
-    end
-  end
-
-  defp deploy_images(device, images, deployment) do
-    images =
-      images
-      |> Enum.reject(&image_deployed?(&1, device))
-      |> Enum.uniq_by(& &1.id)
-
-    Enum.reduce_while(images, :ok, fn image, _acc ->
-      case Containers.deploy_image(image, device, deployment, tenant: image.tenant_id) do
-        {:ok, _image_deployment} ->
-          {:cont, :ok}
-
-        {:error, reason} ->
-          {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  defp image_deployed?(image, device) do
-    case Containers.fetch_image_deployment(image.id, device.id, tenant: image.tenant_id) do
-      {:ok, _deployment} ->
-        true
-
-      _ ->
-        false
-    end
-  end
-
-  defp deploy_volumes(device, volumes, deployment) do
-    volumes =
-      volumes
-      |> Enum.reject(&volume_deployed?(&1, device))
-      |> Enum.uniq_by(& &1.id)
-
-    Enum.reduce_while(volumes, :ok, fn volume, _acc ->
-      case Containers.deploy_volume(volume, device, deployment, tenant: volume.tenant_id) do
-        {:ok, _device} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  defp deploy_containers(device, containers, deployment) do
-    containers =
-      containers
-      |> Enum.uniq_by(& &1.id)
-      |> Enum.reject(&container_deployed?(&1, device))
-
-    Enum.reduce_while(containers, :ok, fn container, _acc ->
-      case Containers.deploy_container(container, device, deployment, tenant: container.tenant_id) do
-        {:ok, _device} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  defp volume_deployed?(volume, device) do
-    case Containers.fetch_volume_deployment(volume.id, device.id, tenant: volume.tenant_id) do
-      {:ok, _deployment} -> true
-      _ -> false
-    end
-  end
-
-  defp container_deployed?(container, device) do
-    case Containers.fetch_container_deployment(container.id, device.id, tenant: container.tenant_id) do
-      {:ok, _container_deployment} -> true
-      _ -> false
-    end
+  defp deploy_container(container_deployment, deployment, tenant) do
+    container_deployment
+    |> Ash.Changeset.for_update(:send_deployment, %{deployment: deployment}, tenant: tenant)
+    |> Ash.update(tenant: tenant)
   end
 end

--- a/backend/lib/edgehog/containers/image/deployment.ex
+++ b/backend/lib/edgehog/containers/image/deployment.ex
@@ -24,6 +24,7 @@ defmodule Edgehog.Containers.Image.Deployment do
     domain: Edgehog.Containers,
     extensions: [AshGraphql.Resource]
 
+  alias Edgehog.Containers.Container.Deployment
   alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Image
   alias Edgehog.Containers.Image.Changes
@@ -51,14 +52,24 @@ defmodule Edgehog.Containers.Image.Deployment do
         allow_nil? false
       end
 
+      change set_attribute(:state, :created)
+      change manage_relationship(:image, type: :append)
+      change manage_relationship(:device, type: :append)
+    end
+
+    update :send_deployment do
+      description """
+      Sends the deployment to the device.
+      Deploys the necessary resources and sends the deployment request.
+      """
+
       argument :deployment, :struct do
         constraints instance_of: Deployment
         allow_nil? false
       end
 
-      change set_attribute(:state, :created)
-      change manage_relationship(:image, type: :append)
-      change manage_relationship(:device, type: :append)
+      require_atomic? false
+
       change Changes.DeployImageOnDevice
     end
 

--- a/backend/lib/edgehog/containers/network/deployment.ex
+++ b/backend/lib/edgehog/containers/network/deployment.ex
@@ -59,6 +59,16 @@ defmodule Edgehog.Containers.Network.Deployment do
       change set_attribute(:state, :created)
       change manage_relationship(:device, type: :append)
       change manage_relationship(:network, type: :append)
+    end
+
+    update :send_deployment do
+      description """
+      Sends the deployment to the device.
+      Deploys the necessary resources and sends the deployment request.
+      """
+
+      require_atomic? false
+
       change Changes.DeployNetworkOnDevice
     end
 

--- a/backend/lib/edgehog/containers/volume/deployment.ex
+++ b/backend/lib/edgehog/containers/volume/deployment.ex
@@ -51,14 +51,24 @@ defmodule Edgehog.Containers.Volume.Deployment do
         allow_nil? false
       end
 
+      change set_attribute(:state, :created)
+      change manage_relationship(:volume, type: :append)
+      change manage_relationship(:device, type: :append)
+    end
+
+    update :send_deployment do
+      description """
+      Sends the deployment to the device.
+      Deploys the necessary resources and sends the deployment request.
+      """
+
       argument :deployment, :struct do
         constraints instance_of: Deployment
         allow_nil? false
       end
 
-      change set_attribute(:state, :created)
-      change manage_relationship(:volume, type: :append)
-      change manage_relationship(:device, type: :append)
+      require_atomic? false
+
       change Changes.DeployVolumeOnDevice
     end
 

--- a/backend/lib/edgehog/deployment_campaigns/deployment_target/changes/deploy.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_target/changes/deploy.ex
@@ -28,6 +28,6 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentTarget.Changes.Deploy do
     device_id = Ash.Changeset.get_attribute(changeset, :device_id)
     deployment = %{device_id: device_id, release_id: release.id}
 
-    Ash.Changeset.manage_relationship(changeset, :deployment, deployment, on_no_match: {:create, :deploy})
+    Ash.Changeset.manage_relationship(changeset, :deployment, deployment, on_no_match: {:create, :just_create})
   end
 end

--- a/backend/test/support/fixtures/deployment_campaigns_fixtures.ex
+++ b/backend/test/support/fixtures/deployment_campaigns_fixtures.ex
@@ -161,7 +161,12 @@ defmodule Edgehog.DeploymentCampaignsFixtures do
     {:ok, target} =
       target
       |> Core.update_target_latest_attempt!(now)
-      |> DeploymentCampaigns.deploy_to_target(release, tenant: tenant)
+      |> DeploymentCampaigns.deploy_to_target(release, tenant: tenant, load: :deployment)
+
+    target
+    |> Map.get(:deployment)
+    |> Ash.Changeset.for_update(:send_deployment, %{deployment: target.deployment}, tenant: tenant)
+    |> Ash.update()
 
     target
   end


### PR DESCRIPTION
Based on #942 

bug: we might receive an `deployment_update` event from a deployment that has
already finished (because of various) conditions, if this happens, the target is
marked as successfull twice and slots get released before the target that
occupied them actually completes.

This PR fixes this bug by discarding messages from deployments whose target are
not in an `in_progress` state.