### PR TITLE
chore: garbage collect dangling resources

### DIFF
--- a/backend/lib/edgehog/containers/calculations/dangling.ex
+++ b/backend/lib/edgehog/containers/calculations/dangling.ex
@@ -1,0 +1,59 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Calculations.Dangling do
+  @moduledoc """
+  Is the current resource dangling? Meaning, is it related to other entities?
+  """
+
+  use Ash.Resource.Calculation
+
+  alias Ash.Resource.Calculation
+
+  @parent_key :parent
+
+  @impl Calculation
+  def init(opts) do
+    if Keyword.has_key?(opts, @parent_key) do
+      {:ok, opts}
+    else
+      {:error, :missing_parent_key}
+    end
+  end
+
+  @impl Calculation
+  def load(_query, opts, _context) do
+    opts[@parent_key]
+  end
+
+  @impl Calculation
+  def calculate(records, opts, _context) do
+    parent = Keyword.fetch!(opts, @parent_key)
+    Enum.map(records, &dangling?(&1, parent))
+  end
+
+  def dangling?(resource, parent) do
+    case Map.get(resource, parent) do
+      nil -> true
+      [] -> true
+      _ -> false
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/container/changes/maybe_delete_children.ex
+++ b/backend/lib/edgehog/containers/container/changes/maybe_delete_children.ex
@@ -1,0 +1,54 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Container.Changes.MaybeDeleteChildren do
+  @moduledoc """
+  Trigger Image, Volume, Network and DeviceMappings deletion if dangling
+  """
+
+  use Ash.Resource.Change
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, %{tenant: tenant}) do
+    with {:ok, container_deployment} <-
+           Ash.load(changeset.data, [
+             :image_deployment,
+             :volume_deployments,
+             :network_deployments,
+             :device_mapping_deployments
+           ]) do
+      resources =
+        [container_deployment.image_deployment] ++
+          container_deployment.volume_deployments ++
+          container_deployment.network_deployments ++
+          container_deployment.device_mapping_deployments
+
+      Ash.Changeset.after_action(changeset, fn _changeset, container_deployment ->
+        Enum.each(resources, fn resource ->
+          resource
+          |> Ash.Changeset.for_destroy(:destroy_if_dangling, %{})
+          |> Ash.destroy!(tenant: tenant)
+        end)
+
+        {:ok, container_deployment}
+      end)
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/container/deployment.ex
+++ b/backend/lib/edgehog/containers/container/deployment.ex
@@ -28,6 +28,7 @@ defmodule Edgehog.Containers.Container.Deployment do
   alias Edgehog.Containers.Container.Calculations
   alias Edgehog.Containers.Container.Changes
   alias Edgehog.Containers.Deployment
+  alias Edgehog.Containers.ManualActions
   alias Edgehog.Devices.Device
 
   graphql do
@@ -120,6 +121,12 @@ defmodule Edgehog.Containers.Container.Deployment do
       require_atomic? false
       change Changes.MaybeNotifyUpwards
     end
+
+    destroy :destroy_if_dangling do
+      require_atomic? false
+      change Changes.MaybeDeleteChildren
+      manual ManualActions.DestroyIfDangling
+    end
   end
 
   attributes do
@@ -181,6 +188,10 @@ defmodule Edgehog.Containers.Container.Deployment do
 
   calculations do
     calculate :is_ready, :boolean, Calculations.Ready
+
+    calculate :dangling?,
+              :boolean,
+              {Edgehog.Containers.Calculations.Dangling, [parent: :deployments]}
   end
 
   identities do

--- a/backend/lib/edgehog/containers/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment.ex
@@ -232,6 +232,11 @@ defmodule Edgehog.Containers.Deployment do
 
       filter expr(release_id == ^arg(:release_id))
     end
+
+    destroy :destroy_and_gc do
+      require_atomic? false
+      change Changes.MaybeDeleteChildren
+    end
   end
 
   attributes do

--- a/backend/lib/edgehog/containers/deployment/changes/maybe_delete_children.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/maybe_delete_children.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.MaybeDeleteChildren do
+  @moduledoc """
+  Trigger Image, Volume, Network and DeviceMappings deletion if dangling
+  """
+
+  use Ash.Resource.Change
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, %{tenant: tenant}) do
+    with {:ok, deployment} <- Ash.load(changeset.data, [:container_deployments]) do
+      container_deployments = deployment.container_deployments
+
+      Ash.Changeset.after_action(changeset, fn _changeset, deployment ->
+        Enum.each(container_deployments, fn resource ->
+          resource
+          |> Ash.Changeset.for_destroy(:destroy_if_dangling, %{})
+          |> Ash.destroy!(tenant: tenant)
+        end)
+
+        {:ok, deployment}
+      end)
+    end
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/relate.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/relate.ex
@@ -46,7 +46,10 @@ defmodule Edgehog.Containers.Deployment.Changes.Relate do
         &%{
           container: &1,
           device: device,
-          deployment: deployment
+          deployment: deployment,
+          # Needed for container_instance identity
+          container_id: &1.id,
+          device_id: &1.id
         }
       )
 

