### PR TITLE
feat: block actions until deployment is ready

### DIFF
--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -115,6 +115,8 @@ defmodule Edgehog.Containers.Deployment do
       Sends a :start command to the release on the device.
       """
 
+      validate Validations.IsReady
+
       manual {ManualActions.SendDeploymentCommand, command: :start}
     end
 
@@ -123,6 +125,8 @@ defmodule Edgehog.Containers.Deployment do
       Sends a :stop command to the release on the device.
       """
 
+      validate Validations.IsReady
+
       manual {ManualActions.SendDeploymentCommand, command: :stop}
     end
 
@@ -130,6 +134,8 @@ defmodule Edgehog.Containers.Deployment do
       description """
       Sends a :delete command to the release on the device.
       """
+
+      validate Validations.IsReady
 
       manual {ManualActions.SendDeploymentCommand, command: :delete}
     end
@@ -158,6 +164,8 @@ defmodule Edgehog.Containers.Deployment do
       argument :target, :uuid do
         allow_nil? false
       end
+
+      validate Validations.IsReady
 
       validate SameApplication
       validate IsUpgrade

--- a/backend/lib/edgehog/containers/deployment/validations/is_ready.ex
+++ b/backend/lib/edgehog/containers/deployment/validations/is_ready.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Edgehog.Containers.Deployment.Validations.IsReady do
+  @moduledoc false
+  use Ash.Resource.Validation
+
+  @impl Ash.Resource.Validation
+  def validate(changeset, _opts, _context) do
+    {:ok, deployment} = Ash.load(changeset.data, :is_ready)
+
+    if deployment.is_ready do
+      :ok
+    else
+      {:error, "This action cannot be performed because the deployment is not ready yet."}
+    end
+  end
+end

--- a/backend/test/edgehog_web/schema/mutation/send_deployment_upgrade_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/send_deployment_upgrade_test.exs
@@ -50,8 +50,11 @@ defmodule EdgehogWeb.Schema.Mutation.SendDeploymentUpgradeTest do
       %{release_0_0_1: release_0_0_1, release_0_0_2: release_0_0_2, tenant: tenant} =
         args
 
-      deployment_0_0_1 =
-        deployment_fixture(release_id: release_0_0_1.id, tenant: tenant)
+      # we need to set the state of deployment in one of ready states so the action validation passes
+      {:ok, deployment_0_0_1} =
+        [release_id: release_0_0_1.id, tenant: tenant]
+        |> deployment_fixture()
+        |> Edgehog.Containers.mark_deployment_as_stopped(tenant: tenant)
 
       expect(CreateDeploymentRequestMock, :send_create_deployment_request, fn _, _, _ -> :ok end)
 
@@ -71,11 +74,11 @@ defmodule EdgehogWeb.Schema.Mutation.SendDeploymentUpgradeTest do
       %{release_0_0_1: release_0_0_1, release_0_0_2: release_0_0_2, tenant: tenant} =
         args
 
-      deployment_0_0_1 =
-        deployment_fixture(
-          release_id: release_0_0_1.id,
-          tenant: tenant
-        )
+      # we need to set the state of deployment in one of ready states so the action validation passes
+      {:ok, deployment_0_0_1} =
+        [release_id: release_0_0_1.id, tenant: tenant]
+        |> deployment_fixture()
+        |> Edgehog.Containers.mark_deployment_as_stopped(tenant: tenant)
 
       expect(CreateDeploymentRequestMock, :send_create_deployment_request, fn _, _, _ -> :ok end)
       expect(DeploymentUpdateMock, :update, fn _, _, _ -> :ok end)
@@ -100,8 +103,11 @@ defmodule EdgehogWeb.Schema.Mutation.SendDeploymentUpgradeTest do
       %{release_0_0_1: release_0_0_1, release_0_0_2: release_0_0_2, tenant: tenant} =
         args
 
-      deployment_0_0_1 =
-        deployment_fixture(release_id: release_0_0_1.id, tenant: tenant)
+      # we need to set the state of deployment in one of ready states so the action validation passes
+      {:ok, deployment_0_0_1} =
+        [release_id: release_0_0_1.id, tenant: tenant]
+        |> deployment_fixture()
+        |> Edgehog.Containers.mark_deployment_as_stopped(tenant: tenant)
 
       release_0_0_2_b = release_fixture(version: release_0_0_2.version, tenant: tenant)
 
@@ -114,11 +120,32 @@ defmodule EdgehogWeb.Schema.Mutation.SendDeploymentUpgradeTest do
       %{release_0_0_1: release_0_0_1, release_0_0_2: release_0_0_2, tenant: tenant} =
         args
 
