### PR TITLE
feat: `MonacoJsonEditor` fro `Network` and `Volume` options

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -289,7 +289,6 @@ const VolumeDetails = ({
                   >
                     <MonacoJsonEditor
                       value={formatJson(mount?.volume.options)}
-                      language="json"
                       onChange={() => {}}
                       defaultValue={formatJson(mount?.volume.options)}
                       readonly={true}
@@ -437,7 +436,6 @@ const NetworkDetails = ({ networks, containerIndex }: networkDetailsProps) => {
                   >
                     <MonacoJsonEditor
                       value={formatJson(net?.options)}
-                      language="json"
                       onChange={() => {}}
                       defaultValue={formatJson(net?.options)}
                       readonly={true}
@@ -516,7 +514,6 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
       >
         <MonacoJsonEditor
           value={formatJson(container.env)}
-          language="json"
           onChange={() => {}}
           defaultValue={formatJson(container.env)}
           readonly={true}
@@ -756,7 +753,6 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
       >
         <MonacoJsonEditor
           value={container.storageOpt.join("\n")}
-          language="json"
           onChange={() => {}}
           defaultValue={container.storageOpt.join("\n")}
           readonly={true}
@@ -775,7 +771,6 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
       >
         <MonacoJsonEditor
           value={container.tmpfs.join("\n")}
-          language="json"
           onChange={() => {}}
           defaultValue={container.tmpfs.join("\n")}
           readonly={true}

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -1,0 +1,141 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import { useRef, useState, useCallback } from "react";
+import { Editor } from "@monaco-editor/react";
+import { FormattedMessage } from "react-intl";
+
+import Icon from "components/Icon";
+
+type MonacoEditorProps = {
+  value: string;
+  language?: string;
+  onChange?: (value: string | undefined) => void;
+  defaultValue?: string;
+  readonly?: boolean;
+  initialLines?: number;
+  autoFormat?: boolean;
+  /**
+   * @important The function is assumed to throw an Error if it fails to parse the
+   * text entered in the editor is correctly parsed.
+   * The Thrown error will be visualised by the editor as aid for the user.
+   * @returns only if it correctly parses */
+  validationFunction?: (text: string) => void;
+  languageForErrorString?: string;
+};
+
+const MonacoEditor = ({
+  value,
+  language,
+  onChange,
+  defaultValue,
+  readonly = false,
+  initialLines = 5,
+  autoFormat = true,
+  validationFunction: validationFunctionProp,
+  languageForErrorString: languageForErrorStringProp,
+}: MonacoEditorProps) => {
+  const editorRef = useRef<any>(null);
+  const validation =
+    validationFunctionProp === undefined || validationFunctionProp === null
+      ? (_text: string) => {}
+      : validationFunctionProp;
+  const lineHeight = 22;
+  const [height, setHeight] = useState(initialLines * lineHeight);
+  const [languageError, setLanguageError] = useState<string | null>(null);
+
+  const format = useCallback(() => {
+    if (editorRef.current && autoFormat && language) {
+      try {
+        const currentValue = editorRef.current.getValue();
+        validation(currentValue);
+        editorRef.current.getAction("editor.action.formatDocument").run();
+        setLanguageError(null);
+      } catch (error: any) {
+        setLanguageError(error.message);
+      }
+    }
+  }, [autoFormat, language]);
+
+  const updateHeight = useCallback(() => {
+    if (editorRef.current) {
+      const contentHeight = editorRef.current.getContentHeight();
+      const minHeight = initialLines * lineHeight;
+      setHeight(Math.max(contentHeight, minHeight));
+      editorRef.current.layout();
+    }
+  }, [initialLines]);
+
+  const handleEditorDidMount = (editor: any) => {
+    editorRef.current = editor;
+    editor.onDidContentSizeChange(updateHeight);
+    editor.onDidChangeModelContent(() => {
+      setTimeout(format, 100);
+    });
+    updateHeight();
+  };
+
+  let languageForErrorString: string;
+  if (language) {
+    languageForErrorString = languageForErrorStringProp
+      ? languageForErrorStringProp
+      : language.charAt(0).toUpperCase() + language.slice(1) + " ";
+  } else {
+    languageForErrorString = "";
+  }
+
+  return (
+    <div className="border rounded bg-white p-2 overflow-hidden">
+      <Editor
+        height={height}
+        defaultLanguage={language}
+        value={value}
+        onChange={onChange}
+        defaultValue={defaultValue}
+        onMount={handleEditorDidMount}
+        options={{
+          automaticLayout: true,
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          wordWrap: "on",
+          readOnly: readonly,
+          lineNumbers: "off",
+          scrollbar: {
+            vertical: "hidden",
+            horizontal: "hidden",
+            alwaysConsumeMouseWheel: false,
+          },
+        }}
+      />
+      {languageError && (
+        <p className="text-red-500 text-sm mt-2">
+          <Icon icon="warning" />
+          <FormattedMessage
+            id="components.MonacoEditor.error"
+            defaultMessage="{language}error: {error}"
+            values={{ language: languageForErrorString, error: languageError }}
+          />
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MonacoEditor;

--- a/frontend/src/components/MonacoJsonEditor.tsx
+++ b/frontend/src/components/MonacoJsonEditor.tsx
@@ -18,15 +18,10 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { useRef, useState, useCallback } from "react";
-import { Editor } from "@monaco-editor/react";
-import { FormattedMessage } from "react-intl";
-
-import Icon from "components/Icon";
+import MonacoEditor from "components/MonacoEditor";
 
 type MonacoJsonEditorProps = {
   value: string;
-  language?: string;
   onChange?: (value: string | undefined) => void;
   defaultValue?: string;
   readonly?: boolean;
@@ -36,83 +31,24 @@ type MonacoJsonEditorProps = {
 
 const MonacoJsonEditor = ({
   value,
-  language = "json",
   onChange,
   defaultValue,
   readonly = false,
   initialLines = 5,
   autoFormat = true,
 }: MonacoJsonEditorProps) => {
-  const editorRef = useRef<any>(null);
-  const lineHeight = 22;
-  const [height, setHeight] = useState(initialLines * lineHeight);
-  const [jsonError, setJsonError] = useState<string | null>(null);
-
-  const formatJson = useCallback(() => {
-    if (editorRef.current && autoFormat && language === "json") {
-      try {
-        const currentValue = editorRef.current.getValue();
-        JSON.parse(currentValue); // validacija
-        editorRef.current.getAction("editor.action.formatDocument").run();
-        setJsonError(null); // nema greške
-      } catch (error: any) {
-        setJsonError(error.message); // snimi grešku
-      }
-    }
-  }, [autoFormat, language]);
-
-  const updateHeight = useCallback(() => {
-    if (editorRef.current) {
-      const contentHeight = editorRef.current.getContentHeight();
-      const minHeight = initialLines * lineHeight;
-      setHeight(Math.max(contentHeight, minHeight));
-      editorRef.current.layout();
-    }
-  }, [initialLines]);
-
-  const handleEditorDidMount = (editor: any) => {
-    editorRef.current = editor;
-    editor.onDidContentSizeChange(updateHeight);
-    editor.onDidChangeModelContent(() => {
-      setTimeout(formatJson, 100);
-    });
-    updateHeight();
-  };
-
   return (
-    <div className="border rounded bg-white p-2 overflow-hidden">
-      <Editor
-        height={height}
-        defaultLanguage={language}
-        value={value}
-        onChange={onChange}
-        defaultValue={defaultValue}
-        onMount={handleEditorDidMount}
-        options={{
-          automaticLayout: true,
-          minimap: { enabled: false },
-          scrollBeyondLastLine: false,
-          wordWrap: "on",
-          readOnly: readonly,
-          lineNumbers: "off",
-          scrollbar: {
-            vertical: "hidden",
-            horizontal: "hidden",
-            alwaysConsumeMouseWheel: false,
-          },
-        }}
-      />
-      {jsonError && (
-        <p className="text-red-500 text-sm mt-2">
-          <Icon icon="warning" />
-          <FormattedMessage
-            id="components.MonacoJsonEditor.jsonError"
-            defaultMessage="JSON error: {error}"
-            values={{ error: jsonError }}
-          />
-        </p>
-      )}
-    </div>
+    <MonacoEditor
+      language={"json"}
+      value={value}
+      onChange={onChange}
+      defaultValue={defaultValue}
+      readonly={readonly}
+      initialLines={initialLines}
+      autoFormat={autoFormat}
+      validationFunction={JSON.parse}
+      languageForErrorString={"JSON"}
+    />
   );
 };
 

--- a/frontend/src/forms/CreateNetwork.tsx
+++ b/frontend/src/forms/CreateNetwork.tsx
@@ -20,7 +20,7 @@
 
 import React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { FieldError, useForm } from "react-hook-form";
+import { Controller, FieldError, useForm } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
 
 import Button from "components/Button";
@@ -30,6 +30,7 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 
 import { yup, envSchema } from "forms";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const FormRow = ({
   id,
@@ -92,6 +93,7 @@ const CreateNetwork = React.memo(({ isLoading = false, onSubmit }: Props) => {
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors, isValid, isSubmitting },
   } = useForm<NetworkData>({
     mode: "onTouched",
@@ -136,13 +138,19 @@ const CreateNetwork = React.memo(({ isLoading = false, onSubmit }: Props) => {
           />
         }
       >
-        <Form.Control
-          as="textarea"
-          rows={5}
-          {...register("options")}
-          isInvalid={!!errors.options}
+        <Controller
+          control={control}
+          name={"options"}
+          render={({ field, fieldState: _fieldState }) => (
+            <MonacoJsonEditor
+              value={field.value ?? ""}
+              onChange={(value) => {
+                field.onChange(value ?? "");
+              }}
+              defaultValue={field.value || "{}"}
+            />
+          )}
         />
-        <ErrorMessage error={errors.options} />
       </FormRow>
 
       <FormRow

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -657,7 +657,6 @@ const ContainerForm = ({
             name={`containers.${index}.env`}
             render={({ field, fieldState: _fieldState }) => (
               <MonacoJsonEditor
-                language="json"
                 value={field.value ?? ""}
                 onChange={(value) => {
                   field.onChange(value ?? "");
@@ -1355,7 +1354,6 @@ const ContainerForm = ({
             render={({ field, fieldState }) => (
               <>
                 <MonacoJsonEditor
-                  language="json"
                   value={field.value ?? ""}
                   onChange={(value) => {
                     field.onChange(value ?? "");
@@ -1390,7 +1388,6 @@ const ContainerForm = ({
             render={({ field, fieldState }) => (
               <>
                 <MonacoJsonEditor
-                  language="json"
                   value={field.value ?? ""}
                   onChange={(value) => {
                     field.onChange(value ?? "");

--- a/frontend/src/forms/CreateVolume.tsx
+++ b/frontend/src/forms/CreateVolume.tsx
@@ -20,7 +20,7 @@
 
 import React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { FieldError, useForm } from "react-hook-form";
+import { Controller, FieldError, useForm } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
 
 import Button from "components/Button";
@@ -30,6 +30,7 @@ import Row from "components/Row";
 import Spinner from "components/Spinner";
 
 import { yup, envSchema } from "forms";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const FormRow = ({
   id,
@@ -86,6 +87,7 @@ const CreateVolume = React.memo(({ isLoading = false, onSubmit }: Props) => {
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors, isValid, isSubmitting },
   } = useForm<VolumeData>({
     mode: "onTouched",
@@ -140,13 +142,19 @@ const CreateVolume = React.memo(({ isLoading = false, onSubmit }: Props) => {
           />
         }
       >
-        <Form.Control
-          as="textarea"
-          rows={5}
-          {...register("options")}
-          isInvalid={!!errors.options}
+        <Controller
+          control={control}
+          name={"options"}
+          render={({ field, fieldState: _fieldState }) => (
+            <MonacoJsonEditor
+              value={field.value ?? ""}
+              onChange={(value) => {
+                field.onChange(value ?? "");
+              }}
+              defaultValue={field.value || "{}"}
+            />
+          )}
         />
-        <ErrorMessage error={errors.options} />
       </FormRow>
 
       <Row className="mt-4">

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -816,8 +816,8 @@
   "components.LedBehaviorDropdown.tooltip": {
     "defaultMessage": "The device LED will blink for 60s."
   },
-  "components.MonacoJsonEditor.jsonError": {
-    "defaultMessage": "JSON error: {error}"
+  "components.MonacoEditor.error": {
+    "defaultMessage": "{language}error: {error}"
   },
   "components.NetworkInterfacesTable.macAddressTitle": {
     "defaultMessage": "MAC Address"

--- a/frontend/src/pages/Network.tsx
+++ b/frontend/src/pages/Network.tsx
@@ -45,6 +45,7 @@ import Result from "components/Result";
 import Spinner from "components/Spinner";
 import Button from "components/Button";
 import DeleteModal from "components/DeleteModal";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const GET_NETWORK_QUERY = graphql`
   query Network_getNetwork_Query($networkId: ID!) {
@@ -187,12 +188,12 @@ const NetworkContent = ({ network }: NetworkContentProps) => {
             />
           }
         >
-          <Form.Control
-            as="textarea"
+          <MonacoJsonEditor
             value={getPrettyOptions()}
-            rows={getPrettyOptions().split("\n").length}
-            readOnly
-            style={{ fontFamily: "monospace", whiteSpace: "pre-wrap" }}
+            onChange={() => {}}
+            defaultValue={getPrettyOptions()}
+            readonly={true}
+            initialLines={1}
           />
         </FormRow>
 

--- a/frontend/src/pages/Volume.tsx
+++ b/frontend/src/pages/Volume.tsx
@@ -45,6 +45,7 @@ import Result from "components/Result";
 import Spinner from "components/Spinner";
 import Button from "components/Button";
 import DeleteModal from "components/DeleteModal";
+import MonacoJsonEditor from "components/MonacoJsonEditor";
 
 const GET_VOLUME_QUERY = graphql`
   query Volume_getVolume_Query($volumeId: ID!) {
@@ -185,12 +186,12 @@ const VolumeContent = ({ volume }: VolumeContentProps) => {
             />
           }
         >
-          <Form.Control
-            as="textarea"
+          <MonacoJsonEditor
             value={getPrettyOptions()}
-            rows={getPrettyOptions().split("\n").length}
-            readOnly
-            style={{ fontFamily: "monospace", whiteSpace: "pre-wrap" }}
+            onChange={() => {}}
+            defaultValue={getPrettyOptions()}
+            readonly={true}
+            initialLines={1}
           />
         </FormRow>
 


### PR DESCRIPTION
The Options for `Networks` and `Volumes` now follow other key-value components in using `MonacoJsonEditor` instead of a simple `TextArea`.