### PR TITLE
feat: add `start` operation support to deployment campaigns 

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_campaigns.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_campaigns.ex
@@ -86,6 +86,11 @@ defmodule Edgehog.DeploymentCampaigns do
         get_by: [:deployment_id],
         not_found_error?: true
 
+      define :fetch_target_by_deployment_and_campaign,
+        action: :read,
+        get_by: [:deployment_id, :deployment_campaign_id],
+        not_found_error?: true
+
       define :mark_target_as_in_progress, action: :mark_as_in_progress
       define :mark_target_as_failed, action: :mark_as_failed
       define :mark_target_as_successful, action: :mark_as_successful
@@ -97,6 +102,8 @@ defmodule Edgehog.DeploymentCampaigns do
         args: [:latest_attempt]
 
       define :deploy_to_target, action: :deploy, args: [:release]
+
+      define :set_target_deployment, action: :set_deployment, args: [:deployment_id]
     end
   end
 end

--- a/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
@@ -179,6 +179,19 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentTarget do
       change set_attribute(:status, :in_progress)
       change Changes.Deploy
     end
+
+    update :set_deployment do
+      description """
+      Links an existing deployment to this target.
+      The target is marked as :in_progress.
+      """
+
+      accept [:deployment_id]
+
+      require_atomic? false
+
+      change set_attribute(:status, :in_progress)
+    end
   end
 
   attributes do


### PR DESCRIPTION
Implement support for the start operation type in deployment campaigns. The start operation checks if a deployment exists and is in an appropriate state before starting it, with proper error handling for cases like missing deployments or deployments in transitional states.