### PR TITLE
ci: compile first, test later

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -24,18 +24,18 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'backend/**'
-    - '.tool-versions'
-    - '.github/workflows/backend-test.yaml'
+      - "backend/**"
+      - ".tool-versions"
+      - ".github/workflows/backend-test.yaml"
     branches:
-    - 'main'
-    - 'release-*'
+      - "main"
+      - "release-*"
   # Run on pull requests matching apps
   pull_request:
     paths:
-    - 'backend/**'
-    - '.tool-versions'
-    - '.github/workflows/backend-test.yaml'
+      - "backend/**"
+      - ".tool-versions"
+      - ".github/workflows/backend-test.yaml"
 
 env:
   MIX_ENV: test
@@ -43,248 +43,193 @@ env:
 
 defaults:
   run:
-    # Define the default working-directory for all run steps
-    working-directory: backend
+    shell: bash
+    working-directory: ./backend
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-22.04
+  build-test:
+    name: Build TEST
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      with:
-        show-progress: false
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-compile@main # main
+        with:
+          working-directory: backend
+          mix-env: test
+          args: "--warnings-as-errors"
 
-    - name: Install OTP and Elixir
-      uses: erlef/setup-beam@v1
-      id: beam
-      with:
-        version-file: .tool-versions
-        version-type: strict
+  formatter:
+    name: Code formatting
+    runs-on: ubuntu-latest
+    needs:
+      - build-test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-format@main
+        with:
+          working-directory: backend
+          mix-env: test
 
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          backend/deps
-          backend/_build
-        key: "${{ runner.os }}-\
-              otp-${{ steps.beam.outputs.otp-version }}-\
-              elixir-${{ steps.beam.outputs.elixir-version }}-\
-              ${{ hashFiles('backend/mix.lock') }}"
+  dialyzer:
+    name: Dialyzer
+    runs-on: ubuntu-latest
+    needs:
+      - build-test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-dialyzer@main
+        with:
+          working-directory: backend
+          mix-env: test
+  credo:
+    name: Credo
+    runs-on: ubuntu-latest
+    needs:
+      - build-test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-credo@main
+        with:
+          working-directory: backend
+          mix-env: test
 
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        mix deps.get --only test
-        mix deps.compile
-
-    - name: Check formatting
-      run: mix format --check-formatted
-
-    - name: Run Credo code analysis
-      run: mix credo --strict
-
-    - name: Check for unused dependencies
-      run: mix do deps.get, deps.unlock --check-unused
-
-    - name: Compile with --warnings-as-errors
-      run: mix compile --warnings-as-errors --force
-
-    # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
-    # Cache key based on Elixir & Erlang version (also useful when running in matrix)
-    - name: Cache Dialyzer's PLT
-      uses: actions/cache/restore@v4
-      id: plt_cache
-      with:
-        key: "${{ runner.os }}-\
-              otp-${{ steps.beam.outputs.otp-version }}-\
-              elixir-${{ steps.beam.outputs.elixir-version }}-\
-              dialyzer-plt"
-        path: backend/priv/plts
-
-    # Create PLTs if no cache was found
-    - name: Create PLTs
-      if: steps.plt_cache.outputs.cache-hit != 'true'
-      run: mix dialyzer --plt
-
-    # By default, the GitHub Cache action will only save the cache if all steps in the job succeed,
-    # so we separate the cache restore and save steps in case running dialyzer fails.
-    - name: Save PLT cache
-      uses: actions/cache/save@v4
-      if: steps.plt_cache.outputs.cache-hit != 'true'
-      id: plt_cache_save
-      with:
-        key: "${{ steps.plt_cache.outputs.cache-primary-key }}"
-        path: backend/priv/plts
-
-    - name: Run dialyzer
-      run: mix dialyzer --format github
-
-  test-coverage:
-    name: Build and Test
+  test:
+    name: Test
+    needs: build-test
     strategy:
       matrix:
-        postgres: [13, 14, 15, 16, 17, 18]
-    env:
-      postgres_version_uploading_to_coveralls: 18
-    runs-on: ubuntu-22.04
+        postgres: [13, 14, 15, 16, 17]
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}
         env:
           POSTGRES_PASSWORD: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      with:
-        show-progress: false
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-test@main
+        with:
+          working-directory: backend
+          mix-env: test
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: postgres
 
