### PR TITLE
test: fix fixtures

### DIFF
--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -34,6 +34,8 @@ defmodule Edgehog.Containers.Deployment do
   alias Edgehog.Containers.Validations.IsUpgrade
   alias Edgehog.Containers.Validations.SameApplication
 
+  @testing Mix.env() == :test
+
   graphql do
     type :deployment
   end
@@ -82,6 +84,24 @@ defmodule Edgehog.Containers.Deployment do
       change manage_relationship(:device_id, :device, type: :append)
       change Changes.Relate
       change {PublishNotification, event_type: :deployment_created}
+    end
+
+    if @testing do
+      create :create_fixture do
+        description """
+        Starts the deployment of a release on a device.
+        It starts an Executor, handling the communication with the device.
+        """
+
+        accept [:release_id, :state, :resources_state]
+
+        argument :device_id, :id do
+          allow_nil? false
+        end
+
+        change manage_relationship(:device_id, :device, type: :append)
+        change Changes.Relate
+      end
     end
 
     update :set_state do

--- a/backend/lib/edgehog/containers/deployment/changes/relate.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/relate.ex
@@ -46,9 +46,7 @@ defmodule Edgehog.Containers.Deployment.Changes.Relate do
         &%{
           container: &1,
           device: device,
-          deployment: deployment,
-          container_id: &1.id,
-          device_id: device.id
+          deployment: deployment
         }
       )
 
@@ -58,6 +56,7 @@ defmodule Edgehog.Containers.Deployment.Changes.Relate do
       inputs,
       on_no_match: {:create, :deploy},
       on_match: :ignore,
+      on_lookup: {:relate, :create},
       use_identities: [:container_instance]
     )
   end

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -297,7 +297,9 @@ defmodule Edgehog.ContainersFixtures do
         release_id: release_id
       })
 
-    Ash.create!(Deployment, params, tenant: tenant)
+    Deployment
+    |> Ash.Changeset.for_create(:create_fixture, params, tenant: tenant)
+    |> Ash.create!(tenant: tenant)
   end
 
   @doc """

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ExUnit.start(exclude: [:integration_storage])
+ExUnit.start(exclude: [:integration_storage], capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(Edgehog.Repo, :manual)
 
 Mox.defmock(Edgehog.Geolocation.GeolocationProviderMock,


### PR DESCRIPTION
Making a deployment fixture does not really look at the release it should deploy. Insted it just creates a `Deployment` resource with the correct release. This might however be a curse when trying to look at related resources.

`deployment_fixture` should instead create a valid deployment for the release, which includes relationships.

This also captures logs in tests, exposing them only for failed tests