### PR TITLE
fix: ignore prefetch_count in comparison of delivery policies

### DIFF
--- a/backend/lib/edgehog/tenants/reconciler/core.ex
+++ b/backend/lib/edgehog/tenants/reconciler/core.ex
@@ -170,7 +170,9 @@ defmodule Edgehog.Tenants.Reconciler.Core do
   end
 
   defp normalize_policy(policy) do
-    update_in(policy, ["retry_times"], &(&1 || 0))
+    policy
+    |> update_in(["retry_times"], &(&1 || 0))
+    |> update_in(["prefetch_count"], &(&1 || 0))
   end
 
   defp list_triggers_that_reference_policy(rm_client, policy_name) do


### PR DESCRIPTION
The current comparison did not properly make a reasonable comparison.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