-    - name: Install OTP and Elixir
-      uses: erlef/setup-beam@v1
-      id: beam
-      with:
-        version-file: .tool-versions
-        version-type: strict
-
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          backend/deps
-          backend/_build
-        key: "${{ runner.os }}-\
-              otp-${{ steps.beam.outputs.otp-version }}-\
-              elixir-${{ steps.beam.outputs.elixir-version }}-\
-              ${{ hashFiles('backend/mix.lock') }}"
-
-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        mix deps.get --only test
-        mix deps.compile
-
-    # Only send upload coverage from a single test in the matrix
-    - name: Test and upload coverage
-      if: matrix.postgres == env.postgres_version_uploading_to_coveralls
-      run: mix coveralls.github -o coverage_results --warnings-as-errors
-
-    - name: Test
-      if: matrix.postgres != env.postgres_version_uploading_to_coveralls
-      run: mix test
+  coverage:
+    name: Coverage
+    needs: build-test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: team-alembic/staple-actions/actions/mix-task@main
+        with:
+          working-directory: backend
+          mix-env: test
+          task: coveralls.github -o coverage_results --warnings-as-errors
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: postgres
 
   integration-minio:
     name: Integration tests using MinIO
-    runs-on: ubuntu-22.04
+    needs: build-test
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      with:
-        show-progress: false
+      - uses: actions/checkout@v5
+      - name: Start MinIO
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest \
+            server /data --console-address ":9001"
 
-    - name: Start MinIO
-      run: |
-        docker run -d \
-          --name minio \
-          -p 9000:9000 \
-          -p 9001:9001 \
-          -e MINIO_ROOT_USER=minioadmin \
-          -e MINIO_ROOT_PASSWORD=minioadmin \
-          minio/minio:latest \
-          server /data --console-address ":9001"
+      - name: Wait for MinIO to be ready
+        run: |
+          echo "Waiting for MinIO to start..."
+          for i in {1..30}; do
+            if curl -f http://localhost:9000/minio/health/live 2>/dev/null; then
+              echo "MinIO is ready!"
+              break
+            fi
+            echo "Attempt $i/30: MinIO not ready yet..."
+            sleep 2
+          done
 
-    - name: Wait for MinIO to be ready
-      run: |
-        echo "Waiting for MinIO to start..."
-        for i in {1..30}; do
-          if curl -f http://localhost:9000/minio/health/live 2>/dev/null; then
-            echo "MinIO is ready!"
-            break
-          fi
-          echo "Attempt $i/30: MinIO not ready yet..."
-          sleep 2
-        done
+      - name: Bucket setup
+        run: |
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x ./mc
+          ./mc alias set minio http://localhost:9000 minioadmin minioadmin;
+          ./mc mb minio/edgehog;
+          ./mc anonymous set download minio/edgehog;
 
-    - name: Bucket setup
-      run: |
-        wget https://dl.min.io/client/mc/release/linux-amd64/mc
-        chmod +x ./mc
-        ./mc alias set minio http://localhost:9000 minioadmin minioadmin;
-        ./mc mb minio/edgehog;
-        ./mc anonymous set download minio/edgehog;
-
-    - name: Install OTP and Elixir
-      uses: erlef/setup-beam@v1
-      id: beam
-      with:
-        version-file: .tool-versions
-        version-type: strict
-
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          backend/deps
-          backend/_build
-        key: "${{ runner.os }}-\
-              otp-${{ steps.beam.outputs.otp-version }}-\
-              elixir-${{ steps.beam.outputs.elixir-version }}-\
-              ${{ hashFiles('backend/mix.lock') }}"
-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        mix deps.get --only test
-        mix deps.compile
-
-    - name: Test
-      env:
-        STORAGE_TYPE: s3
-        S3_ACCESS_KEY_ID: minioadmin
-        S3_SECRET_ACCESS_KEY: minioadmin
-        S3_REGION: local
-        S3_SCHEME: http://
-        S3_HOST: localhost
-        S3_PORT: 9000
-        S3_BUCKET: edgehog
-        S3_ASSET_HOST: http://localhost:9000/edgehog
-      run: mix test --only integration_storage
+      - uses: team-alembic/staple-actions/actions/mix-task@main
+        with:
+          mix-env: test
+          working-directory: backend
+          task: test --only integration_storage
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: postgres
+          STORAGE_TYPE: s3
+          S3_ACCESS_KEY_ID: minioadmin
+          S3_SECRET_ACCESS_KEY: minioadmin
+          S3_REGION: local
+          S3_SCHEME: http://
+          S3_HOST: localhost
+          S3_PORT: 9000
+          S3_BUCKET: edgehog
+          S3_ASSET_HOST: http://localhost:9000/edgehog
 
   integration-azurite:
     name: Integration tests using Azurite
