### PR TITLE
Update memory and CPU swappiness validation

### DIFF
--- a/backend/lib/edgehog/containers/container/container.ex
+++ b/backend/lib/edgehog/containers/container/container.ex
@@ -295,6 +295,7 @@ defmodule Edgehog.Containers.Container do
 
     attribute :memory_swappiness, :integer do
       public? true
+      constraints min: 0, max: 100
     end
 
     attribute :volume_driver, :string do

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -380,6 +380,7 @@ const applicationSchema = (intl: any) =>
               .transform((value) => value?.trim()),
             portBindings: portBindingsSchema,
             memory: optionalNumberSchema
+              .min(6 * 1024 * 1024)
               .integer()
               .nullable()
               .label(
@@ -391,6 +392,8 @@ const applicationSchema = (intl: any) =>
 
             memoryReservation: optionalNumberSchema
               .integer()
+              .min(0)
+              .max(yup.ref("memory"))
               .nullable()
               .label(
                 intl.formatMessage({
@@ -400,6 +403,26 @@ const applicationSchema = (intl: any) =>
               ),
             memorySwap: optionalNumberSchema
               .integer()
+              .test(
+                "memorySwap-valid",
+                intl.formatMessage({
+                  id: "forms.CreateRelease.memorySwapInvalid",
+                  defaultMessage:
+                    "Memory Swap must be greater than/equal to Memory.",
+                }),
+                function (value) {
+                  const memory = this.parent.memory;
+                  if (
+                    value === undefined ||
+                    value === null ||
+                    memory === undefined ||
+                    memory === null
+                  ) {
+                    return true;
+                  }
+                  return value >= memory;
+                },
+              )
               .nullable()
               .label(
                 intl.formatMessage({
@@ -451,6 +474,7 @@ const applicationSchema = (intl: any) =>
               }),
             cpuRealtimePeriod: optionalNumberSchema
               .integer()
+              .min(1000)
               .nullable()
               .label(
                 intl.formatMessage({
@@ -460,6 +484,7 @@ const applicationSchema = (intl: any) =>
               ),
             cpuRealtimeRuntime: optionalNumberSchema
               .integer()
+              .max(yup.ref("cpuRealtimePeriod"))
               .nullable()
               .label(
                 intl.formatMessage({

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1327,6 +1327,9 @@
   "forms.CreateRelease.memoryReservationLabel": {
     "defaultMessage": "Memory Reservation (bytes)"
   },
+  "forms.CreateRelease.memorySwapInvalid": {
+    "defaultMessage": "Memory Swap must be greater than/equal to Memory."
+  },
   "forms.CreateRelease.memorySwapLabel": {
     "defaultMessage": "Memory Swap (bytes)"
   },


### PR DESCRIPTION
Updated validation logic for memory and CPU-related fields to align with Docker’s constraints.

- Synced ranges with Docker-supported values (memory, memory-reservation, memory-swap, memory-swappiness, cpu-period, cpu-quota).
- Allowed negative values where applicable to ensure compatibility with reuse release.
- Prevented invalid inputs that could cause runtime or UI issues.

<details> <summary>Screenshots</summary>
<img width="1553" height="531" alt="image" src="https://github.com/user-attachments/assets/d917f58e-be49-46fe-a866-ed753d9a0267" />


</details> 
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

 [*] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
 [*] Make sure to open your PR against the right branch: master / release-VERSION
 [*] Make sure to sign-off all your commits
 [*] GPG signing is appreciated
 [*] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
