### PR TITLE
fix: Rename tables to follow plural naming convention

### DIFF
--- a/backend/lib/edgehog/deployment_campaigns/deployment_campaign.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_campaign.ex
@@ -218,7 +218,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentCampaign do
   end
 
   postgres do
-    table "deployment_campaign"
+    table "deployment_campaigns"
 
     references do
       reference :channel,

--- a/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
+++ b/backend/lib/edgehog/deployment_campaigns/deployment_target.ex
@@ -258,7 +258,7 @@ defmodule Edgehog.DeploymentCampaigns.DeploymentTarget do
   end
 
   postgres do
-    table "deployment_target"
+    table "deployment_targets"
 
     references do
       reference :device, on_delete: :delete

--- a/backend/priv/repo/migrations/20251114084851_rename_deployment_tables_to_plural.exs
+++ b/backend/priv/repo/migrations/20251114084851_rename_deployment_tables_to_plural.exs
@@ -1,0 +1,111 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Repo.Migrations.RenameDeploymentTablesToPlural do
+  @moduledoc """
+  Renames deployment tables to follow the plural naming convention.
+
+  This migration renames existing tables instead of creating new ones:
+  - deployment_target -> deployment_targets
+  - deployment_campaign -> deployment_campaigns
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # Rename regular tables
+    rename table(:deployment_target), to: table(:deployment_targets)
+    rename table(:deployment_campaign), to: table(:deployment_campaigns)
+
+    # Rename constraints for deployment_target -> deployment_targets
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_target_tenant_id_fkey TO deployment_targets_tenant_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_target_deployment_campaign_id_fkey TO deployment_targets_deployment_campaign_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_target_device_id_fkey TO deployment_targets_device_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_target_deployment_id_fkey TO deployment_targets_deployment_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_target_pkey TO deployment_targets_pkey"
+
+    # Rename constraints for deployment_campaign -> deployment_campaigns
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaign_tenant_id_fkey TO deployment_campaigns_tenant_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaign_release_id_fkey TO deployment_campaigns_release_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaign_channel_id_fkey TO deployment_campaigns_channel_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaign_target_release_id_fkey TO deployment_campaigns_target_release_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaign_pkey TO deployment_campaigns_pkey"
+
+    # Rename indexes for deployment_targets
+    execute "ALTER INDEX deployment_target_tenant_id_index RENAME TO deployment_targets_tenant_id_index"
+
+    execute "ALTER INDEX deployment_target_id_tenant_id_index RENAME TO deployment_targets_id_tenant_id_index"
+
+    # Rename indexes for deployment_campaigns
+    execute "ALTER INDEX deployment_campaign_tenant_id_index RENAME TO deployment_campaigns_tenant_id_index"
+
+    execute "ALTER INDEX deployment_campaign_id_tenant_id_index RENAME TO deployment_campaigns_id_tenant_id_index"
+
+    execute "ALTER INDEX deployment_campaign_tenant_id_channel_id_index RENAME TO deployment_campaigns_tenant_id_channel_id_index"
+  end
+
+  def down do
+    # Revert index names for deployment_campaigns
+    execute "ALTER INDEX deployment_campaigns_tenant_id_channel_id_index RENAME TO deployment_campaign_tenant_id_channel_id_index"
+
+    execute "ALTER INDEX deployment_campaigns_id_tenant_id_index RENAME TO deployment_campaign_id_tenant_id_index"
+
+    execute "ALTER INDEX deployment_campaigns_tenant_id_index RENAME TO deployment_campaign_tenant_id_index"
+
+    # Revert index names for deployment_targets
+    execute "ALTER INDEX deployment_targets_id_tenant_id_index RENAME TO deployment_target_id_tenant_id_index"
+
+    execute "ALTER INDEX deployment_targets_tenant_id_index RENAME TO deployment_target_tenant_id_index"
+
+    # Revert constraint names for deployment_campaigns
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaigns_pkey TO deployment_campaign_pkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaigns_target_release_id_fkey TO deployment_campaign_target_release_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaigns_channel_id_fkey TO deployment_campaign_channel_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaigns_release_id_fkey TO deployment_campaign_release_id_fkey"
+
+    execute "ALTER TABLE deployment_campaigns RENAME CONSTRAINT deployment_campaigns_tenant_id_fkey TO deployment_campaign_tenant_id_fkey"
+
+    # Revert constraint names for deployment_targets
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_targets_pkey TO deployment_target_pkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_targets_deployment_id_fkey TO deployment_target_deployment_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_targets_device_id_fkey TO deployment_target_device_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_targets_deployment_campaign_id_fkey TO deployment_target_deployment_campaign_id_fkey"
+
+    execute "ALTER TABLE deployment_targets RENAME CONSTRAINT deployment_targets_tenant_id_fkey TO deployment_target_tenant_id_fkey"
+
+    # Revert regular tables
+    rename table(:deployment_campaigns), to: table(:deployment_campaign)
+    rename table(:deployment_targets), to: table(:deployment_target)
+  end
+end

--- a/backend/priv/resource_snapshots/repo/deployment_campaigns/20251114084851.json
+++ b/backend/priv/resource_snapshots/repo/deployment_campaigns/20251114084851.json
@@ -1,0 +1,315 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "status",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "outcome",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "deployment_mechanism",
+      "type": "map"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"deploy\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "operation_type",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "start_timestamp",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "completion_timestamp",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "tenant_id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "deployment_campaigns_tenant_id_fkey",
+        "on_delete": "delete",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "tenants"
+      },
+      "scale": null,
+      "size": null,
+      "source": "tenant_id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_campaigns_release_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "application_releases"
+      },
+      "scale": null,
+      "size": null,
+      "source": "release_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_campaigns_target_release_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "application_releases"
+      },
+      "scale": null,
+      "size": null,
+      "source": "target_release_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": true,
+        "match_type": "full",
+        "match_with": {
+          "tenant_id": "tenant_id"
+        },
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_campaigns_channel_id_fkey",
+        "on_delete": "nothing",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "channels"
+      },
+      "scale": null,
+      "size": null,
+      "source": "channel_id",
+      "type": "integer"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "id",
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "id"
+        },
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": true,
+      "using": null,
+      "where": null
+    },
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": false,
+      "using": null,
+      "where": null
+    }
+  ],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "9B01F3BE8103CA7CD7766C17C1529B433297634B0E0ABB8C026A5F3BAFC5D9BA",
+  "identities": [],
+  "multitenancy": {
+    "attribute": "tenant_id",
+    "global": false,
+    "strategy": "attribute"
+  },
+  "repo": "Elixir.Edgehog.Repo",
+  "schema": null,
+  "table": "deployment_campaigns"
+}

--- a/backend/priv/resource_snapshots/repo/deployment_targets/20251114084851.json
+++ b/backend/priv/resource_snapshots/repo/deployment_targets/20251114084851.json
@@ -1,0 +1,277 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "status",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "retry_count",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "latest_attempt",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "completion_timestamp",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "tenant_id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "deployment_targets_tenant_id_fkey",
+        "on_delete": "delete",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "tenants"
+      },
+      "scale": null,
+      "size": null,
+      "source": "tenant_id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_targets_deployment_campaign_id_fkey",
+        "on_delete": "delete",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "deployment_campaigns"
+      },
+      "scale": null,
+      "size": null,
+      "source": "deployment_campaign_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_targets_device_id_fkey",
+        "on_delete": "delete",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "devices"
+      },
+      "scale": null,
+      "size": null,
+      "source": "device_id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": "tenant_id",
+          "global": false,
+          "strategy": "attribute"
+        },
+        "name": "deployment_targets_deployment_id_fkey",
+        "on_delete": "nilify",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "application_deployments"
+      },
+      "scale": null,
+      "size": null,
+      "source": "deployment_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "id",
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "id"
+        },
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": true,
+      "using": null,
+      "where": null
+    },
+    {
+      "all_tenants?": true,
+      "concurrently": false,
+      "error_fields": [
+        "tenant_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "tenant_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": null,
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": false,
+      "using": null,
+      "where": null
+    }
+  ],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "8EFBD957B8F20F1909B86F89510F333F6BFE7D933879CA44A6AD0630712CBB3F",
+  "identities": [],
+  "multitenancy": {
+    "attribute": "tenant_id",
+    "global": false,
+    "strategy": "attribute"
+  },
+  "repo": "Elixir.Edgehog.Repo",
+  "schema": null,
+  "table": "deployment_targets"
+}


### PR DESCRIPTION
Rename all tables to use consistent plural naming:
- `deployment_target` → `deployment_targets`,
- `deployment_campaign` → `deployment_campaigns`,

Also rename all associated constraints and indexes to match the new table names for consistency. This ensures the database schema follows PostgreSQL best practices with plural table names throughout.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
