### PR TITLE
refactor(containers): use readable labels for Restart Policy

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -39,6 +39,7 @@ import MonacoJsonEditor from "components/MonacoJsonEditor";
 import MultiSelect from "./MultiSelect";
 import InfiniteScroll from "./InfiniteScroll";
 import DeviceMappingsFormInput from "components/DeviceMappingsFormInput";
+import { restartPolicyOptions } from "forms/CreateRelease";
 
 const CONTAINERS_TO_LOAD_NEXT = 5;
 
@@ -615,7 +616,14 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
           />
         }
       >
-        <Form.Control value={container.restartPolicy ?? ""} readOnly />
+        <Form.Control
+          value={
+            restartPolicyOptions.find(
+              (opt) => opt.value === container.restartPolicy,
+            )?.label ?? ""
+          }
+          readOnly
+        />
       </FormRow>
 
       <FormRow

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -523,7 +523,7 @@ const initialData: ReleaseInputData = {
   requiredSystemModels: [],
 };
 
-const restartPolicyOptions = [
+export const restartPolicyOptions = [
   { value: "no", label: "No" },
   { value: "always", label: "Always" },
   { value: "on_failure", label: "On Failure" },


### PR DESCRIPTION
Labels are user readable and uniform wherever Restart Policy values are displayed.


<details>
<summary>
Screenshots
</summary>

<img width="1892" height="883" alt="image" src="https://github.com/user-attachments/assets/a9fefcbf-cbd8-4f68-aa12-16e52eeaeec5" />

<img width="1892" height="883" alt="image" src="https://github.com/user-attachments/assets/26ee1834-7087-480a-abd3-f01d476a74bd" />

</details>