### PR TITLE
Fix TypeError on network and volume options and validate nested JSON

### DIFF
--- a/frontend/src/forms/CreateNetwork.tsx
+++ b/frontend/src/forms/CreateNetwork.tsx
@@ -29,7 +29,7 @@ import Form from "components/Form";
 import Row from "components/Row";
 import Spinner from "components/Spinner";
 
-import { yup, envSchema } from "forms";
+import { yup, optionsSchema } from "forms";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import { FormRowWithMargin as FormRow } from "components/FormRow";
 
@@ -45,7 +45,7 @@ const networkSchema = yup
   .object({
     label: yup.string().required(),
     driver: yup.string().nullable(),
-    options: envSchema.nullable(),
+    options: optionsSchema.nullable(),
     internal: yup.boolean(),
     enableIpv6: yup.boolean(),
   })
@@ -71,6 +71,29 @@ const ErrorMessage = ({ error }: { error?: FieldError }) => {
       <FormattedMessage id={error.message} defaultMessage={error.message} />
     </Form.Control.Feedback>
   );
+};
+
+export const optionsValidation = (input: any): void => {
+  if (!input) return;
+
+  const parsed =
+    typeof input === "object" && !Array.isArray(input)
+      ? input
+      : JSON.parse(input);
+
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("Expected an object with key-value pairs");
+  }
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!["string", "number", "boolean"].includes(typeof value)) {
+      throw new TypeError(
+        `Value for '${key}' must be a one of: string, number or boolean. Got: ${
+          Array.isArray(value) ? "array" : typeof value
+        }`,
+      );
+    }
+  }
 };
 
 const CreateNetwork = React.memo(({ isLoading = false, onSubmit }: Props) => {
@@ -132,6 +155,7 @@ const CreateNetwork = React.memo(({ isLoading = false, onSubmit }: Props) => {
                 field.onChange(value ?? "");
               }}
               defaultValue={field.value || "{}"}
+              additionalValidation={optionsValidation}
             />
           )}
         />

--- a/frontend/src/forms/CreateVolume.tsx
+++ b/frontend/src/forms/CreateVolume.tsx
@@ -29,9 +29,10 @@ import Form from "components/Form";
 import Row from "components/Row";
 import Spinner from "components/Spinner";
 
-import { yup, envSchema } from "forms";
+import { yup, optionsSchema } from "forms";
 import MonacoJsonEditor from "components/MonacoJsonEditor";
 import { FormRowWithMargin as FormRow } from "components/FormRow";
+import { optionsValidation } from "./CreateNetwork";
 
 type VolumeData = {
   label: string;
@@ -43,7 +44,7 @@ const volumeSchema = yup
   .object({
     label: yup.string().required(),
     driver: yup.string().nullable(),
-    options: envSchema.nullable().notRequired(),
+    options: optionsSchema.nullable().notRequired(),
   })
   .required();
 
@@ -136,6 +137,7 @@ const CreateVolume = React.memo(({ isLoading = false, onSubmit }: Props) => {
                 field.onChange(value ?? "");
               }}
               defaultValue={field.value || "{}"}
+              additionalValidation={optionsValidation}
             />
           )}
         />

--- a/frontend/src/forms/index.ts
+++ b/frontend/src/forms/index.ts
@@ -665,6 +665,34 @@ const envSchema = yup
   })
   .default("{}");
 
+const optionsSchema = yup
+  .string()
+  .nullable()
+  .transform((value) => value?.trim())
+  .test({
+    name: "is-json",
+    message: messages.envInvalidJson.id,
+    test: (value) => {
+      if (!value) return true;
+      return isValidJson(value);
+    },
+  })
+  .test({
+    name: "no-nested-values",
+    test: (value) => {
+      if (!value) return true;
+      if (!isValidJson(value)) return true;
+
+      const parsed = JSON.parse(value);
+      if (typeof parsed !== "object" || Array.isArray(parsed)) {
+        return false;
+      }
+      return Object.values(parsed).every((v) =>
+        ["string", "number", "boolean"].includes(typeof v),
+      );
+    },
+  });
+
 const ipv4PortRegex =
   /^(\d{1,5}(-\d{1,5})?(:(\d{1,5}(-\d{1,5})?))?(\/(tcp|udp))?|(\d{1,3}\.){3}\d{1,3}:\d{1,5}(-\d{1,5})?:\d{1,5}(-\d{1,5})?(\/(tcp|udp))?)$/;
 const ipv6PortRegex =
@@ -921,4 +949,5 @@ export {
   volumesSchema,
   deviceMappingsSchema,
   requiredSystemModelsSchema,
+  optionsSchema,
 };


### PR DESCRIPTION
Replaced `envSchema` with a dedicated `optionsSchema` for network and volume options to fix a TypeScript TypeError that occurred when calling .trim() on arrays.

`envSchema` was transforming JSON input into an array of key-value objects, which caused form submission to failed.
This fixes the runtime error and ensures consistent validation for network and volume options.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
