### PR TITLE
feat: create device upon registration in astarte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed 
+- With Astarte versions >= 1.3, devices are available in Edgehog upon registration, without waiting for their first connection
+
+
 ## [0.10.0-alpha.7] - 2025-10-28
-## Changed 
+### Changed 
 - Added a default image for devices that don’t have an associated system model image, replacing the plain grey placeholder
 - Containers now allow to specify binds.
 - Frontend validation for port bindings support the full docker specification: [docker documentation](https://docs.docker.com/reference/compose-file/services/#ports).

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -101,6 +101,19 @@ defmodule Edgehog.Devices.Device do
       change set_attribute(:last_connection, arg(:timestamp))
     end
 
+    create :from_device_registered_event do
+      upsert? true
+      upsert_identity :unique_realm_device_id
+      upsert_fields [:updated_at]
+
+      accept [:realm_id]
+      argument :device_id, :string, allow_nil?: false
+
+      # Only if created
+      change set_attribute(:device_id, arg(:device_id))
+      change set_attribute(:name, arg(:device_id))
+    end
+
     create :from_device_disconnected_event do
       upsert? true
       upsert_identity :unique_realm_device_id

--- a/backend/lib/edgehog/triggers/device_registered.ex
+++ b/backend/lib/edgehog/triggers/device_registered.ex
@@ -1,0 +1,25 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Triggers.DeviceRegistered do
+  @moduledoc false
+  use Ash.Resource,
+    data_layer: :embedded
+end

--- a/backend/lib/edgehog/triggers/event.ex
+++ b/backend/lib/edgehog/triggers/event.ex
@@ -24,6 +24,12 @@ defmodule Edgehog.Triggers.Event do
     subtype_of: :union,
     constraints: [
       types: [
+        device_registered: [
+          type: Edgehog.Triggers.DeviceRegistered,
+          tag: :type,
+          tag_value: "device_registered",
+          cast_tag?: false
+        ],
         device_connected: [
           type: Edgehog.Triggers.DeviceConnected,
           tag: :type,

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -30,6 +30,7 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
   alias Edgehog.OSManagement
   alias Edgehog.Triggers.DeviceConnected
   alias Edgehog.Triggers.DeviceDisconnected
+  alias Edgehog.Triggers.DeviceRegistered
   alias Edgehog.Triggers.IncomingData
   alias Edgehog.Triggers.TriggerPayload
 
@@ -75,6 +76,14 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
 
     Device
     |> Ash.Changeset.for_create(:from_device_connected_event, params)
+    |> Ash.create(tenant: tenant)
+  end
+
+  defp handle_event(%DeviceRegistered{}, tenant, realm_id, device_id, _timestamp) do
+    params = %{realm_id: realm_id, device_id: device_id}
+
+    Device
+    |> Ash.Changeset.for_create(:from_device_registered_event, params)
     |> Ash.create(tenant: tenant)
   end
 

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-registration.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-registration.json.eex
@@ -1,0 +1,18 @@
+{
+    "name": "edgehog-registration",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "ignore_ssl_errors": false,
+        "http_method": "post",
+        "http_static_headers": {}
+    },
+    "simple_triggers": [
+        {
+            "type": "device_trigger",
+            "on": "device_registered"
+        }
+    ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
+}

--- a/backend/test/edgehog/tenants/reconciler_test.exs
+++ b/backend/test/edgehog/tenants/reconciler_test.exs
@@ -36,11 +36,12 @@ defmodule Edgehog.Tenants.ReconcilerTest do
       # its pid to allow mocks call from it
       Mox.set_mox_global()
 
-      # Mock the Astarte version check to support trigger delivery policies
+      # Mock the Astarte version check to support trigger delivery policies and
+      # device registration and deletion triggers
       Tesla.Mock.mock_global(fn
         %{method: :get, url: url} ->
           if String.ends_with?(url, "/version") do
-            %Tesla.Env{status: 200, body: %{"data" => "1.2.0"}}
+            %Tesla.Env{status: 200, body: %{"data" => "1.3.0"}}
           else
             %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not found"}}}
           end
@@ -111,11 +112,12 @@ defmodule Edgehog.Tenants.ReconcilerTest do
       # its pid to allow mocks call from it
       Mox.set_mox_global()
 
-      # Mock the Astarte version check to support trigger delivery policies
+      # Mock the Astarte version check to support trigger delivery policies and
+      # device registration and deletion triggers
       Tesla.Mock.mock_global(fn
         %{method: :get, url: url} ->
           if String.ends_with?(url, "/version") do
-            %Tesla.Env{status: 200, body: %{"data" => "1.2.0"}}
+            %Tesla.Env{status: 200, body: %{"data" => "1.3.0"}}
           else
             %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not found"}}}
           end
@@ -186,7 +188,12 @@ defmodule Edgehog.Tenants.ReconcilerTest do
       end)
 
       interface_count = length(Reconciler.Core.list_required_interfaces())
-      trigger_count = "foo" |> Reconciler.Core.list_required_triggers(false) |> length()
+
+      # NOTE: edgehog-registration trigger cannot be installed on astarte
+      # 1.0.0, only from astarte 1.3 onwards device registration (and
+      # deletion) triggers are supported.
+      trigger_count =
+        "foo" |> Reconciler.Core.list_required_triggers(false) |> length() |> Kernel.-(1)
 
       test_pid = self()
       ref = make_ref()


### PR DESCRIPTION
`device_registered` triggers will be available in astarte 1.3. This installs and handles such triggers if the astarte version at runtime is compatible.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