--- a/backend/lib/edgehog/containers/device_mapping/deployment.ex
+++ b/backend/lib/edgehog/containers/device_mapping/deployment.ex
@@ -28,6 +28,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
   alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.DeviceMapping
   alias Edgehog.Containers.DeviceMapping.Changes
+  alias Edgehog.Containers.ManualActions
   alias Edgehog.Devices.Device
 
   graphql do
@@ -98,6 +99,11 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
       change set_attribute(:last_message, arg(:message))
       change set_attribute(:state, :error)
     end
+
+    destroy :destroy_if_dangling do
+      require_atomic? false
+      manual ManualActions.DestroyIfDangling
+    end
   end
 
   attributes do
@@ -131,6 +137,10 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment do
 
   calculations do
     calculate :is_ready, :boolean, expr(state in [:present, :not_present])
+
+    calculate :dangling?,
+              :boolean,
+              {Edgehog.Containers.Calculations.Dangling, [parent: :container_deployments]}
   end
 
   identities do

--- a/backend/lib/edgehog/containers/image/image.ex
+++ b/backend/lib/edgehog/containers/image/image.ex
@@ -26,8 +26,8 @@ defmodule Edgehog.Containers.Image do
 
   alias Edgehog.Containers.Container
   alias Edgehog.Containers.Image.Calculations
-  alias Edgehog.Containers.Image.ManualActions
   alias Edgehog.Containers.ImageCredentials
+  alias Edgehog.Containers.ManualActions
 
   graphql do
     type :image

--- a/backend/lib/edgehog/containers/manual_actions/destroy_if_dangling.ex
+++ b/backend/lib/edgehog/containers/manual_actions/destroy_if_dangling.ex
@@ -18,19 +18,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.Containers.Image.ManualActions.DestroyIfDangling do
-  @moduledoc false
+defmodule Edgehog.Containers.ManualActions.DestroyIfDangling do
+  @moduledoc """
+  Is the given resource dangling (`dangling?` calculation returns true)? -> delete it!
+  """
 
   use Ash.Resource.ManualDestroy
 
   @impl Ash.Resource.ManualDestroy
   def destroy(changeset, _opts, %{tenant: tenant}) do
-    image = changeset.data
+    resource = changeset.data
 
-    with {:ok, image} <- Ash.load(image, :dangling?) do
-      if image.dangling?, do: Ash.destroy(image, tenant: tenant)
+    with {:ok, resource} <- Ash.load(resource, :dangling?) do
+      if resource.dangling? do
+        with :ok <- Ash.destroy(resource, tenant: tenant) do
+          {:ok, resource}
+        end
+      else
+        {:error, :not_dangling}
+      end
     end
-
-    {:ok, image}
   end
 end

--- a/backend/lib/edgehog/containers/network/deployment.ex
+++ b/backend/lib/edgehog/containers/network/deployment.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Containers.Network.Deployment do
 
   alias Edgehog.Containers.Changes.MaybeNotifyUpwards
   alias Edgehog.Containers.Deployment
+  alias Edgehog.Containers.ManualActions
   alias Edgehog.Containers.Network
   alias Edgehog.Containers.Network.Changes
   alias Edgehog.Devices.Device
@@ -97,6 +98,11 @@ defmodule Edgehog.Containers.Network.Deployment do
       change set_attribute(:last_message, arg(:message))
       change set_attribute(:state, :error)
     end
+
+    destroy :destroy_if_dangling do
+      require_atomic? false
+      manual ManualActions.DestroyIfDangling
+    end
   end
 
   attributes do
@@ -130,6 +136,10 @@ defmodule Edgehog.Containers.Network.Deployment do
 
   calculations do
     calculate :is_ready, :boolean, expr(state in [:available, :unavailable])
+
+    calculate :dangling?,
+              :boolean,
+              {Edgehog.Containers.Calculations.Dangling, [parent: :container_deployments]}
   end
 
   identities do

--- a/backend/lib/edgehog/containers/volume/deployment.ex
+++ b/backend/lib/edgehog/containers/volume/deployment.ex
@@ -26,6 +26,7 @@ defmodule Edgehog.Containers.Volume.Deployment do
 
   alias Edgehog.Containers.Changes.MaybeNotifyUpwards
   alias Edgehog.Containers.Deployment
