### PR TITLE
ci: do not consider changelogs in typos and format

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -43,3 +43,7 @@ PN = "PN"
 
 [default.extend-identifiers]
 OTPs = "OTPs"
+
+# Exclude changelogs: they're auto generated based on commits which are linted
+[files]
+extend-exclude = ["**/CHANGELOG.md"]

--- a/dprint.json
+++ b/dprint.json
@@ -11,7 +11,8 @@
     "**/*-lock.json",
     ".reuse/templates/*",
     "**/schema.graphql",
-    "frontend/**"
+    "frontend/**",
+    "backend/CHANGELOG.md"
   ],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.0.wasm",

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -5,3 +5,4 @@ coverage
 node_modules
 src/api/__generated__
 src/i18n/langs-compiled
+CHANGELOG.md


### PR DESCRIPTION
## Make `typos`, `dprint` and `prettier` ignore frontend changelog.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request.

If it fixes a bug or resolves a feature request, be sure to link to the related issue.
Example:
    - Fixes #123
-->
Frontend CI checked the CHANGELOG file, which is auto-generated from commits, including typos there. It also checked formatting of such file, which was wrongfully marked as unformatted.


## Checklist

<!--
Put an `x` in the boxes that apply. You can fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask.
This is simply a reminder of what will be checked before merging.
-->

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation (if appropriate)
