### PR TITLE
feat: Add file upload UX with advanced options 

### DIFF
--- a/frontend/src/components/DeviceTabs/FilesUploadTab.tsx
+++ b/frontend/src/components/DeviceTabs/FilesUploadTab.tsx
@@ -182,11 +182,13 @@ const formatRelayErrors = (
 type ManualFileDownloadRequestFormWrapperProps = {
   setErrorFeedback: (feedback: React.ReactNode) => void;
   deviceId: string;
+  showAdvancedOptions: boolean;
 };
 
 const ManualFileDownloadRequestFormWrapper = ({
   setErrorFeedback,
   deviceId,
+  showAdvancedOptions,
 }: ManualFileDownloadRequestFormWrapperProps) => {
   const intl = useIntl();
   const [isUploading, setIsUploading] = useState(false);
@@ -229,6 +231,9 @@ const ManualFileDownloadRequestFormWrapper = ({
           destination,
           ttlSeconds,
           progressTracked,
+          fileMode,
+          userId,
+          groupId,
         } = values;
 
         let uploadBlob: Blob;
@@ -264,13 +269,6 @@ const ManualFileDownloadRequestFormWrapper = ({
         const archiveData = new Uint8Array(await uploadBlob.arrayBuffer());
         const fileDownloadRequestId = uuidv7();
         const digest = await computeDigest(archiveData);
-
-        // Note: The browser File API does not expose Unix file permissions (fileMode),
-        // userId, or groupId. These are OS-level metadata not available in web browsers.
-        // We use sensible defaults: fileMode 0 (rw-r--r--), userId -1, groupId -1.
-        const fileMode = 0;
-        const userId = -1;
-        const groupId = -1;
 
         // Get presigned URL from the backend
         const presignedUrls = await new Promise<{
@@ -433,6 +431,7 @@ const ManualFileDownloadRequestFormWrapper = ({
     <ManualFileDownloadRequestForm
       isLoading={isUploading}
       onFileSubmit={handleFileUpload}
+      showAdvancedOptions={showAdvancedOptions}
     />
   );
 };
@@ -441,12 +440,14 @@ type ManualFileDownloadRequestFromRepositoryFormWrapperProps = {
   setErrorFeedback: (feedback: React.ReactNode) => void;
   repositoriesQueryRef: PreloadedQuery<FilesUploadTab_getRepositories_Query>;
   deviceId: string;
+  showAdvancedOptions: boolean;
 };
 
 const ManualFileDownloadRequestFromRepositoryFormWrapper = ({
   setErrorFeedback,
   repositoriesQueryRef,
   deviceId,
+  showAdvancedOptions,
 }: ManualFileDownloadRequestFromRepositoryFormWrapperProps) => {
   const intl = useIntl();
   const [isUploading, setIsUploading] = useState(false);
@@ -473,6 +474,9 @@ const ManualFileDownloadRequestFromRepositoryFormWrapper = ({
           destination,
           ttlSeconds,
           progressTracked,
+          fileMode,
+          userId,
+          groupId,
         } = values;
 
         let compression: string | null = null;
@@ -482,12 +486,6 @@ const ManualFileDownloadRequestFromRepositoryFormWrapper = ({
         }
 
         const fileDownloadRequestId = uuidv7();
-
-        // Default Unix file permissions since the repository doesn't store this metadata.
-        // Defaults: fileMode 0 (rw-r--r--), userId -1, groupId -1.
-        const fileMode = 0;
-        const userId = -1;
-        const groupId = -1;
 
         // Create the file download request with all metadata
         await new Promise<void>((resolve, reject) => {
@@ -566,28 +564,9 @@ const ManualFileDownloadRequestFromRepositoryFormWrapper = ({
       repositoriesData={repositoriesData}
       isLoading={isUploading}
       onFileSubmit={handleFileUpload}
+      showAdvancedOptions={showAdvancedOptions}
     />
   );
-};
-
-type FileDownloadRequestsContentProps = {
-  deviceRef: FilesUploadTab_fileDownloadRequests$key;
-};
-
-const FileDownloadRequestsContent = ({
-  deviceRef,
-}: FileDownloadRequestsContentProps) => {
-  const { data } = usePaginationFragment<
-    FilesUploadTab_PaginationQuery,
-    FilesUploadTab_fileDownloadRequests$key
-  >(DEVICE_FILE_DOWNLOAD_REQUESTS_FRAGMENT, deviceRef);
-
-  const fileDownloadRequests = useMemo(
-    () => data.fileDownloadRequests?.edges?.map((edge) => edge.node) ?? [],
-    [data.fileDownloadRequests],
-  );
-
-  return <FileDownloadRequestsTable requests={fileDownloadRequests} />;
 };
 
 type FilesUploadTabProps = {
@@ -601,6 +580,20 @@ const FilesUploadTab = ({ deviceRef }: FilesUploadTabProps) => {
   const [updateMode, setUpdateMode] = useState<"repository" | "file">("file");
 
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
+
+  const { data } = usePaginationFragment<
+    FilesUploadTab_PaginationQuery,
+    FilesUploadTab_fileDownloadRequests$key
+  >(DEVICE_FILE_DOWNLOAD_REQUESTS_FRAGMENT, deviceRef);
+
+  const fileDownloadRequests = useMemo(
+    () => data.fileDownloadRequests?.edges?.map((edge) => edge.node) ?? [],
+    [data.fileDownloadRequests],
+  );
+
+  const showAdvancedOptions =
+    data.capabilities.includes("POSIX_FILE_TRANSFER_STORAGE") ||
+    data.capabilities.includes("POSIX_FILE_TRANSFER_STREAM");
 
   const [getRepositoriesQuery, getRepositories] =
     useQueryLoader<FilesUploadTab_getRepositories_Query>(
@@ -687,6 +680,7 @@ const FilesUploadTab = ({ deviceRef }: FilesUploadTabProps) => {
               <ManualFileDownloadRequestFormWrapper
                 setErrorFeedback={setErrorFeedback}
                 deviceId={deviceId || ""}
+                showAdvancedOptions={showAdvancedOptions}
               />
             ) : (
               getRepositoriesQuery && (
@@ -694,6 +688,7 @@ const FilesUploadTab = ({ deviceRef }: FilesUploadTabProps) => {
                   repositoriesQueryRef={getRepositoriesQuery}
                   setErrorFeedback={setErrorFeedback}
                   deviceId={deviceId || ""}
+                  showAdvancedOptions={showAdvancedOptions}
                 />
               )
             )}
@@ -711,7 +706,7 @@ const FilesUploadTab = ({ deviceRef }: FilesUploadTabProps) => {
           />
         </h5>
 
-        <FileDownloadRequestsContent deviceRef={deviceRef} />
+        <FileDownloadRequestsTable requests={fileDownloadRequests} />
       </div>
     </Tab>
   );

--- a/frontend/src/components/FileDropzone.tsx
+++ b/frontend/src/components/FileDropzone.tsx
@@ -22,6 +22,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import CloseButton from "@/components/CloseButton";
+import Icon from "@/components/Icon";
 import Tag from "@/components/Tag";
 import { formatFileSize } from "@/lib/files";
 
@@ -193,6 +194,9 @@ const FileDropzone = ({ files, onChange, isInvalid }: FileDropzoneProps) => {
       >
         {files.length === 0 ? (
           <div className="py-2">
+            <div className="mb-2 text-secondary">
+              <Icon icon="folder" size="3x" />
+            </div>
             <p className="mb-1 text-muted">
               <FormattedMessage
                 id="components.FileDropzone.dropzonePrompt"

--- a/frontend/src/forms/ManualFileDownloadRequestForm.tsx
+++ b/frontend/src/forms/ManualFileDownloadRequestForm.tsx
@@ -26,6 +26,7 @@ import Select from "react-select";
 
 import Button from "@/components/Button";
 import Col from "@/components/Col";
+import CollapseItem, { useCollapseToggle } from "@/components/CollapseItem";
 import FileDropzone from "@/components/FileDropzone";
 import Form from "@/components/Form";
 import { FormRowWithMargin as FormRow } from "@/components/FormRow";
@@ -43,12 +44,16 @@ type FileDownloadRequestFormValues = {
   destination: string | null;
   ttlSeconds: number;
   progressTracked: boolean;
+  fileMode?: number;
+  userId?: number;
+  groupId?: number;
 };
 
 type ManualFileDownloadRequestFormProps = {
   className?: string;
   isLoading: boolean;
   onFileSubmit: (values: FileDownloadRequestFormValues) => void;
+  showAdvancedOptions?: boolean;
 };
 
 const destinationTypeOptions = [
@@ -61,8 +66,11 @@ const ManualFileDownloadRequestForm = ({
   className,
   isLoading,
   onFileSubmit,
+  showAdvancedOptions = false,
 }: ManualFileDownloadRequestFormProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const { open: advancedOptionsOpen, toggle: toggleAdvancedOptions } =
+    useCollapseToggle();
 
   const {
     formState: { errors },
@@ -80,6 +88,9 @@ const ManualFileDownloadRequestForm = ({
       destination: null,
       ttlSeconds: 0,
       progress: false,
+      fileMode: undefined,
+      userId: undefined,
+      groupId: undefined,
     },
     resolver: zodResolver(fileDownloadRequestFormSchema),
   });
@@ -109,6 +120,9 @@ const ManualFileDownloadRequestForm = ({
         destination: data.destination,
         ttlSeconds: data.ttlSeconds,
         progressTracked: data.progress,
+        fileMode: data.fileMode,
+        userId: data.userId,
+        groupId: data.groupId,
       });
       setSelectedFiles([]);
       reset();
@@ -124,7 +138,7 @@ const ManualFileDownloadRequestForm = ({
         id="file"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestForm.fileLabel"
+            id="forms.ManualFileDownloadRequestForm.fileLabel"
             defaultMessage="Files"
           />
         }
@@ -139,7 +153,7 @@ const ManualFileDownloadRequestForm = ({
         ) : (
           <Form.Text muted>
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.fileHint"
+              id="forms.ManualFileDownloadRequestForm.fileHint"
               defaultMessage="Select files or a folder. Multiple items will be compressed into a tar.gz archive."
             />
           </Form.Text>
@@ -151,7 +165,7 @@ const ManualFileDownloadRequestForm = ({
           id="archiveName"
           label={
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.archiveNameLabel"
+              id="forms.ManualFileDownloadRequestForm.archiveNameLabel"
               defaultMessage="Archive Name"
             />
           }
@@ -163,7 +177,7 @@ const ManualFileDownloadRequestForm = ({
           />
           <Form.Text muted>
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.archiveNameHint"
+              id="forms.ManualFileDownloadRequestForm.archiveNameHint"
               defaultMessage="Optional name for the tar.gz archive. Defaults to 'files-archive' if left empty."
             />
           </Form.Text>
@@ -174,7 +188,7 @@ const ManualFileDownloadRequestForm = ({
         id="destinationType"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestForm.destinationLabel"
+            id="forms.ManualFileDownloadRequestForm.destinationLabel"
             defaultMessage="Destination"
           />
         }
@@ -205,7 +219,7 @@ const ManualFileDownloadRequestForm = ({
           id="destination"
           label={
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.destinationPathLabel"
+              id="forms.ManualFileDownloadRequestForm.destinationPathLabel"
               defaultMessage="Destination Path"
             />
           }
@@ -222,7 +236,7 @@ const ManualFileDownloadRequestForm = ({
           ) : (
             <Form.Text muted>
               <FormattedMessage
-                id="components.ManualFileDownloadRequestForm.destinationPathHint"
+                id="forms.ManualFileDownloadRequestForm.destinationPathHint"
                 defaultMessage="Absolute path on the target device where the file should be written."
               />
             </Form.Text>
@@ -234,7 +248,7 @@ const ManualFileDownloadRequestForm = ({
         id="ttlSeconds"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestForm.ttlLabel"
+            id="forms.ManualFileDownloadRequestForm.ttlLabel"
             defaultMessage="TTL (seconds)"
           />
         }
@@ -252,7 +266,7 @@ const ManualFileDownloadRequestForm = ({
         ) : (
           <Form.Text muted>
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.ttlHint"
+              id="forms.ManualFileDownloadRequestForm.ttlHint"
               defaultMessage="Set to 0 for no expiry."
             />
           </Form.Text>
@@ -263,7 +277,7 @@ const ManualFileDownloadRequestForm = ({
         id="progress"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestForm.progressLabel"
+            id="forms.ManualFileDownloadRequestForm.progressLabel"
             defaultMessage="Report Progress"
           />
         }
@@ -276,12 +290,86 @@ const ManualFileDownloadRequestForm = ({
         <FormFeedback feedback={errors.progress?.message} />
       </FormRow>
 
+      {showAdvancedOptions && (
+        <div className="mb-3">
+          <CollapseItem
+            type="flat"
+            open={advancedOptionsOpen}
+            onToggle={toggleAdvancedOptions}
+            isInsideTable={true}
+            title={
+              <FormattedMessage
+                id="forms.ManualFileDownloadRequestForm.advancedOptionsTitle"
+                defaultMessage="Advanced Options"
+              />
+            }
+          >
+            <FormRow
+              id="userId"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestForm.userIdLabel"
+                  defaultMessage="User ID"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`userId` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.userId}
+              />
+              <FormFeedback feedback={errors.userId?.message} />
+            </FormRow>
+
+            <FormRow
+              id="groupId"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestForm.groupIdLabel"
+                  defaultMessage="Group ID"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`groupId` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.groupId}
+              />
+              <FormFeedback feedback={errors.groupId?.message} />
+            </FormRow>
+
+            <FormRow
+              id="fileMode"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestForm.fileModeLabel"
+                  defaultMessage="File Mode"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`fileMode` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.fileMode}
+              />
+              <FormFeedback feedback={errors.fileMode?.message} />
+            </FormRow>
+          </CollapseItem>
+        </div>
+      )}
+
       <Row>
         <Col className="d-flex justify-content-end">
           <Button variant="primary" type="submit" disabled={isLoading}>
             {isLoading && <Spinner size="sm" className="me-2" />}
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.uploadButton"
+              id="forms.ManualFileDownloadRequestForm.uploadButton"
               defaultMessage="Upload"
             />
           </Button>

--- a/frontend/src/forms/ManualFileDownloadRequestFromRepositoryForm.tsx
+++ b/frontend/src/forms/ManualFileDownloadRequestFromRepositoryForm.tsx
@@ -34,6 +34,7 @@ import type {
 
 import Button from "@/components/Button";
 import Col from "@/components/Col";
+import CollapseItem, { useCollapseToggle } from "@/components/CollapseItem";
 import FileSelect from "@/components/FileSelect";
 import Form from "@/components/Form";
 import { FormRowWithMargin as FormRow } from "@/components/FormRow";
@@ -79,6 +80,9 @@ const fromRepositoryInitialData: ManualFileDownloadRequestFromRepositoryData = {
   destination: null,
   ttlSeconds: 0,
   progressTracked: false,
+  fileMode: undefined,
+  userId: undefined,
+  groupId: undefined,
 };
 
 const destinationOptions = [
@@ -92,6 +96,7 @@ type ManualFileDownloadRequestFromRepositoryFormProps = {
   repositoriesData?: ManualFileDownloadRequestFromRepositoryForm_repositories_Fragment$key;
   isLoading: boolean;
   onFileSubmit: (values: ManualFileDownloadRequestFromRepositoryData) => void;
+  showAdvancedOptions: boolean;
 };
 
 const ManualFileDownloadRequestFromRepositoryForm = ({
@@ -99,8 +104,11 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
   className,
   isLoading,
   onFileSubmit,
+  showAdvancedOptions,
 }: ManualFileDownloadRequestFromRepositoryFormProps) => {
   const intl = useIntl();
+  const { open: advancedOptionsOpen, toggle: toggleAdvancedOptions } =
+    useCollapseToggle();
 
   const {
     control,
@@ -290,7 +298,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
         id="destinationType"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestForm.destinationLabel"
+            id="forms.ManualFileDownloadRequestFromRepositoryForm.destinationLabel"
             defaultMessage="Destination"
           />
         }
@@ -321,7 +329,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
           id="destination"
           label={
             <FormattedMessage
-              id="components.ManualFileDownloadRequestForm.destinationPathLabel"
+              id="forms.ManualFileDownloadRequestFromRepositoryForm.destinationPathLabel"
               defaultMessage="Destination Path"
             />
           }
@@ -338,7 +346,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
           ) : (
             <Form.Text muted>
               <FormattedMessage
-                id="components.ManualFileDownloadRequestForm.destinationPathHint"
+                id="forms.ManualFileDownloadRequestFromRepositoryForm.destinationPathHint"
                 defaultMessage="Absolute path on the target device where the file should be written."
               />
             </Form.Text>
@@ -350,7 +358,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
         id="ttlSeconds"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestFromRepositoryForm.ttlLabel"
+            id="forms.ManualFileDownloadRequestFromRepositoryForm.ttlLabel"
             defaultMessage="TTL (seconds)"
           />
         }
@@ -368,7 +376,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
         ) : (
           <Form.Text muted>
             <FormattedMessage
-              id="components.ManualFileDownloadRequestFromRepositoryForm.ttlHint"
+              id="forms.ManualFileDownloadRequestFromRepositoryForm.ttlHint"
               defaultMessage="Set to 0 for no expiry."
             />
           </Form.Text>
@@ -379,7 +387,7 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
         id="progress"
         label={
           <FormattedMessage
-            id="components.ManualFileDownloadRequestFromRepositoryForm.progressLabel"
+            id="forms.ManualFileDownloadRequestFromRepositoryForm.progressLabel"
             defaultMessage="Report Progress"
           />
         }
@@ -392,12 +400,86 @@ const ManualFileDownloadRequestFromRepositoryForm = ({
         <FormFeedback feedback={errors.progressTracked?.message} />
       </FormRow>
 
+      {showAdvancedOptions && (
+        <div className="mb-3">
+          <CollapseItem
+            type="flat"
+            open={advancedOptionsOpen}
+            onToggle={toggleAdvancedOptions}
+            isInsideTable={true}
+            title={
+              <FormattedMessage
+                id="forms.ManualFileDownloadRequestFromRepositoryForm.advancedOptionsTitle"
+                defaultMessage="Advanced Options"
+              />
+            }
+          >
+            <FormRow
+              id="userId"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestFromRepositoryForm.userIdLabel"
+                  defaultMessage="User ID"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`userId` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.userId}
+              />
+              <FormFeedback feedback={errors.userId?.message} />
+            </FormRow>
+
+            <FormRow
+              id="groupId"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestFromRepositoryForm.groupIdLabel"
+                  defaultMessage="Group ID"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`groupId` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.groupId}
+              />
+              <FormFeedback feedback={errors.groupId?.message} />
+            </FormRow>
+
+            <FormRow
+              id="fileMode"
+              label={
+                <FormattedMessage
+                  id="forms.ManualFileDownloadRequestFromRepositoryForm.fileModeLabel"
+                  defaultMessage="File Mode"
+                />
+              }
+            >
+              <Form.Control
+                type="text"
+                {...register(`fileMode` as const, {
+                  setValueAs: (v) => (v === "" ? undefined : Number(v)),
+                })}
+                isInvalid={!!errors.fileMode}
+              />
+              <FormFeedback feedback={errors.fileMode?.message} />
+            </FormRow>
+          </CollapseItem>
+        </div>
+      )}
+
       <Row>
         <Col className="d-flex justify-content-end">
           <Button variant="primary" type="submit" disabled={isLoading}>
             {isLoading && <Spinner size="sm" className="me-2" />}
             <FormattedMessage
-              id="components.ManualFileDownloadRequestFromRepositoryForm.uploadButton"
+              id="forms.ManualFileDownloadRequestFromRepositoryForm.uploadButton"
               defaultMessage="Upload"
             />
           </Button>

--- a/frontend/src/forms/validation.ts
+++ b/frontend/src/forms/validation.ts
@@ -552,6 +552,9 @@ const fileDownloadRequestFormSchema = z
     destination: nullableDestinationSchema,
     ttlSeconds: z.number(messages.number.id).int().min(0),
     progress: z.boolean(),
+    fileMode: z.number(messages.number.id).int().positive().optional(),
+    userId: z.number(messages.number.id).int().positive().optional(),
+    groupId: z.number(messages.number.id).int().positive().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.destinationType === "FILESYSTEM" && data.destination === null) {
@@ -605,6 +608,9 @@ const manualFileDownloadRequestFromRepositorySchema = z
     destination: nullableDestinationSchema,
     ttlSeconds: z.number(messages.number.id).int().min(0),
     progressTracked: z.boolean(),
+    fileMode: z.number(messages.number.id).int().positive().optional(),
+    userId: z.number(messages.number.id).int().positive().optional(),
+    groupId: z.number(messages.number.id).int().positive().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.destinationType === "FILESYSTEM" && data.destination === null) {

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -1101,44 +1101,11 @@
   "components.ManualFileDownloadRequestForm.archiveNameLabel": {
     "defaultMessage": "Archive Name"
   },
-  "components.ManualFileDownloadRequestForm.destinationLabel": {
-    "defaultMessage": "Destination"
-  },
-  "components.ManualFileDownloadRequestForm.destinationPathHint": {
-    "defaultMessage": "Absolute path on the target device where the file should be written."
-  },
-  "components.ManualFileDownloadRequestForm.destinationPathLabel": {
-    "defaultMessage": "Destination Path"
-  },
   "components.ManualFileDownloadRequestForm.fileHint": {
     "defaultMessage": "Select files or a folder. Multiple items will be compressed into a tar.gz archive."
   },
   "components.ManualFileDownloadRequestForm.fileLabel": {
     "defaultMessage": "Files"
-  },
-  "components.ManualFileDownloadRequestForm.progressLabel": {
-    "defaultMessage": "Report Progress"
-  },
-  "components.ManualFileDownloadRequestForm.ttlHint": {
-    "defaultMessage": "Set to 0 for no expiry."
-  },
-  "components.ManualFileDownloadRequestForm.ttlLabel": {
-    "defaultMessage": "TTL (seconds)"
-  },
-  "components.ManualFileDownloadRequestForm.uploadButton": {
-    "defaultMessage": "Upload"
-  },
-  "components.ManualFileDownloadRequestFromRepositoryForm.progressLabel": {
-    "defaultMessage": "Report Progress"
-  },
-  "components.ManualFileDownloadRequestFromRepositoryForm.ttlHint": {
-    "defaultMessage": "Set to 0 for no expiry."
-  },
-  "components.ManualFileDownloadRequestFromRepositoryForm.ttlLabel": {
-    "defaultMessage": "TTL (seconds)"
-  },
-  "components.ManualFileDownloadRequestFromRepositoryForm.uploadButton": {
-    "defaultMessage": "Upload"
   },
   "components.ManualOtaFromFileCollection.baseImageFromCollectionLabel": {
     "defaultMessage": "Base Image Collection"
@@ -2258,14 +2225,80 @@
   "forms.DeploymentCampaignForm.targetReleaseLabel": {
     "defaultMessage": "Target Release"
   },
+  "forms.ManualFileDownloadRequestForm.advancedOptionsTitle": {
+    "defaultMessage": "Advanced Options"
+  },
+  "forms.ManualFileDownloadRequestForm.archiveNameHint": {
+    "defaultMessage": "Optional name for the tar.gz archive. Defaults to 'files-archive' if left empty."
+  },
+  "forms.ManualFileDownloadRequestForm.archiveNameLabel": {
+    "defaultMessage": "Archive Name"
+  },
+  "forms.ManualFileDownloadRequestForm.destinationLabel": {
+    "defaultMessage": "Destination"
+  },
+  "forms.ManualFileDownloadRequestForm.destinationPathHint": {
+    "defaultMessage": "Absolute path on the target device where the file should be written."
+  },
+  "forms.ManualFileDownloadRequestForm.destinationPathLabel": {
+    "defaultMessage": "Destination Path"
+  },
+  "forms.ManualFileDownloadRequestForm.fileHint": {
+    "defaultMessage": "Select files or a folder. Multiple items will be compressed into a tar.gz archive."
+  },
+  "forms.ManualFileDownloadRequestForm.fileLabel": {
+    "defaultMessage": "Files"
+  },
+  "forms.ManualFileDownloadRequestForm.fileModeLabel": {
+    "defaultMessage": "File Mode"
+  },
+  "forms.ManualFileDownloadRequestForm.groupIdLabel": {
+    "defaultMessage": "Group ID"
+  },
+  "forms.ManualFileDownloadRequestForm.progressLabel": {
+    "defaultMessage": "Report Progress"
+  },
+  "forms.ManualFileDownloadRequestForm.ttlHint": {
+    "defaultMessage": "Set to 0 for no expiry."
+  },
+  "forms.ManualFileDownloadRequestForm.ttlLabel": {
+    "defaultMessage": "TTL (seconds)"
+  },
+  "forms.ManualFileDownloadRequestForm.uploadButton": {
+    "defaultMessage": "Upload"
+  },
+  "forms.ManualFileDownloadRequestForm.userIdLabel": {
+    "defaultMessage": "User ID"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.advancedOptionsTitle": {
+    "defaultMessage": "Advanced Options"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.destinationLabel": {
+    "defaultMessage": "Destination"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.destinationPathHint": {
+    "defaultMessage": "Absolute path on the target device where the file should be written."
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.destinationPathLabel": {
+    "defaultMessage": "Destination Path"
+  },
   "forms.ManualFileDownloadRequestFromRepositoryForm.fileLabel": {
     "defaultMessage": "File"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.fileModeLabel": {
+    "defaultMessage": "File Mode"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.groupIdLabel": {
+    "defaultMessage": "Group ID"
   },
   "forms.ManualFileDownloadRequestFromRepositoryForm.noRepositoriesAvailable": {
     "defaultMessage": "No repositories available"
   },
   "forms.ManualFileDownloadRequestFromRepositoryForm.noRepositoriesFoundMatching": {
     "defaultMessage": "No repositories found matching \"{inputValue}\""
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.progressLabel": {
+    "defaultMessage": "Report Progress"
   },
   "forms.ManualFileDownloadRequestFromRepositoryForm.repositoryLabel": {
     "defaultMessage": "Repository"
@@ -2275,6 +2308,18 @@
   },
   "forms.ManualFileDownloadRequestFromRepositoryForm.selectRepositoryHint": {
     "defaultMessage": "Select a repository before selecting a file..."
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.ttlHint": {
+    "defaultMessage": "Set to 0 for no expiry."
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.ttlLabel": {
+    "defaultMessage": "TTL (seconds)"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.uploadButton": {
+    "defaultMessage": "Upload"
+  },
+  "forms.ManualFileDownloadRequestFromRepositoryForm.userIdLabel": {
+    "defaultMessage": "User ID"
   },
   "forms.ManualOtaFromFileCollection.baseImageCollectionOption": {
     "defaultMessage": "Search or select a base image collection..."


### PR DESCRIPTION
## Add file upload UX with advanced options 


- add advanced options in file upload request forms and upload tab flow  so that users can specify `userId`, `groupId` and `fileMode` for  the uploaded file
- add a folder icon to the file dropzone for clearer visual guidance


## Checklist

<!--
Put an `x` in the boxes that apply. You can fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask.
This is simply a reminder of what will be checked before merging.
-->

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation (if appropriate)

## Further Comments (optional)

<!--
If this is a relatively large or complex change, explain:
    - Why you chose this solution
    - What alternatives you considered
    - Any trade-offs or follow-up work
-->

## Screenshots / Demos (optional)

<details><summary>Screenshots</summary>
<p>

Old:
<img width="1917" height="864" alt="image" src="https://github.com/user-attachments/assets/5bda7b8a-525d-4b73-8636-38de38bc7a27" />


Updated:
<img width="1917" height="864" alt="image" src="https://github.com/user-attachments/assets/491c08ae-41d9-414b-9a3d-9c55b04a5da5" />
<img width="1917" height="864" alt="image" src="https://github.com/user-attachments/assets/517656d6-e3d2-4717-87a0-36f1a4102636" />


</p>
</details> 
