### PR TITLE
test: increase exit timeout in campaigns test

### DIFF
--- a/backend/test/edgehog/deployment_campaigns/lazy/executor_test.exs
+++ b/backend/test/edgehog/deployment_campaigns/lazy/executor_test.exs
@@ -571,7 +571,7 @@ defmodule Edgehog.DeploymentCampaigns.Lazy.ExecutorTest do
       # Start the execution
       start_execution(pid)
 
-      assert_normal_exit(pid, ref)
+      assert_normal_exit(pid, ref, 2000)
       assert_deployment_campaign_outcome(tenant, deployment_campaign_id, :failure)
     end
   end


### PR DESCRIPTION
Campaigns test sometimes failed in CI because the server was not exiting with `:normal`. This was only due to a race condition and increasing the timeout should remove this kind of problem.

Closes #1010

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
