### PR TITLE
ci: use edgehog app

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -7,13 +7,13 @@
       "package-name": "backend",
       "release-type": "elixir",
       "component": "backend",
-      "include-component-in-tag": true
+      "include-component-in-tag": false
     },
     "frontend": {
       "package-name": "frontend",
       "release-type": "node",
       "component": "frontend",
-      "include-component-in-tag": true
+      "include-component-in-tag": false
     }
   },
   "plugins": [

--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2025 SECO Mind Srl
+# Copyright 2025, 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 name: fast-forward
 on:
@@ -28,16 +26,15 @@ jobs:
     if: ${{ contains(github.event.comment.body, '/fast-forward') && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-      # Needs issue permission to post comments on pull request
-      issues: write
-
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.EDGEHOG_APP_APP_ID }}
+          private-key: ${{ secrets.EDGEHOG_APP_PRIVATE_KEY }}
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
         with:
-          github_token: ${{ secrets.ADMIN_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           merge: true
           comment: on-error

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -21,11 +21,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
 name: Release CI
 
 jobs:
@@ -35,15 +30,20 @@ jobs:
       backend--release_created: ${{ steps.release.outputs.backend--release_created }}
       backend--version: ${{ steps.release.outputs.backend--version }}
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.EDGEHOG_APP_APP_ID }}
+          private-key: ${{ secrets.EDGEHOG_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
   publish-docs:
     needs: [make-release]
     uses: ./.github/workflows/docs-ci.yaml
-    secrets: inherit
     with:
       release-made: ${{ needs.make-release.outputs.backend--release_created }}
       release-version: ${{ needs.make-release.outputs.backend--version }}


### PR DESCRIPTION

## Use Edgehog app for repository management

Uses edgehog app to do automatic authorized operations on the repository (fast-forward, make releases, ...). This lifts the curse of using a personal access token of a user with write permissions on the repo.

## Checklist

<!--
Put an `x` in the boxes that apply. You can fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask.
This is simply a reminder of what will be checked before merging.
-->

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation (if appropriate)
