### PR TITLE
refactor: Add reusable `StringArrayForm` component

### DIFF
--- a/frontend/src/components/ContainersTable.tsx
+++ b/frontend/src/components/ContainersTable.tsx
@@ -34,6 +34,7 @@ import type {
 } from "api/__generated__/ContainersTable_ContainerFragment.graphql";
 
 import Form from "components/Form";
+import StringArrayFormInput from "components/StringArrayFormInput";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import MultiSelect from "./MultiSelect";
 import InfiniteScroll from "./InfiniteScroll";
@@ -147,13 +148,6 @@ const styles = {
   detailsWrapper: {
     padding: 12,
   },
-};
-
-const formatBindingsList = (
-  portBindings: readonly string[] | null | undefined,
-) => {
-  if (!portBindings || portBindings.length === 0) return "";
-  return portBindings.join(", ");
 };
 
 const formatJson = (jsonString: unknown) => {
@@ -587,9 +581,9 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
               />
             }
           >
-            <Form.Control
-              value={container.extraHosts?.join(", ") ?? ""}
-              readOnly
+            <StringArrayFormInput
+              value={Array.from(container.extraHosts ?? [])}
+              mode="details"
             />
           </FormRow>
           <FormRow
@@ -601,9 +595,9 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
               />
             }
           >
-            <Form.Control
-              value={formatBindingsList(container.portBindings)}
-              readOnly
+            <StringArrayFormInput
+              value={Array.from(container.portBindings ?? [])}
+              mode="details"
             />
           </FormRow>
           <NetworkDetails
@@ -630,9 +624,9 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
               />
             }
           >
-            <Form.Control
-              value={formatBindingsList(container.binds)}
-              readOnly
+            <StringArrayFormInput
+              value={Array.from(container.binds ?? [])}
+              mode="details"
             />
           </FormRow>
           <FormRow
@@ -655,12 +649,9 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
               />
             }
           >
-            <MonacoJsonEditor
-              value={container.storageOpt.join("\n")}
-              onChange={() => {}}
-              defaultValue={container.storageOpt.join("\n")}
-              readonly={true}
-              initialLines={1}
+            <StringArrayFormInput
+              value={Array.from(container.storageOpt ?? [])}
+              mode="details"
             />
           </FormRow>
           <FormRow
@@ -672,12 +663,9 @@ const ContainerDetails = ({ container, index }: ContainerDetailsProps) => {
               />
             }
           >
-            <MonacoJsonEditor
-              value={container.tmpfs.join("\n")}
-              onChange={() => {}}
-              defaultValue={container.tmpfs.join("\n")}
-              readonly={true}
-              initialLines={1}
+            <StringArrayFormInput
+              value={Array.from(container.tmpfs ?? [])}
+              mode="details"
             />
           </FormRow>
           <FormRow

