### PR TITLE
refactor: remove custom Ash notifier events

### DIFF
--- a/backend/lib/edgehog/containers/deployment/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment/deployment.ex
@@ -282,7 +282,6 @@ defmodule Edgehog.Containers.Deployment do
     module EdgehogWeb.Endpoint
 
     publish :deploy, [[:id, "*"]]
-    publish :destroy_and_gc, [[:id, "*"]]
     publish :just_create, [[:id, "*"]]
 
     publish :mark_as_sent, [[:id, "*"]]
@@ -291,42 +290,7 @@ defmodule Edgehog.Containers.Deployment do
     publish :mark_as_timed_out, [[:id, "*"]]
     publish :append_event, [[:id, "*"]]
     publish :maybe_run_ready_actions, [[:id, "*"]]
-
-    transform fn notification ->
-      deployment = notification.data
-      action = notification.action.name
-
-      event_type =
-        cond do
-          Map.get(notification.metadata || %{}, :custom_event) == :deployment_ready ->
-            :deployment_ready
-
-          action in [:deploy, :just_create] ->
-            :deployment_created
-
-          action in [
-            :mark_as_sent,
-            :mark_as_started,
-            :mark_as_stopped,
-            :append_event,
-            :maybe_run_ready_actions
-          ] ->
-            :deployment_updated
-
-          action in [
-            :mark_as_timed_out
-          ] ->
-            :deployment_timeout
-
-          action == :destroy_and_gc ->
-            :deployment_deleted
-
-          true ->
-            :unknown_event
-        end
-
-      {event_type, deployment}
-    end
+    publish :destroy_and_gc, [[:id, "*"]]
   end
 
   postgres do

--- a/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
+++ b/backend/lib/edgehog/os_management/ota_operation/ota_operation.ex
@@ -223,30 +223,9 @@ defmodule Edgehog.OSManagement.OTAOperation do
 
     publish :create_managed, [[:id, "*"]]
     publish :manual, [[:id, "*"]]
+
     publish :mark_as_timed_out, [[:id, "*"]]
     publish :update_status, [[:id, "*"]]
-
-    transform fn notification ->
-      ota_operation = notification.data
-      action = notification.action.name
-
-      event_type =
-        cond do
-          action in [:create_managed, :manual] ->
-            :ota_operation_created
-
-          action in [
-            :mark_as_timed_out,
-            :update_status
-          ] ->
-            :ota_operation_updated
-
-          true ->
-            :unknown_event
-        end
-
-      {event_type, ota_operation}
-    end
   end
 
   postgres do

--- a/backend/test/edgehog/os_management_test.exs
+++ b/backend/test/edgehog/os_management_test.exs
@@ -83,7 +83,12 @@ defmodule Edgehog.OSManagementTest do
                  tenant: tenant
                )
 
-      assert_receive %{payload: {:ota_operation_created, ^ota_operation}}
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "create_managed",
+        payload: %Ash.Notifier.Notification{
+          data: ^ota_operation
+        }
+      }
     end
 
     test "create_managed_ota_operation/2 fails if the Astarte request fails", %{

--- a/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/core_test.exs
@@ -659,7 +659,12 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.CoreTest do
       # Generate a publish on the PubSub
       OSManagement.update_ota_operation_status!(ota_operation, "Acknowledged")
 
-      assert_receive %{payload: {:ota_operation_updated, %OTAOperation{status: :acknowledged}}}
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "update_status",
+        payload: %Ash.Notifier.Notification{
+          data: %OTAOperation{status: :acknowledged}
+        }
+      }
     end
   end
 

--- a/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_manual_ota_operation_test.exs
@@ -107,8 +107,9 @@ defmodule EdgehogWeb.Schema.Mutation.CreateManualOTAOperationTest do
 
       ota_operation = [tenant: tenant] |> create_ota_operation_mutation() |> extract_result!()
 
-      assert_receive %{
-        payload: {:ota_operation_created, %OTAOperation{} = ota_operation_event}
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "manual",
+        payload: %Ash.Notifier.Notification{data: %OTAOperation{} = ota_operation_event}
       }
 
       assert AshGraphql.Resource.encode_relay_id(ota_operation_event) == ota_operation["id"]


### PR DESCRIPTION
This refactor removes the previous `transform` based custom events from Ash notifiers and updates all event handling to rely solely on native Phoenix.Socket.Broadcast notifications.