### PR TITLE
fix: Reused container data removal

### DIFF
--- a/frontend/src/forms/ContainerForm.tsx
+++ b/frontend/src/forms/ContainerForm.tsx
@@ -66,7 +66,6 @@ type ContainerFormProps = {
   control: Control<ReleaseInputData>;
   isImported?: boolean;
   isModified?: boolean;
-  markUserInteraction: () => void;
 };
 
 // react-hook-form returns targetGroups validation error as Array<Record<string, FieldError>> type
@@ -124,7 +123,6 @@ const ContainerForm = ({
   control,
   isImported = false,
   isModified = false,
-  markUserInteraction,
 }: ContainerFormProps) => {
   const volumesForm = useFieldArray({
     control,
@@ -255,7 +253,6 @@ const ContainerForm = ({
                         value={selectedOption}
                         onChange={(option) => {
                           field.onChange(option ? option.value : null);
-                          markUserInteraction();
                         }}
                         options={imageCredentials}
                         isClearable
@@ -352,7 +349,6 @@ const ContainerForm = ({
                         value={mappedValue}
                         onChange={(selected) => {
                           onChange(selected.map((s) => ({ id: s.value })));
-                          markUserInteraction();
                         }}
                         onBlur={onBlur}
                         options={networks}
@@ -390,14 +386,10 @@ const ContainerForm = ({
 
                     const handleAddExtraHost = () => {
                       field.onChange([...extraHosts, ""]);
-
-                      markUserInteraction();
                     };
 
                     const handleDeleteExtraHost = (i: number) => {
                       field.onChange(extraHosts.filter((_, idx) => idx !== i));
-
-                      markUserInteraction();
                     };
 
                     const handleChangeHost = (i: number, value: string) => {
@@ -406,8 +398,6 @@ const ContainerForm = ({
                       updated[i] = value;
 
                       field.onChange(updated);
-
-                      markUserInteraction();
                     };
 
                     return (
@@ -597,7 +587,6 @@ const ContainerForm = ({
                                         }
                                         onChange={(selected) => {
                                           field.onChange(selected?.value);
-                                          markUserInteraction();
                                         }}
                                         onBlur={field.onBlur}
                                         options={availableOptions}
@@ -711,7 +700,6 @@ const ContainerForm = ({
                         value={field.value ?? ""}
                         onChange={(value) => {
                           field.onChange(value ?? "");
-                          markUserInteraction();
                         }}
                         defaultValue={field.value || "[]"}
                         initialLines={1}
@@ -750,7 +738,6 @@ const ContainerForm = ({
                         value={field.value ?? ""}
                         onChange={(value) => {
                           field.onChange(value ?? "");
-                          markUserInteraction();
                         }}
                         defaultValue={field.value || "[]"}
                         initialLines={1}
@@ -1069,7 +1056,6 @@ const ContainerForm = ({
                         }))}
                         onChange={(selected) => {
                           onChange(selected.map((s) => s.id));
-                          markUserInteraction();
                         }}
                         onBlur={onBlur}
                         options={options}
@@ -1113,7 +1099,6 @@ const ContainerForm = ({
                         }))}
                         onChange={(selected) => {
                           onChange(selected.map((s) => s.id));
-                          markUserInteraction();
                         }}
                         onBlur={onBlur}
                         options={options}
@@ -1161,7 +1146,6 @@ const ContainerForm = ({
                         value={selectedOption}
                         onChange={(option) => {
                           field.onChange(option ? option.value : null);
-                          markUserInteraction();
                         }}
                         options={restartPolicyOptions}
                         isClearable
@@ -1194,7 +1178,6 @@ const ContainerForm = ({
                       }
                       onChange={(value) => {
                         field.onChange(value ?? "");
-                        markUserInteraction();
                       }}
                       defaultValue={
                         field.value && typeof field.value !== "string"

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -485,7 +485,7 @@ const CreateRelease = ({
     resolver: yupResolver(applicationSchema()),
   });
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append } = useFieldArray({
     control,
     name: "containers",
   });
@@ -510,15 +510,17 @@ const CreateRelease = ({
     >(null);
 
   const [showImportSuccess, setShowImportSuccess] = useState(false);
-  const [importedData, setImportedData] = useState<ReleaseInputData | null>(
-    null,
-  );
   const [justImported, setJustImported] = useState(false);
   const isImportingRef = useRef(false);
-  const userHasInteractedRef = useRef(false);
+  const importedContainersSnapshotRef = useRef<ContainerInput[]>([]);
 
   // Watch all form values to detect changes
   const formValues = useWatch({ control });
+
+  // Helper function to check if a specific container is imported
+  const isContainerImported = (containerIndex: number): boolean => {
+    return containerIndex < importedContainersSnapshotRef.current.length;
+  };
 
   // Helper function to check if a specific container is modified
   const isContainerModified = (containerIndex: number): boolean => {
@@ -527,32 +529,52 @@ const CreateRelease = ({
       return false;
     }
 
-    // Only show modified if user has actually interacted with the form
-    if (!userHasInteractedRef.current) {
+    if (!isContainerImported(containerIndex)) {
       return false;
     }
 
-    if (
-      !importedData?.containers?.[containerIndex] ||
-      !formValues?.containers?.[containerIndex]
-    ) {
+    const importedContainer =
+      importedContainersSnapshotRef.current[containerIndex];
+    const currentContainer = formValues?.containers?.[containerIndex];
+
+    if (!importedContainer || !currentContainer) {
       return false;
     }
 
-    // Simple JSON comparison - only after user interaction
-    const importedContainer = importedData.containers[containerIndex];
-    const currentContainer = formValues.containers[containerIndex];
-
+    // Simple JSON comparison - check if this specific container has changed
     return (
       JSON.stringify(importedContainer) !== JSON.stringify(currentContainer)
     );
   };
 
-  // Helper function to mark user interaction
-  const markUserInteraction = () => {
-    if (!isImportingRef.current && !justImported) {
-      userHasInteractedRef.current = true;
+  // Wrapper for remove that also updates imported containers tracking
+  const handleRemoveContainer = (index: number) => {
+    // Get current containers
+    const currentContainers = formValues.containers || [];
+
+    // Create new array without the removed container
+    const newContainers = currentContainers.filter((_, i) => i !== index);
+
+    // Update imported containers data if needed
+    if (index < importedContainersSnapshotRef.current.length) {
+      const newSnapshot = [...importedContainersSnapshotRef.current];
+      newSnapshot.splice(index, 1);
+      importedContainersSnapshotRef.current = newSnapshot;
     }
+
+    // Reset the containers field with the new array to clear any cached state
+    reset(
+      {
+        version: formValues.version || "",
+        requiredSystemModels: formValues.requiredSystemModels || [],
+        containers: newContainers,
+      },
+      {
+        keepErrors: false,
+        keepDirty: true,
+        keepTouched: false,
+      },
+    );
   };
 
   const parseJsonToStringArray = (jsonStr: string | undefined): string[] => {
@@ -624,8 +646,6 @@ const CreateRelease = ({
 
           onSubmit(submitData);
         })}
-        onChange={markUserInteraction}
-        onInput={markUserInteraction}
       >
         <Stack gap={2}>
           {showImportSuccess && (
@@ -690,7 +710,6 @@ const CreateRelease = ({
                     value={mappedValue}
                     onChange={(selected) => {
                       onChange(selected.map(({ value }) => ({ id: value })));
-                      markUserInteraction();
                     }}
                     onBlur={onBlur}
                     options={systemModelsOptions}
@@ -719,30 +738,21 @@ const CreateRelease = ({
           </Stack>
 
           {fields.map((field, index) => {
-            // Check if this container was imported (either by index or by checking if any containers were imported)
-            const hasImportedContainers = Boolean(
-              importedData?.containers?.length,
-            );
-            const isThisContainerImported =
-              hasImportedContainers &&
-              index < (importedData?.containers?.length || 0);
-
             return (
               <ContainerForm
                 key={field.id}
                 index={index}
                 register={register}
                 errors={errors}
-                remove={remove}
+                remove={handleRemoveContainer}
                 imageCredentials={imageCredentialsOptions}
                 networks={networkOptions}
                 volumes={volumeOptions}
                 control={control}
-                isImported={isThisContainerImported}
+                isImported={isContainerImported(index)}
                 isModified={
-                  isThisContainerImported && isContainerModified(index)
+                  isContainerImported(index) && isContainerModified(index)
                 }
-                markUserInteraction={markUserInteraction}
               />
             );
           })}
@@ -882,16 +892,22 @@ const CreateRelease = ({
             setJustImported(true);
             setShowImportSuccess(true);
 
-            // Immediately set imported data so tags can show
-            setImportedData(newFormData);
+            // Store the imported containers snapshot
+            importedContainersSnapshotRef.current = mappedContainers;
 
             // Use requestAnimationFrame to wait for the reset to complete
             requestAnimationFrame(() => {
               requestAnimationFrame(() => {
+                // After form has settled, take a snapshot of the actual form values
+                // This ensures we compare against what the form actually contains
+                const settledContainers = control._formValues.containers || [];
+                importedContainersSnapshotRef.current = JSON.parse(
+                  JSON.stringify(settledContainers),
+                );
+
                 // Clear flags after form reset is complete
                 isImportingRef.current = false;
                 setJustImported(false);
-                userHasInteractedRef.current = false; // Reset interaction flag
               });
             });
 


### PR DESCRIPTION
- Preserves the current version value during the import operation.
- Prevents removed reused container data from persisting when new containers are added, ensuring each new container starts with a clean slate
- Fix issue where modifying one imported container would mark all imported containers as modified due to global interaction tracking

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
