### PR TITLE
fix: only reconcile when really needed

### DIFF
--- a/backend/lib/edgehog/containers/reconciler/core.ex
+++ b/backend/lib/edgehog/containers/reconciler/core.ex
@@ -289,8 +289,10 @@ defmodule Edgehog.Containers.Reconciler.Core do
   end
 
   defp reconcile_deployment?(state, status) do
-    if state == status,
-      do: :ok,
-      else: :reconcile
+    case {state, status} do
+      {:started, "Started"} -> :ok
+      {:stopped, "Stopped"} -> :ok
+      _ -> :reconcile
+    end
   end
 end


### PR DESCRIPTION
`deployments` got reconciled way more frequently than needed: `state` and `status` could not pass a `==/2` validation as the first is an atom, while the second is a string.