+  alias Edgehog.Containers.ManualActions
   alias Edgehog.Containers.Volume
   alias Edgehog.Containers.Volume.Changes
   alias Edgehog.Devices.Device
@@ -99,6 +100,11 @@ defmodule Edgehog.Containers.Volume.Deployment do
       change set_attribute(:last_message, arg(:message))
       change set_attribute(:state, :error)
     end
+
+    destroy :destroy_if_dangling do
+      require_atomic? false
+      manual ManualActions.DestroyIfDangling
+    end
   end
 
   attributes do
@@ -132,6 +138,10 @@ defmodule Edgehog.Containers.Volume.Deployment do
 
   calculations do
     calculate :is_ready, :boolean, expr(state in [:available, :unavailable])
+
+    calculate :dangling?,
+              :boolean,
+              {Edgehog.Containers.Calculations.Dangling, [parent: :container_deployments]}
   end
 
   identities do

--- a/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
+++ b/backend/lib/edgehog/triggers/handler/manual_actions/handle_trigger.ex
@@ -318,7 +318,10 @@ defmodule Edgehog.Triggers.Handler.ManualActions.HandleTrigger do
 
             # The device is removing the deployment, remove it!
             nil ->
-              Containers.destroy_deployment!(deployment, tenant: tenant)
+              deployment
+              |> Ash.Changeset.for_destroy(:destroy_and_gc, %{}, tenant: tenant)
+              |> Ash.destroy()
+
               {:ok, deployment}
           end
         end

--- a/backend/test/edgehog/containers/deployment/dangling.exs
+++ b/backend/test/edgehog/containers/deployment/dangling.exs
@@ -1,0 +1,79 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.DeploymentTest do
+  @moduledoc false
+  use Edgehog.DataCase, async: true
+
+  import Edgehog.ContainersFixtures
+  import Edgehog.TenantsFixtures
+
+  alias Edgehog.Containers.Container
+  alias Edgehog.Containers.Image
+
+  setup do
+    tenant = tenant_fixture()
+    deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
+
+    %{tenant: tenant, deployment: deployment}
+  end
+
+  test "destroy_if_dangling removes the container_deployment only if danlging", %{
+    tenant: tenant,
+    deployment: deployment
+  } do
+    deployment = Ash.load!(deployment, :container_deployments)
+    [container_deployment] = deployment.container_deployments
+
+    assert {:error, _} =
+             container_deployment
+             |> Ash.Changeset.for_destroy(:destroy_if_dangling)
+             |> Ash.destroy()
+
+    Ash.destroy!(deployment)
+
+    assert :ok = Ash.destroy(container_deployment)
+  end
+
+  test "destroy_and_gc garbage collects", %{
+    tenant: tenant,
+    deployment: deployment
+  } do
+    deployment =
+      Ash.load!(deployment,
+        container_deployments: [
+          :image_deployment,
+          :volume_deployments,
+          :network_deployments,
+          :device_mapping_deployments
+        ]
+      )
+
+    [container_deployment] = deployment.container_deployments
+    image_deployment = container_deployment.image_deployment
+
+    deployment
+    |> Ash.Changeset.for_destroy(:destroy_and_gc)
+    |> Ash.destroy!()
+
+    assert {:error, _} = Ash.get(Image.Deployment, image_deployment.id)
+    assert {:error, _} = Ash.get(Container.Deployment, container_deployment.id)
+  end
+end

--- a/backend/test/support/fixtures/containers_fixtures.ex
+++ b/backend/test/support/fixtures/containers_fixtures.ex
@@ -289,7 +289,13 @@ defmodule Edgehog.ContainersFixtures do
       end)
 
     {release_id, opts} =
-      Keyword.pop_lazy(opts, :release_id, fn -> release_fixture(tenant: tenant).id end)
+      Keyword.pop_lazy(opts, :release_id, fn ->
+        release_opts = Keyword.get(opts, :release_opts, [])
+        release_opts = Keyword.put(release_opts, :tenant, tenant)
+        release_fixture(release_opts).id
+      end)
+
+    opts = Keyword.delete(opts, :release_opts)
 
     params =
       Enum.into(opts, %{


### PR DESCRIPTION
`Deployment` resources can be dangling. This happens when a device nilifies one of the `Available*` interfaces without nilifying the other resources. This commit introduces `destroy_if_dangling` and `danlging?` deletion action and calculation (respectively), to trigger a deletion when a resource is dangling.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
