### PR TITLE
fix: Clear target release on version conflict

### DIFF
--- a/frontend/src/components/ReleaseSelect.tsx
+++ b/frontend/src/components/ReleaseSelect.tsx
@@ -159,7 +159,7 @@ const ReleaseSelect = ({
     }
 
     return releases;
-  }, [paginationData]);
+  }, [paginationData, isTarget, selectedApp, selectedRelease]);
 
   const getReleaseLabel = (release: ReleaseRecord) => release.version;
   const getReleaseValue = (release: ReleaseRecord) => release.id;
@@ -186,6 +186,7 @@ const ReleaseSelect = ({
         id: "components.ReleaseSelect.releaseOption",
         defaultMessage: "Search or select a release...",
       })}
+      isClearable
       options={releaseOptions}
       getOptionLabel={getReleaseLabel}
       getOptionValue={getReleaseValue}
@@ -278,6 +279,17 @@ const ReleaseSelectWrapper = ({
   }, [getApplication, selectedApp]);
 
   useEffect(fetchApplication, [fetchApplication]);
+
+  // Clear selected target release if selectedRelease is >= currently selected target release
+  useEffect(() => {
+    if (
+      controllerProps.value &&
+      selectedRelease &&
+      semver.gte(selectedRelease.version, controllerProps.value.version)
+    ) {
+      controllerProps.onChange(null);
+    }
+  }, [selectedRelease, controllerProps.value, controllerProps]);
 
   return (
     <ErrorBoundary onReset={fetchApplication} FallbackComponent={ErrorFallback}>


### PR DESCRIPTION
- Clear selected target release when selected release is greater than or equal to current target release.
- Update the dependencies of the releaseOptions useMemo ensuring the list of target releases updates correctly when the selected release changes.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
