### PR TITLE
fix: vendored device runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -185,7 +185,7 @@ _register-device:
 connect-device: _check-rust-prereqs _check-astarte-prereqs _init-device-runtime _register-device
     @echo "🚀 Starting Edgehog Device Runtime..."
     @echo "💡 TODO: run 'ttyd -W bash' to support Edgehog's remote terminal functionality"
-    cd edgehog-device-runtime && RUST_LOG=debug cargo run --features "forwarder containers"
+    cd edgehog-device-runtime && RUST_LOG=debug cargo run --features "forwarder,containers,vendored"
 
 # Clean up all generated files and directories
 [private]


### PR DESCRIPTION
the device runtime has a bug in debian derivatives with the libsqlite3 library: basically crashes every time an action is performed on the db. This is known and solved issue, by unsing the `vendored` feature of the device runtime such issue should not be a problem.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
