### PR TITLE
fix: run reconciliation after provisioning is complete

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -32,9 +32,18 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      backend--release_created: ${{ steps.release.outputs.backend--release_created }}
+      backend--version: ${{ steps.release.outputs.backend--version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: actions/create-github-app-token@v3
+        id: app-token
         with:
+          app-id: ${{ vars.EDGEHOG_APP_APP_ID }}
+          private-key: ${{ secrets.EDGEHOG_APP_PRIVATE_KEY }}
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
-          target-branch: ${{ github.ref_name }}

--- a/backend/lib/edgehog/tenants/tenant/changes/trigger_reconciliation.ex
+++ b/backend/lib/edgehog/tenants/tenant/changes/trigger_reconciliation.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,13 +24,23 @@ defmodule Edgehog.Tenants.Tenant.Changes.TriggerReconciliation do
 
   alias Edgehog.Tenants
 
+  require Logger
+
   @impl Ash.Resource.Change
   def change(changeset, _opts, _ctx) do
-    Ash.Changeset.after_action(changeset, fn _changeset, tenant ->
-      # TODO: this can probably be done with Ash notifiers, investigate that
-      Tenants.reconcile_tenant(tenant)
+    Ash.Changeset.after_transaction(changeset, &maybe_trigger_reconciliation/2)
+  end
 
-      {:ok, tenant}
-    end)
+  defp maybe_trigger_reconciliation(_changeset, {:ok, tenant} = result) do
+    # TODO: this can probably be done with Ash notifiers, investigate that
+    Tenants.reconcile_tenant(tenant)
+
+    result
+  end
+
+  defp maybe_trigger_reconciliation(_changeset, {:error, error} = result) do
+    Logger.debug("Tenant creation did not complete.", error: error)
+
+    result
   end
 end


### PR DESCRIPTION
#### What this PR does / why we need it:

Duplication of #1334 ++ Update of the CI so that I don't have to make anything to publish

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
