### PR TITLE
fix: icon alignment in field help

### DIFF
--- a/frontend/src/components/FieldHelp.tsx
+++ b/frontend/src/components/FieldHelp.tsx
@@ -68,19 +68,24 @@ interface FieldHelpProps {
   id: FieldKey;
   size?: number;
   children: React.ReactNode;
+  itemsAlignment?: "baseline" | "center" | "start" | "end";
 }
 
-const FieldHelp = ({ id, size = 16, children }: FieldHelpProps) => {
+const FieldHelp = ({
+  id,
+  size = 16,
+  children,
+  itemsAlignment = "baseline",
+}: FieldHelpProps) => {
   const explanation = getFieldExplanation(id);
 
   return (
-    <div className="d-flex justify-content-center align-items-center gap-2">
+    <div
+      className={`d-flex justify-content-center align-items-${itemsAlignment} gap-2`}
+    >
       <div className="flex-grow-1 w-100">{children}</div>
 
-      <div
-        data-tooltip-id={`tooltip-${id}`}
-        className="d-inline-flex align-items-center"
-      >
+      <div data-tooltip-id={`tooltip-${id}`}>
         <Icon
           icon={"faCircleQuestion"}
           style={{

--- a/frontend/src/forms/ContainerForm.tsx
+++ b/frontend/src/forms/ContainerForm.tsx
@@ -1181,7 +1181,7 @@ const ContainerForm = ({
                 />
               }
             >
-              <FieldHelp id="env">
+              <FieldHelp id="env" itemsAlignment="center">
                 <Controller
                   control={control}
                   name={`containers.${index}.env`}
@@ -1227,7 +1227,7 @@ const ContainerForm = ({
               />
             }
           >
-            <FieldHelp id="deviceMappings">
+            <FieldHelp id="deviceMappings" itemsAlignment="center">
               <div className="p-3 mb-3 bg-light border rounded">
                 <DeviceMappingsFormInput
                   editableProps={dmFormInputProps}


### PR DESCRIPTION
Field help icon remains aligned with the input field regardless of error rendering.

<details>
<summary>
Screenshots
</summary>

Before fix:

<img width="1627" height="267" alt="image" src="https://github.com/user-attachments/assets/980b2d0c-746e-4484-8a5b-027d330d5526" />

After fix:

<img width="1616" height="227" alt="image" src="https://github.com/user-attachments/assets/e6704d7f-477d-41e6-a889-023ab89007b3" />

<img width="1626" height="472" alt="image" src="https://github.com/user-attachments/assets/232a134c-44b6-4682-855a-7e947c6aba32" />

</details>