### PR TITLE
fix: null `env` in `Container`s

### DIFF
--- a/backend/lib/edgehog/containers/container/container.ex
+++ b/backend/lib/edgehog/containers/container/container.ex
@@ -232,6 +232,7 @@ defmodule Edgehog.Containers.Container do
 
     attribute :env, {:array, EnvVar} do
       default []
+      allow_nil? false
       public? true
     end
 

--- a/backend/priv/resource_snapshots/repo/containers/20251009143455.json
+++ b/backend/priv/resource_snapshots/repo/containers/20251009143455.json
@@ -44,7 +44,7 @@
       "type": "text"
     },
     {
-      "allow_nil?": true,
+      "allow_nil?": false,
       "default": "[]",
       "generated?": false,
       "primary_key?": false,
@@ -375,7 +375,7 @@
   ],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "C222564DA7C705E91573C06655C0B99A79AF5BCD09B523B5D9B74D3BB217A6E1",
+  "hash": "90E81FEDC0181BFC61A3102B8387999BEEB110AE80E824F70D5F4762415E7443",
   "identities": [],
   "multitenancy": {
     "attribute": "tenant_id",

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -2843,7 +2843,7 @@ type Container {
   restartPolicy: String
   portBindings: [String!]!
   hostname: String!
-  env: [ContainerEnvVar!]
+  env: [ContainerEnvVar!]!
   privileged: Boolean
   networkMode: String!
   extraHosts: [String!]!

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -1776,7 +1776,7 @@ const CreateRelease = ({
           const submitData: ReleaseSubmitData = {
             ...data,
             containers: data.containers?.map((container) => ({
-              env: container.env,
+              env: container.env || undefined,
               extraHosts: container.extraHosts || undefined,
               image: {
                 reference: container.image.reference,


### PR DESCRIPTION
Fix errors that could arise if the `env` field in some container was set to
NULL before the migration.
