### PR TITLE
feat: add stop operation support to deployment campaigns

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/core.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/core.ex
@@ -447,8 +447,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
         start(target, release)
 
       :stop ->
-        # Placeholder for future stop operation
-        {:error, :not_implemented}
+        stop(target, release)
 
       :delete ->
         # Placeholder for future delete operation
@@ -467,7 +466,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
     - deployment_mechanism: The deployment mechanism settings.
 
   ## Returns
-    - `{:ok, :already_deployed}`, if the release is already deployed to the target.
+    - `{:ok, :already_in_desired_state}`, if the release is already deployed to the target.
     - The result of the deployment operation otherwise.
   """
   def deploy(target, release, deployment_mechanism) do
@@ -476,7 +475,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
     # to send all the informations but fails as the resources are already
     # present.
     if application_deployed?(target, release) do
-      {:ok, :already_deployed}
+      {:ok, :already_in_desired_state}
     else
       {:ok, target} = do_deploy(target, release, deployment_mechanism)
 
@@ -526,7 +525,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
 
   ## Returns
     - `{:ok, target}` if the start command is successfully sent.
-    - `{:ok, :already_started}` if the deployment is already in a started state.
+    - `{:ok, :already_in_desired_state}` if the deployment is already in a started state.
     - `{:error, :deployment_not_found}` if the deployment doesn't exist on the target.
     - `{:error, :deployment_deleting}` if the deployment is being deleted.
     - `{:error, :deployment_transitioning}` if the deployment is in a transitional state.
@@ -534,7 +533,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
   """
   def start(target, release) do
     if application_deployed?(target, release) do
-      {:ok, updated_target} = do_start(target, release)
+      {:ok, updated_target} = link_target_deployment(target, release)
 
       deployment =
         updated_target
@@ -544,7 +543,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
       cond do
         # Check if already started
         deployment.state == :started ->
-          {:ok, :already_started}
+          {:ok, :already_in_desired_state}
 
         # Check if being deleted
         deployment.state == :deleting ->
@@ -570,7 +569,60 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Core do
     end
   end
 
-  defp do_start(target, release) do
+  @doc """
+  Stops the release on the target device.
+
+  ## Parameters
+    - target: The deployment target struct.
+    - release: The release struct to be stopped.
+
+  ## Returns
+    - `{:ok, target}` if the stop command is successfully sent.
+    - `{:ok, :already_in_desired_state}` if the deployment is already in a stopped state.
+    - `{:error, :deployment_not_found}` if the deployment doesn't exist on the target.
+    - `{:error, :deployment_deleting}` if the deployment is being deleted.
+    - `{:error, :deployment_transitioning}` if the deployment is in a transitional state.
+    - `{:error, reason}` for any other errors.
+  """
+  def stop(target, release) do
+    if application_deployed?(target, release) do
+      {:ok, updated_target} = link_target_deployment(target, release)
+
+      deployment =
+        updated_target
+        |> Ash.load!([:deployment], tenant: updated_target.tenant_id)
+        |> Map.get(:deployment)
+
+      cond do
+        # Check if already stopped
+        deployment.state == :stopped ->
+          {:ok, :already_in_desired_state}
+
+        # Check if being deleted
+        deployment.state == :deleting ->
+          {:error, :deployment_deleting}
+
+        # Check if in a transitional state
+        deployment.state in [:starting, :stopping] ->
+          {:error, :deployment_transitioning}
+
+        # Stop the deployment
+        true ->
+          deployment_result =
+            deployment
+            |> Ash.Changeset.for_update(:stop, %{}, tenant: updated_target.tenant_id)
+            |> Ash.update()
+
+          with {:ok, _deployment} <- deployment_result do
+            {:ok, updated_target}
+          end
+      end
+    else
+      {:error, :deployment_not_found}
+    end
+  end
+
+  defp link_target_deployment(target, release) do
     target = update_target_latest_attempt!(target)
 
     device =

--- a/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
@@ -285,11 +285,8 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Executor do
            new_data.deployment_mechanism,
            new_data.operation_type
          ) do
-      {:ok, :already_deployed} ->
-        {:keep_state, new_data, internal_event({:already_deployed, target})}
-
-      {:ok, :already_started} ->
-        {:keep_state, new_data, internal_event({:already_deployed, target})}
+      {:ok, :already_in_desired_state} ->
+        {:keep_state, new_data, internal_event({:already_in_desired_state, target})}
 
       {:ok, %DeploymentTarget{} = target} ->
         {:keep_state, new_data, internal_event({:deployed, target})}
@@ -303,7 +300,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Executor do
     end
   end
 
-  def handle_event(:internal, {:already_deployed, target}, :deployment, data) do
+  def handle_event(:internal, {:already_in_desired_state, target}, :deployment, data) do
     # The target already has the operation completed, just log and mark it as successful
     log_operation_already_completed(data.operation_type, target.device_id)
     _ = Core.mark_target_as_successful!(target)


### PR DESCRIPTION
Implement support for the `stop` operation type in deployment campaigns. The `stop` operation checks if a deployment exists and is in an appropriate state before stopping it, with proper error handling for cases like missing deployments or deployments in transitional states.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
