### PR TITLE
fix: force expand all tree nodes on data updates

### DIFF
--- a/frontend/src/components/DeploymentDetails.tsx
+++ b/frontend/src/components/DeploymentDetails.tsx
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Card, Col, Row } from "react-bootstrap";
 import Tree, { useTreeState } from "react-hyper-tree";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -438,9 +438,25 @@ const ContainerDeploymentItem = ({
 
   const { required, handlers } = useTreeState({
     data: treeData,
-    defaultOpened: true,
     id: prefix,
   });
+
+  useEffect(() => {
+    const openNodeAndChildren = (nodes: any[]) => {
+      if (!nodes) return;
+
+      nodes.forEach((node) => {
+        handlers.setOpen(node.id, true);
+        if (node.children && node.children.length > 0) {
+          openNodeAndChildren(node.children);
+        }
+      });
+    };
+
+    if (treeData && treeData.length > 0) {
+      openNodeAndChildren(treeData);
+    }
+  }, [treeData, handlers]);
 
   return (
     <Tree


### PR DESCRIPTION

#### What this PR does / why we need it:
The tree component automatically collapses whenever the data updates. This happens because `defaultOpened` only works on the first load, and the library loses the expansion state when treeData receives new objects from useMemo.

Added a useEffect that runs a recursive function to force open all nodes and their children every time treeData changes. This ensures the tree stays fully expanded even after data refreshes.
#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
