### PR TITLE
[Fix] Add GraphiQL playground interface to router

### DIFF
--- a/backend/lib/edgehog_web/router.ex
+++ b/backend/lib/edgehog_web/router.ex
@@ -49,7 +49,9 @@ defmodule EdgehogWeb.Router do
     forward "/", EdgehogWeb.AdminAPI
   end
 
-  forward "/graphiql", Absinthe.Plug.GraphiQL, schema: EdgehogWeb.Schema
+  forward "/graphiql", Absinthe.Plug.GraphiQL,
+    schema: EdgehogWeb.Schema,
+    interface: :playground
 
   scope "/tenants/:tenant_slug" do
     scope "/api" do


### PR DESCRIPTION
Add the GraphiQL Playground interface to the router configuration.

The `:advanced ` interface option is no longer available in the latest version of Absinthe.
The `:playground ` interface is the new default and provides a more modern and feature-rich environment for interacting with the GraphQL API, including better support for subscriptions and documentation.

- Enabled :playground option in the GraphiQL forward route
- Allows developers to use the interactive GraphQL Playground for testing queries and subscriptions

<details> <summary>Screenshots</summary>

<img width="1915" height="1087" alt="image" src="https://github.com/user-attachments/assets/ef2d2af6-d0d8-44b7-8a2d-5c82241df6f7" />

</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

 [*] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
 [*] Make sure to open your PR against the right branch: master / release-VERSION
 [*] Make sure to sign-off all your commits
 [*] GPG signing is appreciated
 [*] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->