### PR TITLE
fix: Wrong endpoint type in ServerToDevice for fileSizeBytes

### DIFF
--- a/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.fileTransfer.posix.ServerToDevice.json
+++ b/backend/priv/astarte_resources/interfaces/io.edgehog.devicemanager.fileTransfer.posix.ServerToDevice.json
@@ -52,7 +52,7 @@
     },
     {
       "endpoint": "/request/fileSizeBytes",
-      "type": "string",
+      "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 3600,


### PR DESCRIPTION

## Change Title

The byte size was a string endpoint instead of longinteger.

Based on: https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/pull/83

## Checklist

<!--
Put an `x` in the boxes that apply. You can fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask.
This is simply a reminder of what will be checked before merging.
-->

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation (if appropriate)

## Further Comments (optional)

<!--
If this is a relatively large or complex change, explain:
    - Why you chose this solution
    - What alternatives you considered
    - Any trade-offs or follow-up work
-->

## Screenshots / Demos (optional)

<!--
If this PR introduces visual or UI changes, it is highly appreciated to include
screenshots, GIFs, or a short video.

This helps reviewers more easily understand the changes and makes it simpler to
track visual differences over time.
-->
