### PR TITLE
fix: ensure migrations can be successfully rolled back

### DIFF
--- a/backend/priv/repo/migrations/20241022083501_rename_image_credentials_name_label.exs
+++ b/backend/priv/repo/migrations/20241022083501_rename_image_credentials_name_label.exs
@@ -48,6 +48,8 @@ defmodule Edgehog.Repo.Migrations.RenameImageCredentialsNameLabel do
                      name: "image_credentials_label_index"
                    )
 
+    rename table(:image_credentials), :label, to: :name
+
     create unique_index(:image_credentials, [:tenant_id, :name],
              name: "image_credentials_name_index"
            )
@@ -55,7 +57,5 @@ defmodule Edgehog.Repo.Migrations.RenameImageCredentialsNameLabel do
     alter table(:image_credentials) do
       modify :name, :text
     end
-
-    rename table(:image_credentials), :label, to: :name
   end
 end

--- a/backend/priv/repo/migrations/20250213111337_deployment_caching.exs
+++ b/backend/priv/repo/migrations/20250213111337_deployment_caching.exs
@@ -40,14 +40,14 @@ defmodule Edgehog.Repo.Migrations.DeploymentCaching do
   end
 
   def down do
+    rename table(:application_deployments), :last_error_message, to: :message
+
+    rename table(:application_deployments), :state, to: :status
+
     alter table(:application_deployments) do
       remove :resources_state
       modify :status, :text, null: false
       modify :message, :text
     end
-
-    rename table(:application_deployments), :last_error_message, to: :message
-
-    rename table(:application_deployments), :state, to: :status
   end
 end

--- a/backend/priv/repo/migrations/20250822131310_multiple_system_models_per_release.exs
+++ b/backend/priv/repo/migrations/20250822131310_multiple_system_models_per_release.exs
@@ -75,10 +75,6 @@ defmodule Edgehog.Repo.Migrations.MultipleSystemModelsPerRelease do
   end
 
   def down do
-    create unique_index(:applications, [:tenant_id, :name, :system_model_id],
-             name: "applications_name_and_system_model_index"
-           )
-
     alter table(:applications) do
       add :system_model_id,
           references(:system_models,
@@ -88,6 +84,10 @@ defmodule Edgehog.Repo.Migrations.MultipleSystemModelsPerRelease do
             prefix: "public"
           )
     end
+
+    create unique_index(:applications, [:tenant_id, :name, :system_model_id],
+             name: "applications_name_and_system_model_index"
+           )
 
     drop constraint(:release_system_models, "release_system_models_tenant_id_fkey")
 

--- a/backend/priv/repo/migrations/20250908101858_deploy_rollout_to_deployment_mechanism.exs
+++ b/backend/priv/repo/migrations/20250908101858_deploy_rollout_to_deployment_mechanism.exs
@@ -37,7 +37,7 @@ defmodule Edgehog.Repo.Migrations.DeployRolloutToDeploymentMechanism do
 
   def down do
     alter table(:deployment_campaign) do
-      modify :deploy_rollout_mechanism, :map
+      modify :deployment_mechanism, :map
     end
 
     rename table(:deployment_campaign), :deployment_mechanism, to: :deploy_rollout_mechanism


### PR DESCRIPTION
When migrating to the Ash framework, we gained the benefit of using ash_postgres to automatically generate database migrations and resource snasphots.
However the resulting migrations do not always run the needed operations in the correct order, for the rollback routine.
This change fixes the needed migrations to ensure that operations are done in the correct order and the database can be rolled back.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
