### PR TITLE
fix: deployment state color mismatch when isReady is false

### DIFF
--- a/frontend/src/components/DeploymentState.tsx
+++ b/frontend/src/components/DeploymentState.tsx
@@ -127,15 +127,15 @@ const DeploymentStateComponent = ({
   state,
   isReady,
 }: DeploymentStateComponentProps) => {
+  const displayedState = isReady ? state : "DEPLOYING";
+
   return (
     <div className="d-flex align-items-center">
       <Icon
         icon={displaySpinner(state, isReady) ? "spinner" : "circle"}
-        className={`me-2 ${stateColors[state]} ${displaySpinner(state, isReady) ? "fa-spin" : ""}`}
+        className={`me-2 ${stateColors[displayedState]} ${displaySpinner(state, isReady) ? "fa-spin" : ""}`}
       />
-      <FormattedMessage
-        id={isReady ? stateMessages[state].id : stateMessages["DEPLOYING"].id}
-      />
+      <FormattedMessage id={stateMessages[displayedState].id} />
     </div>
   );
 };


### PR DESCRIPTION
Previously, when isReady was false, the component would display the "Deploying" message but use the color of the actual state, causing incorrect color representation (e.g., "Deploying" in red when state was ERROR).

Now both the message and color are determined by displayedState, ensuring they are always synchronized. When isReady is false, both use DEPLOYING (muted gray).

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