-      deployment_0_0_2 = deployment_fixture(release_id: release_0_0_2.id, tenant: tenant)
+      # we need to set the state of deployment in one of ready states so the action validation passes
+      {:ok, deployment_0_0_2} =
+        [release_id: release_0_0_2.id, tenant: tenant]
+        |> deployment_fixture()
+        |> Edgehog.Containers.mark_deployment_as_stopped(tenant: tenant)
 
       [tenant: tenant, deployment: deployment_0_0_2, target: release_0_0_1]
       |> send_deployment_upgrade_mutation()
       |> extract_error!()
+    end
+
+    test "fails when deployment is in non ready state", args do
+      %{release_0_0_1: release_0_0_1, release_0_0_2: release_0_0_2, tenant: tenant} =
+        args
+
+      deployment_0_0_1 =
+        deployment_fixture(release_id: release_0_0_1.id, tenant: tenant)
+
+      expect(CreateDeploymentRequestMock, :send_create_deployment_request, 0, fn _, _, _ ->
+        :ok
+      end)
+
+      _result =
+        [tenant: tenant, deployment: deployment_0_0_1, target: release_0_0_2]
+        |> send_deployment_upgrade_mutation()
+        |> extract_error!()
     end
   end
 

--- a/backend/test/edgehog_web/schema/mutation/update_deployment_start_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/update_deployment_start_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2024 SECO Mind Srl
+# Copyright 2024 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,11 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateDeploymentStartTest do
 
   describe "startDeployment mutation tests" do
     test "start on an existing deployment", %{tenant: tenant} do
-      deployment = deployment_fixture(tenant: tenant)
+      # we need to set the state of deployment in one of ready states so the action validation passes
+      {:ok, deployment} =
+        [tenant: tenant]
+        |> deployment_fixture()
+        |> Edgehog.Containers.mark_deployment_as_stopped(tenant: tenant)
 
       expect(DeploymentCommandMock, :send_deployment_command, 1, fn _, _, _ -> :ok end)
 
@@ -41,6 +45,15 @@ defmodule EdgehogWeb.Schema.Mutation.UpdateDeploymentStartTest do
       deployment = deployment_fixture(tenant: tenant)
 
       deployment |> Ash.Changeset.for_destroy(:destroy) |> Ash.destroy!()
+
+      [tenant: tenant, deployment: deployment]
+      |> send_start_deployment_mutation()
+      |> extract_error!()
+    end
+
+    test "start on nonready deployment return an error", %{tenant: tenant} do
+      # deployment is not ready because it is in :pending state
+      deployment = deployment_fixture(tenant: tenant)
 
       [tenant: tenant, deployment: deployment]
       |> send_start_deployment_mutation()

--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -151,15 +151,18 @@ const ActionButtons = ({
   state,
   onStart,
   onStop,
+  disabled,
 }: {
   intl: ReturnType<typeof useIntl>;
   state: DeploymentState;
   onStart: () => void;
   onStop: () => void;
+  disabled: boolean;
 }) => (
   <div>
     {state === "STOPPED" || state === "ERROR" ? (
       <Button
+        disabled={disabled}
         onClick={onStart}
         className="btn p-0 text-success border-0 bg-transparent icon-click"
         title={intl.formatMessage({
@@ -171,6 +174,7 @@ const ActionButtons = ({
       </Button>
     ) : state === "STARTED" ? (
       <Button
+        disabled={disabled}
         onClick={onStop}
         className="btn p-0 text-danger border-0 bg-transparent icon-click"
         title={intl.formatMessage({
@@ -611,6 +615,7 @@ const DeployedApplicationsTable = ({
       cell: ({ row, getValue }) => (
         <div className="d-flex align-items-center">
           <ActionButtons
+            disabled={!getValue().isReady}
             intl={intl}
             state={getValue().state}
             onStart={() => handleStartDeployedApplication(getValue().id)}
@@ -622,7 +627,7 @@ const DeployedApplicationsTable = ({
               setSelectedDeployment(row.original);
               handleShowUpgradeModal();
             }}
-            disabled={getValue().state === "DELETING"}
+            disabled={getValue().state === "DELETING" || !getValue()?.isReady}
             className="btn p-0 border-0 bg-transparent ms-4 icon-click"
             title={intl.formatMessage({
               id: "components.DeployedApplicationsTable.upgradeButtonTitle",
@@ -633,7 +638,7 @@ const DeployedApplicationsTable = ({
           </Button>
 
           <Button
-            disabled={getValue().state === "DELETING"}
+            disabled={getValue().state === "DELETING" || !getValue()?.isReady}
             className="btn p-0 border-0 bg-transparent ms-4 icon-click"
             title={intl.formatMessage({
               id: "components.DeployedApplicationsTable.deleteButtonTitle",


### PR DESCRIPTION
Prevent Start, Stop, Delete, and Upgrade actions from being executed when the deployment is not in a ready state.
