### PR TITLE
fix: Remove Dockerfile Warnings for Casing and ENV Format

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021-2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ ARG DEBIAN_VERSION=bookworm-20240701-slim
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
-FROM ${BUILDER_IMAGE} as builder
+FROM ${BUILDER_IMAGE} AS builder
 
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git \
@@ -89,9 +89,9 @@ RUN apt-get update -y && \
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR "/app"
 RUN chown nobody /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2021-2024 SECO Mind Srl
+# SPDX-FileCopyrightText: 2021-2025 SECO Mind Srl
 # SPDX-License-Identifier: Apache-2.0
-FROM node:22.4.0 as builder
+FROM node:22.4.0 AS builder
 
 WORKDIR /app
 ADD package*.json ./


### PR DESCRIPTION
Fix two warnings found in the Dockerfiles:

1. **FromAsCasing**: The `as` keyword casing was inconsistent. This has been fixed by updating the `as` keyword to match the correct casing convention.

2. **LegacyKeyValueFormat**: The format used for setting environment variables with `ENV` was outdated. The legacy `ENV key value` format has been updated to the proper `ENV key=value` format.

These changes help eliminate the warnings and ensure the Dockerfiles are compliant with best practices.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
