### PR TITLE
refactor: remove horizontal line highlights in Monaco Editor

### DIFF
--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -122,6 +122,7 @@ const MonacoEditor = ({
             horizontal: "hidden",
             alwaysConsumeMouseWheel: false,
           },
+          renderLineHighlight: "none",
         }}
       />
       {languageError && (


### PR DESCRIPTION
Monaco Editor doesn't show horizontal line highlights which leads to a cleaner UI.

<details>
<summary>
Screenshots
</summary>

Old:

<img width="1627" height="267" alt="Screenshot from 2025-11-19 13-15-42" src="https://github.com/user-attachments/assets/0c823a7d-3e0a-4e80-a7e6-f5f5c3ecec93" />

<img width="1627" height="267" alt="Screenshot from 2025-11-19 13-15-56" src="https://github.com/user-attachments/assets/8f382840-088a-4319-bb3e-39c96d2b12b1" />

New:

<img width="1627" height="267" alt="Screenshot from 2025-11-19 13-16-39" src="https://github.com/user-attachments/assets/28310683-25a0-4fa4-8f8b-3cf7f135f764" />

<img width="1627" height="267" alt="Screenshot from 2025-11-19 13-16-26" src="https://github.com/user-attachments/assets/5894c9bf-9ec0-4d4a-9bd7-4d15555ab4bf" />

</details>