### PR TITLE
chore: handle deployments deletion

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
@@ -207,5 +207,11 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentTarget do
 
   postgres do
     table "deployment_target"
+
+    references do
+      reference :device, on_delete: :delete
+      reference :deployment, on_delete: :delete
+      reference :deployment_campaign, on_delete: :delete
+    end
   end
 end


### PR DESCRIPTION
The device publishes a `nil` value on `Available*` interfaces when removing a resource. This should trigger the associated `.Deployment` resource's deletion: fixed.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
