### PR TITLE
Add confirmation modal for removing container

### DIFF
--- a/frontend/src/forms/ContainerForm.tsx
+++ b/frontend/src/forms/ContainerForm.tsx
@@ -66,6 +66,7 @@ type ContainerFormProps = {
   control: Control<ReleaseInputData>;
   isImported?: boolean;
   isModified?: boolean;
+  onRequestRemove: (index: number) => void;
 };
 
 // react-hook-form returns targetGroups validation error as Array<Record<string, FieldError>> type
@@ -116,13 +117,13 @@ const ContainerForm = ({
   index,
   register,
   errors,
-  remove,
   imageCredentials,
   networks,
   volumes,
   control,
   isImported = false,
   isModified = false,
+  onRequestRemove,
 }: ContainerFormProps) => {
   const volumesForm = useFieldArray({
     control,
@@ -1225,7 +1226,7 @@ const ContainerForm = ({
         <div className="d-flex justify-content-start align-items-center">
           <Button
             variant="danger"
-            onClick={() => remove(index)}
+            onClick={() => onRequestRemove(index)}
             className="mt-3"
           >
             <FormattedMessage

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -588,6 +588,12 @@ const CreateRelease = ({
     }
   };
 
+  const [removeIndex, setRemoveIndex] = useState<number | null>(null);
+
+  const handleRequestRemove = (index: number) => {
+    setRemoveIndex(index);
+  };
+
   return (
     <>
       <form
@@ -753,6 +759,7 @@ const CreateRelease = ({
                 isModified={
                   isContainerImported(index) && isContainerModified(index)
                 }
+                onRequestRemove={handleRequestRemove}
               />
             );
           })}
@@ -773,6 +780,41 @@ const CreateRelease = ({
                 defaultMessage="Add Container"
               />
             </Button>
+            {removeIndex !== null && (
+              <ConfirmModal
+                confirmLabel={
+                  <FormattedMessage
+                    id="forms.CreateRelease.confirmRemoveLabel"
+                    defaultMessage="Remove"
+                  />
+                }
+                onCancel={() => setRemoveIndex(null)}
+                onConfirm={() => {
+                  handleRemoveContainer(removeIndex);
+                  setRemoveIndex(null);
+                }}
+                title={
+                  <FormattedMessage
+                    id="forms.CreateRelease.confirmRemoveTitle"
+                    defaultMessage="Remove Container"
+                  />
+                }
+                confirmVariant="danger"
+              >
+                <p>
+                  <FormattedMessage
+                    id="forms.CreateRelease.confirmRemoveDescription"
+                    defaultMessage="Are you sure you want to remove <bold>Container {number}</bold>?"
+                    values={{
+                      number: removeIndex + 1,
+                      bold: (chunks: React.ReactNode) => (
+                        <strong>{chunks}</strong>
+                      ),
+                    }}
+                  />
+                </p>
+              </ConfirmModal>
+            )}
           </div>
 
           <div className="d-flex justify-content-end align-items-center">

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1817,6 +1817,15 @@
   "forms.CreateRelease.confirmPrompt": {
     "defaultMessage": "Choose a release from which you want to copy containers and their configurations."
   },
+  "forms.CreateRelease.confirmRemoveDescription": {
+    "defaultMessage": "Are you sure you want to remove <bold>Container {number}</bold>?"
+  },
+  "forms.CreateRelease.confirmRemoveLabel": {
+    "defaultMessage": "Remove"
+  },
+  "forms.CreateRelease.confirmRemoveTitle": {
+    "defaultMessage": "Remove Container"
+  },
   "forms.CreateRelease.containersTitle": {
     "defaultMessage": "Containers"
   },


### PR DESCRIPTION
Added simple confirmation modal that asks users to confirm or cancel the removal action.

<img width="908" height="366" alt="image" src="https://github.com/user-attachments/assets/3bfe1c49-e202-4c9b-82b8-c81d7d0992f8" />

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
