### PR TITLE
fix(containers): refresh application list after deletion

### DIFF
--- a/frontend/src/components/ApplicationsTable.tsx
+++ b/frontend/src/components/ApplicationsTable.tsx
@@ -22,6 +22,7 @@ import { FormattedMessage } from "react-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { graphql, useMutation, usePaginationFragment } from "react-relay/hooks";
 import _ from "lodash";
+import { ConnectionHandler } from "relay-runtime";
 
 import type { ApplicationsTable_PaginationQuery } from "../api/__generated__/ApplicationsTable_PaginationQuery.graphql";
 import type {
@@ -191,18 +192,13 @@ const ApplicationsTable = ({
           if (!deletedId) return;
 
           const root = store.getRoot();
-          const applications = root.getLinkedRecord("applications");
-          if (!applications) return;
-
-          const results = applications.getLinkedRecords("results");
-          if (!results) return;
-
-          applications.setLinkedRecords(
-            results.filter((app) => app.getDataID() !== deletedId),
-            "results",
+          const applicationConnection = ConnectionHandler.getConnection(
+            root,
+            "ApplicationsTable_applications",
           );
-
-          store.delete(deletedId);
+          if (applicationConnection) {
+            ConnectionHandler.deleteNode(applicationConnection, deletedId);
+          }
         },
       });
     },


### PR DESCRIPTION
Edgehog correctly deletes the application (when possible) but client-side data isn't updated correctly. This is due to pagination and infinite scrolling that were introduced after the delete functionality. The delete functionality is now modified to use ConnectionHandler for updating the relay store, so the deleted app is not visible anymore from the UI.