### PR TITLE
test: fix test failing because short timeout

### DIFF
--- a/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
+++ b/backend/test/edgehog/update_campaigns/push_rollout/executor_test.exs
@@ -590,7 +590,7 @@ defmodule Edgehog.UpdateCampaigns.PushRollout.ExecutorTest do
       # Start the execution
       start_execution(pid)
 
-      assert_normal_exit(pid, ref)
+      assert_normal_exit(pid, ref, 2000)
       assert_update_campaign_outcome(tenant, update_campaign_id, :failure)
     end
 


### PR DESCRIPTION
Sometimes campaign test failed not because of a real problem in the test itself but rather becasue of a non `:normal` stop of the campaign executor due to a short timeout. Similar to #1067