### PR TITLE
fix: Use Node.js 22 for SpectaQL to avoid compatibility issues

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -92,6 +92,10 @@ jobs:
     - name: Extract GraphQL Schema
       working-directory: ./edgehog/backend
       run: mix absinthe.schema.sdl --schema EdgehogWeb.Schema
+    - name: Setup Node.js 22 for SpectaQL
+      uses: actions/setup-node@v6
+      with:
+        node-version: "22"
     - name: Install SpectaQL
       run: npm install -g spectaql
     - name: Build SpectaQL Docs


### PR DESCRIPTION
SpectaQL 3.0.5 has compatibility issues with Node.js 24, resulting in "arrangeData is not a function" errors. This change temporarily switches to Node.js 22 specifically for the SpectaQL documentation generation steps, while keeping Node.js 24 for the rest of the workflow.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
