### PR TITLE
Show application name in breadcrumbs on create release page

### DIFF
--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -2731,7 +2731,7 @@
     "defaultMessage": "Could not create the release, please try again."
   },
   "pages.ReleaseCreate.title": {
-    "defaultMessage": "Create Release"
+    "defaultMessage": "Create Release for {applicationName}"
   },
   "pages.SystemModel.deleteModal.description": {
     "defaultMessage": "This action cannot be undone. This will permanently delete the System Model <bold>{systemModel}</bold>.",


### PR DESCRIPTION
The application name is now displayed in the breadcrumbs within the page header on the Create Release page, providing better context for users.

<img width="1916" height="455" alt="image" src="https://github.com/user-attachments/assets/56287390-ffb8-4ce2-8a2a-4b6d69217ea5" />
