### PR TITLE
ci: expand docs workflow triggers to include admin API and Ash resources

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2021-2024 SECO Mind Srl
+# Copyright 2021-2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,11 @@ on:
     # Documentation pages
     - 'doc/**'
     # Schema files
+    - 'backend/lib/edgehog_web/admin_api/**'
     - 'backend/lib/edgehog_web/schema.ex'
     - 'backend/lib/edgehog_web/schema/**'
+    # Ash resources, including new Ash domains
+    - 'backend/lib/edgehog/**'
     - 'backend/mix.exs'
     - 'backend/mix.lock'
     # SpectaQL configuration file


### PR DESCRIPTION
The docs workflow now monitors additional backend paths to ensure documentation is regenerated when the GraphQL schema changes due to modifications in:
- Admin API modules that define GraphQL types and operations
- Ash resources and domains that are exposed through the schema

This prevents outdated API documentation when backend changes are made outside the previously monitored schema directory.

Also updates copyright year to 2025.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
