### PR TITLE
chore: disable unsupported releases

### DIFF
--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -650,6 +650,7 @@ const ApplicationsTab = ({ deviceRef }: ApplicationsTabProps) => {
         <DeployedApplicationsTable
           deviceRef={device}
           isOnline={isOnline}
+          systemModelName={device.systemModel?.name}
           setErrorFeedback={setErrorFeedback}
           onDeploymentChange={handleRefetch}
         />


### PR DESCRIPTION
On the device page/applications tab in upgrade modal, releases with non-matching system model are disabled
 
<img width="1777" height="965" alt="image" src="https://github.com/user-attachments/assets/082d1e1d-76d1-4840-8c58-4b6e6fcd7db9" />

