### PR TITLE
Disable already used system models when creating a Base Image Collection

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -463,6 +463,9 @@
   "components.CreateBaseImageCollectionForm.systemModelOption": {
     "defaultMessage": "Select a System Model"
   },
+  "components.CreateBaseImageCollectionForm.systemModelOptionUsed": {
+    "defaultMessage": "{name} (already used)"
+  },
   "components.CreateDeviceGroup.handleLabel": {
     "defaultMessage": "Handle"
   },

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -51,6 +51,16 @@ const CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY = graphql`
       __typename
       count
     }
+    baseImageCollections {
+      edges {
+        node {
+          systemModel {
+            id
+            name
+          }
+        }
+      }
+    }
     ...CreateBaseImageCollection_OptionsFragment
   }
 `;
@@ -69,10 +79,12 @@ const CREATE_BASE_IMAGE_COLLECTION_MUTATION = graphql`
 
 type BaseImageCollectionProps = {
   baseImageCollectionOptions: BaseImageCollectionCreate_getOptions_Query$data;
+  usedSystemModelIds?: string[];
 };
 
 const BaseImageCollection = ({
   baseImageCollectionOptions,
+  usedSystemModelIds = [],
 }: BaseImageCollectionProps) => {
   const navigate = useNavigate();
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
@@ -156,6 +168,7 @@ const BaseImageCollection = ({
         optionsRef={baseImageCollectionOptions}
         onSubmit={handleCreateBaseImageCollection}
         isLoading={isCreatingBaseImageCollection}
+        usedSystemModelIds={usedSystemModelIds}
       />
     </>
   );
@@ -196,13 +209,18 @@ const BaseImageCollectionWrapper = ({
     CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY,
     getBaseImageCollectionOptionsQuery,
   );
-  const { systemModels } = baseImageCollectionOptions;
+  const { systemModels, baseImageCollections } = baseImageCollectionOptions;
   if (systemModels?.count === 0) {
     return <NoSystemModels />;
   }
+
+  const usedSystemModelIds =
+    baseImageCollections?.edges?.map((edge) => edge.node.systemModel.id) ?? [];
+
   return (
     <BaseImageCollection
       baseImageCollectionOptions={baseImageCollectionOptions}
+      usedSystemModelIds={usedSystemModelIds}
     />
   );
 };


### PR DESCRIPTION
When creating a new Base Image Collection, users should not be able to select system models that are already associated with an existing Base Image Collection
<img width="1919" height="644" alt="image" src="https://github.com/user-attachments/assets/6c2f2697-fe20-4b01-8279-9c5d41465d9e" />

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
