### PR TITLE
Fix missing isReady propagation for DeploymentStateComponent

### DIFF
--- a/frontend/src/components/DeploymentsTable.tsx
+++ b/frontend/src/components/DeploymentsTable.tsx
@@ -51,6 +51,7 @@ const DEPLOYMENTS_TABLE_FRAGMENT = graphql`
         node {
           id
           state
+          isReady
           device {
             id
             name
@@ -139,7 +140,10 @@ const columns = [
       />
     ),
     cell: ({ row }) => (
-      <DeploymentStateComponent state={row.original.state as DeploymentState} />
+      <DeploymentStateComponent
+        state={row.original.state as DeploymentState}
+        isReady={row.original.isReady}
+      />
     ),
   }),
 ];


### PR DESCRIPTION
Ensure that `isReady` from the deployments query is passed down to DeploymentStateComponent, so that deployments correctly display application state instead of remaining in Deploying.

<img width="1918" height="906" alt="image" src="https://github.com/user-attachments/assets/a9aeaf39-740a-4f51-8d93-7732731286f2" />
<img width="1918" height="818" alt="image" src="https://github.com/user-attachments/assets/34020a16-60c2-44fe-9a48-9c1cf5c103d6" />


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
