### PR TITLE
fix: use correct default for `read_only_rootfs`

### DIFF
--- a/backend/lib/edgehog/containers/container/container.ex
+++ b/backend/lib/edgehog/containers/container/container.ex
@@ -318,7 +318,7 @@ defmodule Edgehog.Containers.Container do
     end
 
     attribute :read_only_rootfs, :boolean do
-      default true
+      default false
       public? true
       allow_nil? false
     end


### PR DESCRIPTION
read_only_rootfs should default to `false`, not `true`.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
