### PR TITLE
chore: improve deployment state display

### DIFF
--- a/frontend/src/components/ApplicationDevicesTable.tsx
+++ b/frontend/src/components/ApplicationDevicesTable.tsx
@@ -49,6 +49,7 @@ const APPLICATION_DEVICES_TABLE_FRAGMENT = graphql`
               node {
                 id
                 state
+                isReady
                 device {
                   id
                   name
@@ -149,6 +150,7 @@ const ApplicationDevicesTable = ({
       cell: ({ row }) => (
         <DeploymentStateComponent
           state={row.original.state as DeploymentState}
+          isReady={row.original.isReady}
         />
       ),
     }),

--- a/frontend/src/components/DeployedApplicationsTable.tsx
+++ b/frontend/src/components/DeployedApplicationsTable.tsx
@@ -509,7 +509,12 @@ const DeployedApplicationsTable = ({
           defaultMessage="State"
         />
       ),
-      cell: ({ getValue }) => <DeploymentStateComponent state={getValue()} />,
+      cell: ({ row, getValue }) => (
+        <DeploymentStateComponent
+          state={getValue()}
+          isReady={row.original.isReady}
+        />
+      ),
     }),
     columnHelper.accessor("isReady", {
       id: "readiness",

--- a/frontend/src/components/DeploymentState.tsx
+++ b/frontend/src/components/DeploymentState.tsx
@@ -111,26 +111,31 @@ const stateMessages = defineMessages<DeploymentState>({
   },
 });
 
-type DeploymentStateComponentProps = {
-  state: DeploymentState;
+const displaySpinner = (state: string, isReady?: boolean | null) => {
+  return (
+    !isReady ||
+    ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
+  );
 };
 
-const DeploymentStateComponent = ({ state }: DeploymentStateComponentProps) => {
+type DeploymentStateComponentProps = {
+  state: DeploymentState;
+  isReady?: boolean | null;
+};
+
+const DeploymentStateComponent = ({
+  state,
+  isReady,
+}: DeploymentStateComponentProps) => {
   return (
     <div className="d-flex align-items-center">
       <Icon
-        icon={
-          ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
-            ? "spinner"
-            : "circle"
-        }
-        className={`me-2 ${stateColors[state]} ${
-          ["STARTING", "STOPPING", "DEPLOYING", "DELETING"].includes(state)
-            ? "fa-spin"
-            : ""
-        }`}
+        icon={displaySpinner(state, isReady) ? "spinner" : "circle"}
+        className={`me-2 ${stateColors[state]} ${displaySpinner(state, isReady) ? "fa-spin" : ""}`}
       />
-      <FormattedMessage id={stateMessages[state].id} />
+      <FormattedMessage
+        id={isReady ? stateMessages[state].id : stateMessages["DEPLOYING"].id}
+      />
     </div>
   );
 };

--- a/frontend/src/components/DeploymentTargetsTable.tsx
+++ b/frontend/src/components/DeploymentTargetsTable.tsx
@@ -94,9 +94,12 @@ const columns = [
           description="Title for the State column of the Deployment Targets table"
         />
       ),
-      cell: ({ getValue }) => {
+      cell: ({ row, getValue }) => {
         const state = getValue();
-        return state && <DeploymentStateComponent state={state} />;
+        const isReady = row.original.deployment?.isReady;
+        return (
+          state && <DeploymentStateComponent state={state} isReady={isReady} />
+        );
       },
     },
   ),

--- a/frontend/src/components/ReleaseDevicesTable.tsx
+++ b/frontend/src/components/ReleaseDevicesTable.tsx
@@ -50,6 +50,7 @@ const RELEASE_DEVICES_TABLE_FRAGMENT = graphql`
         node {
           id
           state
+          isReady
           device {
             id
             name
@@ -129,6 +130,7 @@ const ReleaseDevicesTable = ({
       cell: ({ row }) => (
         <DeploymentStateComponent
           state={row.original.state as DeploymentState}
+          isReady={row.original.isReady}
         />
       ),
     }),


### PR DESCRIPTION
The UI is improved to make it easier to understand the current rollout/runtime state of deployments. Values for the State field of deployments (e.g. Started/Stopped/etc.) are not displayed, until the deployment is ready.

