### PR TITLE
fix: stale validation error on create/edit

### DIFF
--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -84,8 +84,9 @@ const BaseImageCollection = ({
 
   const handleCreateBaseImageCollection = useCallback(
     (baseImageCollection: BaseImageCollectionData) => {
+      const newBaseImageCollection = { ...baseImageCollection };
       createBaseImageCollection({
-        variables: { input: baseImageCollection },
+        variables: { input: newBaseImageCollection },
         onCompleted(data, errors) {
           const baseImageCollectionId =
             data.createBaseImageCollection?.result?.id;

--- a/frontend/src/pages/DeviceGroup.tsx
+++ b/frontend/src/pages/DeviceGroup.tsx
@@ -219,8 +219,9 @@ const DeviceGroupContent = ({ deviceGroup }: DeviceGroupContentProps) => {
 
   const handleUpdateDeviceGroup = useCallback(
     (deviceGroup: DeviceGroupData) => {
+      const newDeviceGroup = { ...deviceGroup };
       updateDeviceGroup({
-        variables: { deviceGroupId, input: deviceGroup },
+        variables: { deviceGroupId, input: newDeviceGroup },
         onCompleted(data, errors) {
           if (errors) {
             const errorFeedback = errors

--- a/frontend/src/pages/DeviceGroupCreate.tsx
+++ b/frontend/src/pages/DeviceGroupCreate.tsx
@@ -55,8 +55,9 @@ const DeviceGroupCreatePage = () => {
 
   const handleCreateDeviceGroup = useCallback(
     (deviceGroup: DeviceGroupData) => {
+      const newDeviceGroup = { ...deviceGroup };
       createDeviceGroup({
-        variables: { input: deviceGroup },
+        variables: { input: newDeviceGroup },
         onCompleted(data, errors) {
           const deviceGroupId = data.createDeviceGroup?.result?.id;
           if (deviceGroupId) {


### PR DESCRIPTION
The validation error clears when updating an entity's property to a unique value, and create/edit operations work without requiring a page refresh.
The fix is applied to `Device Group` and `Base Image Collection`.

