### PR TITLE
feat: implement retry logic for all deployment campaign operation types

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_mechanism/lazy/executor.ex
@@ -564,7 +564,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentMechanism.Lazy.Executor do
       |> Core.increase_retry_count!()
       |> Core.update_target_latest_attempt!(DateTime.utc_now())
 
-    case Core.retry_target_deployment(target) do
+    case Core.retry_target_operation(target, data.operation_type) do
       :ok ->
         # Setup a timeout for the Deployment retry
         action = setup_retry_timeout(data.tenant_id, target, data.deployment_mechanism)

--- a/backend/test/edgehog/deployment_campaigns/lazy/core_test.exs
+++ b/backend/test/edgehog/deployment_campaigns/lazy/core_test.exs
@@ -52,7 +52,7 @@ defmodule Edgehog.DeploymentCampaigns.Lazy.CoreTest do
         :ok
       end)
 
-      assert :ok = Core.retry_target_deployment(target)
+      assert :ok = Core.retry_target_operation(target, :deploy)
     end
 
     test "fails if Astarte API replies with a failure", ctx do
@@ -64,7 +64,7 @@ defmodule Edgehog.DeploymentCampaigns.Lazy.CoreTest do
         {:error, %AstarteAPIError{status: 500, response: "Internal server error"}}
       end)
 
-      assert {:error, reason} = Core.retry_target_deployment(target)
+      assert {:error, reason} = Core.retry_target_operation(target, :deploy)
 
       assert %Invalid{
                errors: [


### PR DESCRIPTION
The retry mechanism only handled deploy operations. Refactor the retry logic to support multiple operation types (`deploy`, `upgrade`, `start`, `stop`, `delete`) through a modular architecture.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