-    runs-on: ubuntu-22.04
+    needs: build-test
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -293,73 +238,46 @@ jobs:
       azurite:
         image: mcr.microsoft.com/azure-storage/azurite
         ports:
-        - "10000:10000"
-        - "10001:10001"
-        - "10002:10002"
+          - "10000:10000"
+          - "10001:10001"
+          - "10002:10002"
         options: >-
-         --health-cmd "nc -z 127.0.0.1 10000"
-         --health-interval 10s
-         --health-timeout 5s
-         --health-retries 5
+          --health-cmd "nc -z 127.0.0.1 10000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      with:
-        show-progress: false
+      - uses: actions/checkout@v5
+      - name: Storage setup
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
+        run: |
+          # install az-cli
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-    - name: Storage setup
-      env:
-        AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
-      run: |
-        # install az-cli
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          # setup container
+          az storage container create --name edgehog --connection-string $AZURE_STORAGE_CONNECTION_STRING
+          az storage container set-permission --name edgehog --public-access blob --connection-string $AZURE_STORAGE_CONNECTION_STRING
 
-        # setup container
-        az storage container create --name edgehog --connection-string $AZURE_STORAGE_CONNECTION_STRING
-        az storage container set-permission --name edgehog --public-access blob --connection-string $AZURE_STORAGE_CONNECTION_STRING
-
-    - name: Install OTP and Elixir
-      uses: erlef/setup-beam@v1
-      id: beam
-      with:
-        version-file: .tool-versions
-        version-type: strict
-
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          backend/deps
-          backend/_build
-        key: "${{ runner.os }}-\
-              otp-${{ steps.beam.outputs.otp-version }}-\
-              elixir-${{ steps.beam.outputs.elixir-version }}-\
-              ${{ hashFiles('backend/mix.lock') }}"
-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        mix deps.get --only test
-        mix deps.compile
-
-    - name: Test
-      env:
-        STORAGE_TYPE: azure
-        AZURE_BLOB_ENDPOINT: "http://localhost:10000/devstoreaccount1"
-        AZURE_CONTAINER: "edgehog"
-        AZURE_STORAGE_ACCOUNT_KEY: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-        AZURE_STORAGE_ACCOUNT_NAME: "devstoreaccount1"
-      run: mix test --only integration_storage
+      - uses: team-alembic/staple-actions/actions/mix-task@main
+        with:
+          mix-env: test
+          working-directory: backend
+          task: test --only integration_storage
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: postgres
+          STORAGE_TYPE: azure
+          AZURE_BLOB_ENDPOINT: "http://localhost:10000/devstoreaccount1"
+          AZURE_CONTAINER: "edgehog"
+          AZURE_STORAGE_ACCOUNT_KEY: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+          AZURE_STORAGE_ACCOUNT_NAME: "devstoreaccount1"
 
   build-docker-image:
     name: Build Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          show-progress: false
-
+      - uses: actions/checkout@v5
       - name: Build Docker image
         run: docker build .


### PR DESCRIPTION
We used to run tests and linting independently. It was sound, but it meant that the CI re-compiled the code (and dependencies) for each job (which meant ~10jobs per PR).

## Alembic CI workflows
Taking inspiration from Ash's CIs themselves, we can use https://github.com/team-alembic/staple-actions. These workflow allow for parallel working and take care of handling cache themselves

## New CI workflows
- `Build DEV` and `Build TEST` separated, the two environments are needed for different jobs
- `Dialyzer`, `Credo` and `Code formatting` as separated jobs. they all depend on compilation and run after that
- `Test` matrix and `Coverage` separated. `Coverage` is its own job running as before with postgres 18. both depend on test compilation
- `Integration Test*` didn't change much, only compilation is demanded to the test build

## Benefits
Devs can focus on what's wrong since dyalizer, credo and format are on different jobs. Testing still fails if one of them fails, but we have more control on coverage reports.