### PR TITLE
fix: add image_credentials_id to image identity

### DIFF
--- a/backend/lib/edgehog/containers/container/container.ex
+++ b/backend/lib/edgehog/containers/container/container.ex
@@ -139,7 +139,7 @@ defmodule Edgehog.Containers.Container do
                on_no_match: :create,
                on_lookup: :relate,
                on_match: :ignore,
-               use_identities: [:reference]
+               use_identities: [:reference_credentials]
              )
 
       change manage_relationship(:networks,

--- a/backend/lib/edgehog/containers/image/image.ex
+++ b/backend/lib/edgehog/containers/image/image.ex
@@ -80,7 +80,7 @@ defmodule Edgehog.Containers.Image do
   end
 
   identities do
-    identity :reference, [:reference]
+    identity :reference_credentials, [:reference, :image_credentials_id]
   end
 
   postgres do

--- a/backend/priv/repo/migrations/20251017140331_add_image_credentials_id_to_image_identity.exs
+++ b/backend/priv/repo/migrations/20251017140331_add_image_credentials_id_to_image_identity.exs
@@ -1,0 +1,45 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.AddImageCredentialsIdToImageIdentity do
+  @moduledoc """
+  Make unique constraint include image_credentials_id so same image reference can be used with different credentials.
+  """
+  use Ecto.Migration
+
+  def up do
+    drop_if_exists unique_index(:images, [:tenant_id, :reference], name: "images_reference_index")
+
+    create unique_index(:images, [:tenant_id, :reference, :image_credentials_id],
+             name: "images_reference_credentials_index"
+           )
+  end
+
+  def down do
+    drop_if_exists unique_index(:images, [:tenant_id, :reference, :image_credentials_id],
+                     name: "images_reference_credentials_index"
+                   )
+
+    IO.warn("""
+    Skipping recreation of images_reference_index because duplicates
+    may exist for (tenant_id, reference). Please clean up manually if needed.
+    """)
+  end
+end

--- a/backend/priv/resource_snapshots/repo/images/20251017140331.json
+++ b/backend/priv/resource_snapshots/repo/images/20251017140331.json
@@ -1,0 +1,186 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "primary_key?": true,
+      "references": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "primary_key?": false,
+      "references": null,
+      "size": null,
+      "source": "reference",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "primary_key?": false,
+      "references": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "primary_key?": false,
+      "references": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "tenant_id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "images_tenant_id_fkey",
+        "on_delete": "delete",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "tenants"
+      },
+      "size": null,
+      "source": "tenant_id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "images_image_credentials_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "image_credentials"
+      },
+      "size": null,
+      "source": "image_credentials_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "id",
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "id"
+        },
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": true,
+      "using": null,
+      "where": null
+    },
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": false,
+      "using": null,
+      "where": null
+    }
+  ],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "FA48B394E31707DCE50DE1C7F38A8C638823199F0DC205C4D96037304547BF27",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "images_reference_credentials_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "reference"
+        },
+        {
+          "type": "atom",
+          "value": "image_credentials_id"
+        }
+      ],
+      "name": "reference_credentials",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": "tenant_id",
+    "global": false,
+    "strategy": "attribute"
+  },
+  "repo": "Elixir.Edgehog.Repo",
+  "schema": null,
+  "table": "images"
+}


### PR DESCRIPTION
Include image_credentials_id as part of the image identity to allow the same image reference to exist with different credentials. Previously, images sharing the same reference but different credentials were treated as identical, causing issues when reusing image references with new credentials.
