### PR TITLE
feat: remove device upon deletion finished in astarte

### DIFF
--- a/backend/lib/edgehog/triggers/device_deletion_finished.ex
+++ b/backend/lib/edgehog/triggers/device_deletion_finished.ex
@@ -1,0 +1,25 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Triggers.DeviceDeletionFinished do
+  @moduledoc false
+  use Ash.Resource,
+    data_layer: :embedded
+end

--- a/backend/lib/edgehog/triggers/event.ex
+++ b/backend/lib/edgehog/triggers/event.ex
@@ -42,6 +42,12 @@ defmodule Edgehog.Triggers.Event do
           tag_value: "device_disconnected",
           cast_tag?: false
         ],
+        device_deleted: [
+          type: Edgehog.Triggers.DeviceDeletionFinished,
+          tag: :type,
+          tag_value: "device_deletion_finished",
+          cast_tag?: false
+        ],
         incoming_data: [
           type: Edgehog.Triggers.IncomingData,
           tag: :type,

--- a/backend/priv/astarte_resources/trigger_templates/edgehog-deletion-finished.json.eex
+++ b/backend/priv/astarte_resources/trigger_templates/edgehog-deletion-finished.json.eex
@@ -1,0 +1,18 @@
+{
+    "name": "edgehog-deletion-finished",
+    "action": {
+        "http_url": "<%= @trigger_url %>",
+        "ignore_ssl_errors": false,
+        "http_method": "post",
+        "http_static_headers": {}
+    },
+    "simple_triggers": [
+        {
+            "type": "device_trigger",
+            "on": "device_deletion_finished"
+        }
+    ]
+    <%= if @can_use_trigger_delivery_policy do %>,
+    "policy": "edgehog-retry-on-server-error"
+    <% end %>
+}

--- a/backend/test/edgehog/tenants/reconciler_test.exs
+++ b/backend/test/edgehog/tenants/reconciler_test.exs
@@ -193,7 +193,7 @@ defmodule Edgehog.Tenants.ReconcilerTest do
       # 1.0.0, only from astarte 1.3 onwards device registration (and
       # deletion) triggers are supported.
       trigger_count =
-        "foo" |> Reconciler.Core.list_required_triggers(false) |> length() |> Kernel.-(1)
+        "foo" |> Reconciler.Core.list_required_triggers(false) |> length() |> Kernel.-(2)
 
       test_pid = self()
       ref = make_ref()


### PR DESCRIPTION
Based on #1007 

This feature allows the astarte-edgehog binomy to handle devices seamlessly: once devices are removed in astarte they are also removed from edgehog.