--- a/frontend/src/components/StringArrayFormInput.tsx
+++ b/frontend/src/components/StringArrayFormInput.tsx
@@ -1,0 +1,115 @@
+/*
+  This file is part of Edgehog.
+
+  Copyright 2025 SECO Mind Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import Button from "components/Button";
+import Form from "components/Form";
+import Stack from "components/Stack";
+import Icon from "components/Icon";
+
+interface StringArrayFormInputProps {
+  value: string[];
+  onChange?: (value: string[]) => void;
+  errors?: { message?: string }[];
+  addButtonLabel?: React.ReactNode;
+  mode?: "input" | "details";
+}
+
+const StringArrayFormInput: React.FC<StringArrayFormInputProps> = ({
+  value,
+  onChange,
+  errors = [],
+  addButtonLabel = (
+    <FormattedMessage
+      id="components.StringArrayFormInput.addButton"
+      defaultMessage="Add Item"
+    />
+  ),
+  mode = "input",
+}) => {
+  const handleAdd = () => {
+    if (onChange) {
+      onChange([...value, ""]);
+    }
+  };
+
+  const handleDelete = (i: number) => {
+    if (onChange) {
+      onChange(value.filter((_, idx) => idx !== i));
+    }
+  };
+
+  const handleChange = (i: number, newValue: string) => {
+    if (onChange) {
+      const updated = [...value];
+      updated[i] = newValue;
+      onChange(updated);
+    }
+  };
+
+  //   TODO Make the details look better and easier to read
+  if (mode === "details") {
+    return (
+      <Form.Control value={value.length > 0 ? value.join(", ") : ""} readOnly />
+    );
+  }
+
+  return (
+    <div className="p-3 bg-light border rounded">
+      <Stack gap={3}>
+        {value.map((item: string, i: number) => {
+          const itemError = errors?.[i]?.message;
+          return (
+            <Stack direction="horizontal" gap={3} key={i}>
+              <Stack>
+                <Form.Control
+                  value={item}
+                  onChange={(e) => handleChange(i, e.target.value)}
+                  isInvalid={!!itemError}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {itemError && <FormattedMessage id={itemError} />}
+                </Form.Control.Feedback>
+              </Stack>
+              <Button
+                className="mb-auto"
+                variant="shadow-danger"
+                onClick={() => handleDelete(i)}
+              >
+                <Icon className="text-danger" icon={"delete"} />
+              </Button>
+            </Stack>
+          );
+        })}
+        <Button
+          className="me-auto"
+          variant="outline-primary"
+          onClick={handleAdd}
+        >
+          {addButtonLabel}
+        </Button>
+      </Stack>
+    </div>
+  );
+};
+
+export default StringArrayFormInput;

--- a/frontend/src/forms/ContainerForm.tsx
+++ b/frontend/src/forms/ContainerForm.tsx
@@ -49,6 +49,7 @@ import DeviceMappingsFormInput from "components/DeviceMappingsFormInput";
 import { FormRow } from "components/FormRow";
 import MultiSelect from "components/MultiSelect";
 import FieldHelp from "components/FieldHelp";
+import StringArrayFormInput from "components/StringArrayFormInput";
 
 type Option = {
   value: string;
@@ -382,85 +383,23 @@ const ContainerForm = ({
                 <Controller
                   control={control}
                   name={`containers.${index}.extraHosts`}
-                  render={({ field }) => {
-                    const extraHosts = field.value || [];
-
-                    const handleAddExtraHost = () => {
-                      field.onChange([...extraHosts, ""]);
-                    };
-
-                    const handleDeleteExtraHost = (i: number) => {
-                      field.onChange(extraHosts.filter((_, idx) => idx !== i));
-                    };
-
-                    const handleChangeHost = (i: number, value: string) => {
-                      const updated = [...extraHosts];
-
-                      updated[i] = value;
-
-                      field.onChange(updated);
-                    };
-
-                    return (
-                      <div className="p-3 mb-3 bg-light border rounded">
-                        <Stack gap={3}>
-                          {extraHosts.map((host, i) => {
-                            const hostError =
-                              errors.containers?.[index]?.extraHosts?.[i]
-                                ?.message;
-
-                            return (
-                              <Stack direction="horizontal" gap={3} key={i}>
-                                <Stack>
-                                  <Form.Control
-                                    value={host}
-                                    onChange={(e) =>
-                                      handleChangeHost(i, e.target.value)
-                                    }
-                                    isInvalid={!!hostError}
-                                  />
-
-                                  <Form.Control.Feedback type="invalid">
-                                    {errors.containers?.[index]?.extraHosts?.[i]
-                                      ?.message && (
-                                      <FormattedMessage
-                                        id={
-                                          errors.containers[index].extraHosts[i]
-                                            .message
-                                        }
-                                      />
-                                    )}
-                                  </Form.Control.Feedback>
-                                </Stack>
-
-                                <Button
-                                  className="mb-auto"
-                                  variant="shadow-danger"
-                                  onClick={() => handleDeleteExtraHost(i)}
-                                >
-                                  <Icon
-                                    className="text-danger"
-                                    icon={"delete"}
-                                  />
-                                </Button>
-                              </Stack>
-                            );
-                          })}
-
-                          <Button
-                            className="me-auto"
-                            variant="outline-primary"
-                            onClick={handleAddExtraHost}
-                          >
-                            <FormattedMessage
-                              id="forms.ContainerForm.addExtraHostButton"
-                              defaultMessage="Add Extra Host"
-                            />
-                          </Button>
-                        </Stack>
-                      </div>
-                    );
-                  }}
+                  render={({ field }) => (
+                    <StringArrayFormInput
+                      value={field.value || []}
+                      onChange={field.onChange}
+                      errors={
+                        Array.isArray(errors.containers?.[index]?.extraHosts)
+                          ? errors.containers[index].extraHosts
+                          : undefined
+                      }
+                      addButtonLabel={
+                        <FormattedMessage
+                          id="forms.ContainerForm.addExtraHostButton"
+                          defaultMessage="Add Extra Host"
+                        />
+                      }
+                    />
+                  )}
                 />
               </FieldHelp>
             </FormRow>
@@ -475,19 +414,27 @@ const ContainerForm = ({
               }
             >
               <FieldHelp id="portBindings">
-                <Form.Control
-                  {...register(`containers.${index}.portBindings` as const)}
-                  type="text"
-                  isInvalid={!!errors.containers?.[index]?.portBindings}
-                />
-
-                <Form.Control.Feedback type="invalid">
-                  {errors.containers?.[index]?.portBindings?.message && (
-                    <FormattedMessage
-                      id={errors.containers[index].portBindings.message}
+                <Controller
+                  control={control}
+                  name={`containers.${index}.portBindings`}
+                  render={({ field }) => (
+                    <StringArrayFormInput
+                      value={field.value || []}
+                      onChange={field.onChange}
+                      errors={
+                        Array.isArray(errors.containers?.[index]?.portBindings)
+                          ? errors.containers[index].portBindings
+                          : undefined
+                      }
+                      addButtonLabel={
+                        <FormattedMessage
+                          id="forms.ContainerForm.addPortBindingButton"
+                          defaultMessage="Add Port Binding"
+                        />
+                      }
                     />
                   )}
-                </Form.Control.Feedback>
+                />
               </FieldHelp>
             </FormRow>
           </Stack>
@@ -512,19 +459,27 @@ const ContainerForm = ({
               }
             >
               <FieldHelp id="binds">
-                <Form.Control
-                  {...register(`containers.${index}.binds` as const)}
-                  type="text"
-                  isInvalid={!!errors.containers?.[index]?.binds}
-                />
-
-                <Form.Control.Feedback type="invalid">
-                  {errors.containers?.[index]?.binds?.message && (
-                    <FormattedMessage
-                      id={errors.containers[index].binds.message}
+                <Controller
+                  control={control}
+                  name={`containers.${index}.binds`}
+                  render={({ field }) => (
+                    <StringArrayFormInput
+                      value={field.value || []}
+                      onChange={field.onChange}
+                      errors={
+                        Array.isArray(errors.containers?.[index]?.binds)
+                          ? errors.containers[index].binds
+                          : undefined
+                      }
+                      addButtonLabel={
+                        <FormattedMessage
+                          id="forms.ContainerForm.addBindsButton"
+                          defaultMessage="Add Binds"
+                        />
+                      }
                     />
                   )}
-                </Form.Control.Feedback>
+                />
               </FieldHelp>
             </FormRow>
 
@@ -538,7 +493,7 @@ const ContainerForm = ({
               }
             >
               <FieldHelp id="volumes">
-                <div className="p-3 mb-3 bg-light border rounded">
+                <div className="p-3 bg-light border rounded">
                   <Stack gap={3}>
                     {volumesForm.fields.map((volume, volIndex) => {
                       const selectedIds = volumesValues
@@ -695,26 +650,22 @@ const ContainerForm = ({
                 <Controller
                   control={control}
                   name={`containers.${index}.storageOpt`}
-                  render={({ field, fieldState }) => (
-                    <>
-                      <MonacoJsonEditor
-                        value={field.value ?? ""}
-                        onChange={(value) => {
-                          field.onChange(value ?? "");
-                        }}
-                        defaultValue={field.value || "[]"}
-                        initialLines={1}
-                        aria-invalid={fieldState.invalid}
-                      />
-                      {fieldState.error && (
-                        <Form.Control.Feedback
-                          type="invalid"
-                          className="d-block"
-                        >
-                          <FormattedMessage id={fieldState.error.message} />
-                        </Form.Control.Feedback>
-                      )}
-                    </>
+                  render={({ field }) => (
+                    <StringArrayFormInput
+                      value={field.value || []}
+                      onChange={field.onChange}
+                      errors={
+                        Array.isArray(errors.containers?.[index]?.storageOpt)
+                          ? errors.containers[index].storageOpt
+                          : undefined
+                      }
+                      addButtonLabel={
+                        <FormattedMessage
+                          id="forms.ContainerForm.addStorageOptButton"
+                          defaultMessage="Add Storage Option"
+                        />
+                      }
+                    />
                   )}
                 />
               </FieldHelp>
@@ -733,26 +684,22 @@ const ContainerForm = ({
                 <Controller
                   control={control}
                   name={`containers.${index}.tmpfs`}
-                  render={({ field, fieldState }) => (
-                    <>
-                      <MonacoJsonEditor
-                        value={field.value ?? ""}
-                        onChange={(value) => {
-                          field.onChange(value ?? "");
-                        }}
-                        defaultValue={field.value || "[]"}
-                        initialLines={1}
-                        aria-invalid={fieldState.invalid}
-                      />
-                      {fieldState.error && (
-                        <Form.Control.Feedback
-                          type="invalid"
-                          className="d-block"
-                        >
-                          <FormattedMessage id={fieldState.error.message} />
-                        </Form.Control.Feedback>
-                      )}
-                    </>
+                  render={({ field }) => (
+                    <StringArrayFormInput
+                      value={field.value || []}
+                      onChange={field.onChange}
+                      errors={
+                        Array.isArray(errors.containers?.[index]?.tmpfs)
+                          ? errors.containers[index].tmpfs
+                          : undefined
+                      }
+                      addButtonLabel={
+                        <FormattedMessage
+                          id="forms.ContainerForm.addTmpfsButton"
+                          defaultMessage="Add Tmpfs Mount"
+                        />
+                      }
+                    />
                   )}
                 />
               </FieldHelp>
@@ -1212,7 +1159,7 @@ const ContainerForm = ({
             }
           >
             <FieldHelp id="deviceMappings" itemsAlignment="center">
-              <div className="p-3 mb-3 bg-light border rounded">
+              <div className="p-3 bg-light border rounded">
                 <DeviceMappingsFormInput
                   editableProps={dmFormInputProps}
                   readOnlyProps={null}

--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -256,13 +256,13 @@ type ContainerInput = {
   networkMode?: string;
   networks?: ContainerCreateWithNestedNetworksInput[];
   extraHosts?: string[];
-  portBindings?: string;
+  portBindings?: string[];
   // Storage Configuration
-  binds?: string;
+  binds?: string[];
   volumes?: ContainerCreateWithNestedVolumesInput[];
   volumeDriver?: string;
-  storageOpt?: string;
-  tmpfs?: string;
+  storageOpt?: string[];
+  tmpfs?: string[];
   readOnlyRootfs?: boolean;
   // Resource Limits
   memory?: number;
@@ -292,18 +292,8 @@ export type ReleaseInputData = {
 
 type ReleaseSubmitData = {
   version: string;
-  containers?: ContainerSubmit[] | null;
+  containers?: ContainerInput[] | null;
   requiredSystemModels: ReleaseCreateRequiredSystemModelsInput[];
-};
-
-type ContainerSubmit = Omit<
-  ContainerInput,
-  "portBindings" | "tmpfs" | "storageOpt" | "binds"
-> & {
-  portBindings?: string[];
-  tmpfs?: string[];
-  storageOpt?: string[];
-  binds?: string[];
 };
 
 export const CapDropList = [
@@ -577,17 +567,6 @@ const CreateRelease = ({
     );
   };
 
-  const parseJsonToStringArray = (jsonStr: string | undefined): string[] => {
-    if (!jsonStr) return [];
-    try {
-      const parsed = JSON.parse(jsonStr);
-      return Array.isArray(parsed) ? parsed.map(String) : [];
-    } catch {
-      console.error("Invalid JSON:", jsonStr);
-      return [];
-    }
-  };
-
   const [removeIndex, setRemoveIndex] = useState<number | null>(null);
 
   const handleRequestRemove = (index: number) => {
@@ -612,19 +591,13 @@ const CreateRelease = ({
               networkMode: container.networkMode || undefined,
               networks: container.networks || undefined,
               extraHosts: container.extraHosts || undefined,
-              portBindings: container.portBindings
-                ? (container.portBindings
-                    .split(",")
-                    .map((v) => v.trim()) as string[])
-                : undefined,
+              portBindings: container.portBindings || undefined,
               // Storage Configuration
-              binds: container.binds
-                ? (container.binds.split(",").map((v) => v.trim()) as string[])
-                : undefined,
+              binds: container.binds || undefined,
               volumes: container.volumes || undefined,
               volumeDriver: container.volumeDriver || undefined,
-              storageOpt: parseJsonToStringArray(container.storageOpt),
-              tmpfs: parseJsonToStringArray(container.tmpfs),
+              storageOpt: container.storageOpt || undefined,
+              tmpfs: container.tmpfs || undefined,
               readOnlyRootfs: container.readOnlyRootfs || undefined,
               // Resource Limits
               memory: container.memory || undefined,
@@ -871,19 +844,16 @@ const CreateRelease = ({
                     c.networks?.edges?.map((n: any) => ({ id: n.node.id })) ??
                     undefined,
                   extraHosts: c.extraHosts ? [...c.extraHosts] : undefined,
-                  portBindings: c.portBindings?.join(",") || undefined,
-
-                  binds: c.binds?.join(",") || undefined,
+                  portBindings: c.extraHosts ? [...c.portBindings] : undefined,
+                  binds: c.extraHosts ? [...c.binds] : undefined,
                   volumes:
                     c.containerVolumes?.edges?.map((v: any) => ({
                       id: v.node.volume.id,
                       target: v.node.target,
                     })) ?? undefined,
                   volumeDriver: c.volumeDriver || undefined,
-                  storageOpt: c.storageOpt
-                    ? JSON.stringify(c.storageOpt)
-                    : undefined,
-                  tmpfs: c.tmpfs ? JSON.stringify(c.tmpfs) : undefined,
+                  storageOpt: c.storageOpt ? [...c.storageOpt] : undefined,
+                  tmpfs: c.tmpfs ? [...c.tmpfs] : undefined,
                   readOnlyRootfs: c.readOnlyRootfs || undefined,
                   // Resource Limits
                   memory: c.memory || undefined,

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1137,6 +1137,9 @@
   "components.StorageTable.totalSpaceTitle": {
     "defaultMessage": "Total Space"
   },
+  "components.StringArrayFormInput.addButton": {
+    "defaultMessage": "Add Item"
+  },
   "components.SystemModelsTable.handleTitle": {
     "defaultMessage": "Handle"
   },
@@ -1354,10 +1357,10 @@
     "defaultMessage": "Success"
   },
   "fieldExplanation.binds.description": {
-    "defaultMessage": "Maps host ports to container ports for external access. Format: [host_port:]container_port[/protocol]. Protocol is TCP by default"
+    "defaultMessage": "Maps host directories to container directories for persistent storage or sharing. Format: /host/path:/container/path[:ro|rw]"
   },
   "fieldExplanation.binds.example": {
-    "defaultMessage": "/data:/data, /config:/config:ro"
+    "defaultMessage": "/data:/data or /config:/config:ro"
   },
   "fieldExplanation.binds.title": {
     "defaultMessage": "Binds"
@@ -1441,7 +1444,7 @@
     "defaultMessage": "List of hostname/IP mappings added to the container's /etc/hosts for custom DNS resolution. 'host-gateway' resolves to the host IP."
   },
   "fieldExplanation.extraHosts.example": {
-    "defaultMessage": "[\"database:192.168.1.5\", \"gateway:host-gateway\"]"
+    "defaultMessage": "\"database:192.168.1.5\" or \"gateway:host-gateway\""
   },
   "fieldExplanation.extraHosts.title": {
     "defaultMessage": "Extra Hosts"
@@ -1507,7 +1510,7 @@
     "defaultMessage": "Memory Swappiness (0-100)"
   },
   "fieldExplanation.networkMode.description": {
-    "defaultMessage": "Supported standard values are: bridge, host, none, and container:'<name|id>'. Any other value is taken as a custom network's name to which this container should connect to. If you are using a different container engine than docker, there could be other values."
+    "defaultMessage": "Supported standard values are: bridge, host, none, and container:'<name|id>'. Any other value is treated as the name of a user-defined network. Other container engines may support additional modes."
   },
   "fieldExplanation.networkMode.example": {
     "defaultMessage": "bridge"
@@ -1522,10 +1525,10 @@
     "defaultMessage": "Attached Networks"
   },
   "fieldExplanation.portBindings.description": {
-    "defaultMessage": "Maps host ports to container ports for external access. Format: host_port:container_port."
+    "defaultMessage": "Maps host ports to container ports for external access. Format: [host_port:]container_port[/protocol]. Protocol defaults to TCP."
   },
   "fieldExplanation.portBindings.example": {
-    "defaultMessage": "8080:80,443:443"
+    "defaultMessage": "\"8080:80\" or \"8080:443/udp\""
   },
   "fieldExplanation.portBindings.title": {
     "defaultMessage": "Port Bindings"
@@ -1552,19 +1555,19 @@
     "defaultMessage": "Restart Policy"
   },
   "fieldExplanation.storageOpt.description": {
-    "defaultMessage": "Options for the storage driver, e.g., limit writable layer size."
+    "defaultMessage": "Driver-specific storage options, such as limiting the size of the writable layer."
   },
   "fieldExplanation.storageOpt.example": {
-    "defaultMessage": "[\"size=100G\"]"
+    "defaultMessage": "\"size=100G\""
   },
   "fieldExplanation.storageOpt.title": {
     "defaultMessage": "Storage Options"
   },
   "fieldExplanation.tmpfs.description": {
-    "defaultMessage": "In-memory filesystems mounted at specified paths. Data is fast but lost on container restart."
+    "defaultMessage": "In-memory filesystems mounted at specified container paths. Data is fast but lost on container restart."
   },
   "fieldExplanation.tmpfs.example": {
-    "defaultMessage": "[\"/tmp:size=64m\"]"
+    "defaultMessage": "\"/tmp:size=64m\""
   },
   "fieldExplanation.tmpfs.title": {
     "defaultMessage": "Tmpfs Mounts"
@@ -1587,8 +1590,20 @@
   "fieldExplanation.volumes.title": {
     "defaultMessage": "Volume Mounts"
   },
+  "forms.ContainerForm.addBindsButton": {
+    "defaultMessage": "Add Binds"
+  },
   "forms.ContainerForm.addExtraHostButton": {
     "defaultMessage": "Add Extra Host"
+  },
+  "forms.ContainerForm.addPortBindingButton": {
+    "defaultMessage": "Add Port Binding"
+  },
+  "forms.ContainerForm.addStorageOptButton": {
+    "defaultMessage": "Add Storage Option"
+  },
+  "forms.ContainerForm.addTmpfsButton": {
+    "defaultMessage": "Add Tmpfs Mount"
   },
   "forms.ContainerForm.addVolumeButton": {
     "defaultMessage": "Add Volume"
@@ -2961,7 +2976,7 @@
     "defaultMessage": "The version must follow the Semantic Versioning spec"
   },
   "validation.binds.format": {
-    "defaultMessage": "Each bind must be in the format hostDir:containerDir[:options], separated by commas."
+    "defaultMessage": "Invalid bind mount format. Use '/host/path:/container/path[:ro|rw]'."
   },
   "validation.cpuQuotaPeriod.format": {
     "defaultMessage": "CPU Period and CPU Quota must be either both set or both unset"
@@ -2973,7 +2988,7 @@
     "defaultMessage": "Must be a valid JSON string."
   },
   "validation.extraHosts.format": {
-    "defaultMessage": "Must be in the form hostname:IP (e.g., myhost:127.0.0.1)"
+    "defaultMessage": "Invalid extra host format. Use 'hostname:IP' or 'hostname:host-gateway'."
   },
   "validation.handle.format": {
     "defaultMessage": "The handle must start with a letter and only contain lower case characters, numbers or the hyphen symbol -"
@@ -2997,16 +3012,16 @@
     "defaultMessage": "{label} must be a positive number."
   },
   "validation.portBindings.format": {
-    "defaultMessage": "Port Bindings must be comma-separated values in the format [HOST:]CONTAINER[/PROTOCOL]"
+    "defaultMessage": "Invalid port binding format. Use [host_port:]container_port[/protocol]."
   },
   "validation.required": {
     "defaultMessage": "Required."
   },
   "validation.storage.format": {
-    "defaultMessage": "Must be a valid JSON array of strings in the format \"key=value\", e.g. [\"size=120G\"]"
+    "defaultMessage": "Invalid storage option format. Use 'key=value'."
   },
   "validation.tmpfs.format": {
-    "defaultMessage": "Must be a valid JSON array of strings in the format \"/path=option1,option2\", e.g. [\"/run=rw,size=64m\"]"
+    "defaultMessage": "Invalid tmpfs mount format. Use '/container/path=option1,option2'."
   },
   "validation.unique": {
     "defaultMessage": "Duplicate value."


### PR DESCRIPTION
Add a new `StringArrayForm` component, designed for both input and display of string array fields. The component replaces previous implementations and ensures a consistent UI for string array data throughout the application.

<details><summary>Screenshots</summary>
<p>

Old:
<img width="2556" height="1221" alt="image" src="https://github.com/user-attachments/assets/fd5e8b53-f9df-498c-a0bc-7f55850c4de9" />
<img width="2556" height="1221" alt="image" src="https://github.com/user-attachments/assets/64e71ffd-bd55-4185-b4a7-1e948f34563a" />


Updated:
<img width="2556" height="1221" alt="image" src="https://github.com/user-attachments/assets/4dfdab1e-ed65-4548-90a5-ca32b150babe" />
<img width="2556" height="1221" alt="image" src="https://github.com/user-attachments/assets/877de2aa-4e8d-43fe-b9bd-5d6c1da80170" />
<img width="2556" height="1221" alt="image" src="https://github.com/user-attachments/assets/c26a74cf-e1ed-47c6-8584-e7aa38b225ad" />


</p>
</details> 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
