### PR TITLE
ci: fix incorrect version.js handling

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -158,6 +158,6 @@ jobs:
           echo "${{ secrets.DOCS_DEPLOY_KEY }}" | ssh-add -
           mkdir -p ~/.ssh/
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git remote add topush "git@github.com:edgehog-device-manager/docs.git"
-          git fetch topush
-          git push topush main
+          git config --global --unset-all url."https://${{ github.token }}:x-oauth-basic@github.com/".insteadOf || true
+          git remote set-url origin git@github.com:edgehog-device-manager/docs.git
+          git push origin main

--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -131,8 +131,6 @@ jobs:
           mkdir docs/$DOCS_DIRNAME
           # Copy doc pages
           cp -r edgehog/doc/doc/* docs/$DOCS_DIRNAME/
-          # Copy version dropdown config
-          cp edgehog/doc/versions.js docs/
           # Copy GraphQL docs
           cp -r ./edgehog/backend/tenant-graphql-api docs/$DOCS_DIRNAME/
           # Copy Admin REST API docs


### PR DESCRIPTION
#### What this PR does / why we need it:

staple-actions configures a global git insteadOf rewrite during mix deps.get, converting GitHub SSH/HTTPS remotes to HTTPS with github.token credentials. That makes the final docs push use the actions token instead of the deploy key and fail with 403. Remove the rewrite before push and reset origin to the SSH remote so the deploy key is used.

The CI in old releases was always copied resulting in wrong `version.js` versions. Fixed for release 0.12

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md