### PR TITLE
fix: Eliminate unnecessary loading delays in update campaign details

### DIFF
--- a/frontend/src/pages/UpdateCampaign.tsx
+++ b/frontend/src/pages/UpdateCampaign.tsx
@@ -47,22 +47,22 @@ import UpdateTargetsTabs from "components/UpdateTargetsTabs";
 import UpdateCampaignForm from "forms/UpdateCampaignForm";
 import { Link, Route } from "Navigation";
 
-const UPDATE_TARGETS_TO_LOAD_FIRST = 15;
+const UPDATE_TARGETS_TO_LOAD_FIRST = 40;
 
 const GET_UPDATE_CAMPAIGN_QUERY = graphql`
   query UpdateCampaign_getUpdateCampaign_Query(
     $updateCampaignId: ID!
-    $first: Int
-    $after: String
-    $filter: UpdateTargetFilterInput
+    $first: Int!
   ) {
     updateCampaign(id: $updateCampaignId) {
       name
       ...UpdateCampaignForm_UpdateCampaignFragment
       ...UpdateCampaignStatsChart_UpdateCampaignStatsChartFragment
-      ...UpdateTargetsTabs_UpdateTargetsFragment
-        @arguments(first: $first, after: $after, filter: $filter)
       ...UpdateCampaign_RefreshFragment
+      ...UpdateTargetsTabs_SuccessfulFragment @arguments(first: $first)
+      ...UpdateTargetsTabs_FailedFragment @arguments(first: $first)
+      ...UpdateTargetsTabs_InProgressFragment @arguments(first: $first)
+      ...UpdateTargetsTabs_IdleFragment @arguments(first: $first)
     }
   }
 `;
@@ -106,7 +106,7 @@ const UpdateCampaignRefresh = ({
       subscriptionRef.current = fetchQuery(
         relayEnvironment,
         GET_UPDATE_CAMPAIGN_QUERY,
-        { updateCampaignId: id },
+        { updateCampaignId: id, first: UPDATE_TARGETS_TO_LOAD_FIRST },
         { fetchPolicy: "network-only" },
       ).subscribe({
         complete: () => {


### PR DESCRIPTION
- Replaced single refetchable fragment with dedicated fragments for each status tab (`SUCCESSFUL`, `FAILED`, `IN_PROGRESS`, `IDLE`).
- Ensured update target fragments load concurrently with the main query instead of being fetched afterward.
- Added lazy loading per tab, data is only fetched when a tab is visited, preventing redundant requests.


Same issue and based on #936 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
