### PR TITLE
fix(just): auto-install backend and frontend dependencies

### DIFF
--- a/justfile
+++ b/justfile
@@ -180,6 +180,7 @@ _edgehog-dev-backend:
     export EDGEHOG_FORWARDER_SECURE_SESSIONS="false"
     export ADMIN_JWT_PUBLIC_KEY_PATH=./priv/repo/seeds/keys/admin_public.pem
     cd backend
+    mix deps.get
     # Setup database. Do not seed the database.
     mix ash.reset
     # Run server
@@ -205,6 +206,7 @@ dev-frontend: (_wait-edgehog "localhost:4000")
     #!/usr/bin/env bash
     @echo "🚀 Initializing Edgehog frontend in dev environment..."
     cd frontend
+    npm install
     npm run start
 
 provision-realm: _check-system-prereqs _check-astarte-prereqs _configure-system _init-astarte _wait-astarte _create-astarte-realm


### PR DESCRIPTION
This removes the requirement to install dependencies manually before running `just dev-frontend` and `just dev-backend`

