### PR TITLE
fix: use translated storage source IDs for storage uploads

### DIFF
--- a/backend/lib/edgehog/files/file_upload_request/changes/validate_source.ex
+++ b/backend/lib/edgehog/files/file_upload_request/changes/validate_source.ex
@@ -1,0 +1,59 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Edgehog.Files.FileUploadRequest.Changes.ValidateSource do
+  @moduledoc """
+  Changes module responsible for validating the `source` field of a `FileUploadRequest`
+  based on the `source_type`.
+  """
+
+  use Ash.Resource.Change
+
+  alias Ash.Error.Changes.InvalidArgument
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    source_type = Ash.Changeset.get_attribute(changeset, :source_type)
+    source = Ash.Changeset.get_attribute(changeset, :source)
+
+    case validate_source(source_type, source) do
+      {:ok, normalized_source} ->
+        Ash.Changeset.change_attribute(changeset, :source, normalized_source)
+
+      {:error, reason} ->
+        Ash.Changeset.add_error(changeset, reason)
+    end
+  end
+
+  defp validate_source(:storage, source) do
+    case AshGraphql.Resource.decode_relay_id(source) do
+      {:ok, %{id: decoded_source}} ->
+        {:ok, decoded_source}
+
+      {:error, _reason} ->
+        {:error,
+         InvalidArgument.exception(
+           field: :source,
+           message: "invalid storage file id"
+         )}
+    end
+  end
+
+  defp validate_source(_source_type, source), do: {:ok, source}
+end

--- a/backend/lib/edgehog/files/file_upload_request/file_upload_request.ex
+++ b/backend/lib/edgehog/files/file_upload_request/file_upload_request.ex
@@ -73,6 +73,7 @@ defmodule Edgehog.Files.FileUploadRequest do
                eager_validate_with: Edgehog.Devices
              )
 
+      change Changes.ValidateSource
       change Changes.SetUploadUrl
       change Changes.SendFileUploadRequest
     end

--- a/backend/test/edgehog_web/schema/mutation/create_file_upload_request_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/create_file_upload_request_test.exs
@@ -22,6 +22,7 @@ defmodule EdgehogWeb.Schema.Mutation.CreateFileUploadRequestTest do
   use EdgehogWeb.GraphqlCase, async: true
 
   import Edgehog.DevicesFixtures
+  import Edgehog.FilesFixtures
 
   alias Astarte.Client.APIError
   alias Edgehog.Astarte.Device.FileUploadRequest.RequestData
@@ -75,6 +76,90 @@ defmodule EdgehogWeb.Schema.Mutation.CreateFileUploadRequestTest do
       assert normalize_json_map(file_upload_request["httpHeaders"]) == %{"X-Test" => "1"}
 
       assert file_upload_request["device"]["deviceId"]
+    end
+
+    test "creates storage file upload request with decoded source id", %{tenant: tenant} do
+      expect(StorageMock, :create_presigned_urls, fn path ->
+        assert String.contains?(path, "uploads/tenants/#{tenant.tenant_id}/file_upload_requests/")
+
+        {:ok,
+         %{
+           put_url: "http://example.test/upload",
+           get_url: "http://example.test/download"
+         }}
+      end)
+
+      file_download_request = manual_file_download_request_fixture(tenant: tenant)
+      encoded_source = AshGraphql.Resource.encode_relay_id(file_download_request)
+
+      expect(FileUploadRequestMock, :request_upload, fn _client, _device_id, request_data ->
+        assert %RequestData{source: source, sourceType: :storage} = request_data
+        assert source == file_download_request.id
+        :ok
+      end)
+
+      result =
+        create_file_upload_request_mutation(
+          tenant: tenant,
+          input: %{
+            "sourceType" => "STORAGE",
+            "source" => encoded_source,
+            "encoding" => "gzip",
+            "progressTracked" => true
+          }
+        )
+
+      file_upload_request = extract_result!(result, "createFileUploadRequest")
+
+      assert file_upload_request["source"] == file_download_request.id
+      assert file_upload_request["sourceType"] == "STORAGE"
+    end
+
+    test "creates streaming file upload request with empty source", %{tenant: tenant} do
+      expect(StorageMock, :create_presigned_urls, fn path ->
+        assert String.contains?(path, "uploads/tenants/#{tenant.tenant_id}/file_upload_requests/")
+
+        {:ok,
+         %{
+           put_url: "http://example.test/upload",
+           get_url: "http://example.test/download"
+         }}
+      end)
+
+      expect(FileUploadRequestMock, :request_upload, fn _client, _device_id, request_data ->
+        assert %RequestData{source: "", sourceType: :streaming} = request_data
+        :ok
+      end)
+
+      result =
+        create_file_upload_request_mutation(
+          tenant: tenant,
+          input: %{
+            "sourceType" => "STREAMING",
+            "source" => "",
+            "encoding" => "gzip",
+            "progressTracked" => true
+          }
+        )
+
+      file_upload_request = extract_result!(result, "createFileUploadRequest")
+
+      assert file_upload_request["source"] == nil
+      assert file_upload_request["sourceType"] == "STREAMING"
+    end
+
+    test "returns error for invalid storage source id", %{tenant: tenant} do
+      result =
+        create_file_upload_request_mutation(
+          tenant: tenant,
+          input: %{
+            "sourceType" => "STORAGE",
+            "source" => "not-a-relay-id"
+          }
+        )
+
+      assert %{message: "invalid storage file id"} =
+               extract_error!(result, "createFileUploadRequest")
     end
 
     test "returns error when device does not exist", %{tenant: tenant} do

--- a/frontend/src/api/schema.graphql
+++ b/frontend/src/api/schema.graphql
@@ -27,58 +27,24 @@ input ContainerCreateWithNestedDeviceMappingsInput {
 
 input CampaignCampaignMechanismFileDownloadInput {
   """
-  Destination-specific information on where to write the file to.
-  Required when destination_type is :filesystem.
-  """
-  destination: String
-
-  """
-  Optional unix uid of the user owning the file. Set to -1 to use device default.
-  Defaults to -1.
-  """
-  userId: Int
-
-  fileId: ID
-
-  """
-  The maximum number of in progress file downloads. The File Download Campaign will
-  have at most this number of File Download Requests that are started but not yet
-  finished (either successfully or not).
-  """
-  maxInProgressOperations: Int
-
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  File Download Request lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
-
-  """
-  The number of attempts that have to be tried before giving up on the
-  file download of a specific target (and considering it an error). Note that the
-  file download is retried only if the request doesn't get acknowledged from the
-  device.
-  """
-  requestRetries: Int
-
-  """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the File Download Campaign terminates with
-  a failure.
-  """
-  maxFailurePercentage: Float
-
-  """
   Optional compression type for the file (e.g., "tar.gz").
   Other values are: ['tar.gz']. Defaults to empty string (no compression).
   """
   compression: String
 
   """
-  Optional ttl for how long to keep the file for on the device, if 0 is forever.
-  Defaults to 0.
+  Destination-specific information on where to write the file to.
+  Required when destination_type is :filesystem.
   """
-  ttlSeconds: Int
+  destination: String
+
+  """
+  Device-specific field indicating where the file should be stored.
+  Supported values are: storage, streaming, filesystem.
+  """
+  destinationType: FileDestination
+
+  fileId: ID
 
   """
   Optional unix mode for the file (e.g., 0o644 for readable by all, writable by owner).
@@ -93,10 +59,44 @@ input CampaignCampaignMechanismFileDownloadInput {
   groupId: Int
 
   """
-  Device-specific field indicating where the file should be stored.
-  Supported values are: storage, streaming, filesystem.
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the File Download Campaign terminates with
+  a failure.
   """
-  destinationType: FileDestination
+  maxFailurePercentage: Float
+
+  """
+  The maximum number of in progress file downloads. The File Download Campaign will
+  have at most this number of File Download Requests that are started but not yet
+  finished (either successfully or not).
+  """
+  maxInProgressOperations: Int
+
+  """
+  The number of attempts that have to be tried before giving up on the
+  file download of a specific target (and considering it an error). Note that the
+  file download is retried only if the request doesn't get acknowledged from the
+  device.
+  """
+  requestRetries: Int
+
+  """
+  The timeout (in seconds) Edgehog has to wait before considering a
+  File Download Request lost (and possibly retry). It must be at least 30 seconds.
+  """
+  requestTimeoutSeconds: Int
+
+  """
+  Optional ttl for how long to keep the file for on the device, if 0 is forever.
+  Defaults to 0.
+  """
+  ttlSeconds: Int
+
+  """
+  Optional unix uid of the user owning the file. Set to -1 to use device default.
+  Defaults to -1.
+  """
+  userId: Int
 }
 
 "An object representing the properties of a File Download campaign mechanism."
@@ -181,17 +181,24 @@ input CampaignCampaignMechanismFirmwareUpgradeInput {
   baseImageId: ID
 
   """
+  This boolean flag determines if the Base Image will be pushed to the
+  Device even if it already has a greater version of the Base Image.
+  """
+  forceDowngrade: Boolean
+
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Update Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
+
+  """
   The maximum number of in progress updates. The Update Campaign will have
   at most this number of OTA Operations that are started but not yet
   finished (either successfully or not).
   """
   maxInProgressOperations: Int
-
-  """
-  The timeout (in seconds) Edgehog has to wait before considering an OTA
-  Request lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -202,17 +209,10 @@ input CampaignCampaignMechanismFirmwareUpgradeInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Update Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering an OTA
+  Request lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
-
-  """
-  This boolean flag determines if the Base Image will be pushed to the
-  Device even if it already has a greater version of the Base Image.
-  """
-  forceDowngrade: Boolean
+  requestTimeoutSeconds: Int
 }
 
 "An object representing the properties of a Firmware Upgrade campaign mechanism."
@@ -258,9 +258,12 @@ type FirmwareUpgrade {
 }
 
 input CampaignCampaignMechanismDeploymentUpgradeInput {
-  releaseId: ID
-
-  targetReleaseId: ID
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
 
   """
   The maximum number of in progress operations. The Campaign will
@@ -269,11 +272,7 @@ input CampaignCampaignMechanismDeploymentUpgradeInput {
   """
   maxInProgressOperations: Int
 
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  Deployment lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
+  releaseId: ID
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -284,11 +283,12 @@ input CampaignCampaignMechanismDeploymentUpgradeInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering a
+  Deployment lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
+  requestTimeoutSeconds: Int
+
+  targetReleaseId: ID
 }
 
 "An object representing the properties of a Upgrade deployment campaign mechanism."
@@ -333,7 +333,12 @@ type DeploymentUpgrade {
 }
 
 input CampaignCampaignMechanismDeploymentDeleteInput {
-  releaseId: ID
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
 
   """
   The maximum number of in progress operations. The Campaign will
@@ -342,11 +347,7 @@ input CampaignCampaignMechanismDeploymentDeleteInput {
   """
   maxInProgressOperations: Int
 
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  Deployment lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
+  releaseId: ID
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -357,11 +358,10 @@ input CampaignCampaignMechanismDeploymentDeleteInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering a
+  Deployment lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
+  requestTimeoutSeconds: Int
 }
 
 "An object representing the properties of a Delete deployment campaign mechanism."
@@ -401,7 +401,12 @@ type DeploymentDelete {
 }
 
 input CampaignCampaignMechanismDeploymentStopInput {
-  releaseId: ID
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
 
   """
   The maximum number of in progress operations. The Campaign will
@@ -410,11 +415,7 @@ input CampaignCampaignMechanismDeploymentStopInput {
   """
   maxInProgressOperations: Int
 
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  Deployment lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
+  releaseId: ID
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -425,11 +426,10 @@ input CampaignCampaignMechanismDeploymentStopInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering a
+  Deployment lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
+  requestTimeoutSeconds: Int
 }
 
 "An object representing the properties of a Stop deployment campaign mechanism."
@@ -469,7 +469,12 @@ type DeploymentStop {
 }
 
 input CampaignCampaignMechanismDeploymentStartInput {
-  releaseId: ID
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
 
   """
   The maximum number of in progress operations. The Campaign will
@@ -478,11 +483,7 @@ input CampaignCampaignMechanismDeploymentStartInput {
   """
   maxInProgressOperations: Int
 
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  Deployment lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
+  releaseId: ID
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -493,11 +494,10 @@ input CampaignCampaignMechanismDeploymentStartInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering a
+  Deployment lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
+  requestTimeoutSeconds: Int
 }
 
 "An object representing the properties of a Start deployment campaign mechanism."
@@ -537,7 +537,12 @@ type DeploymentStart {
 }
 
 input CampaignCampaignMechanismDeploymentDeployInput {
-  releaseId: ID
+  """
+  The maximum percentage of failures allowed over the number of total targets.
+  If the failures exceed this threshold, the Deployment Campaign terminates with
+  a failure.
+  """
+  maxFailurePercentage: Float
 
   """
   The maximum number of in progress deployments. The Update Campaign will
@@ -546,11 +551,7 @@ input CampaignCampaignMechanismDeploymentDeployInput {
   """
   maxInProgressOperations: Int
 
-  """
-  The timeout (in seconds) Edgehog has to wait before considering a
-  Deployment lost (and possibly retry). It must be at least 30 seconds.
-  """
-  requestTimeoutSeconds: Int
+  releaseId: ID
 
   """
   The number of attempts that have to be tried before giving up on the
@@ -561,11 +562,10 @@ input CampaignCampaignMechanismDeploymentDeployInput {
   requestRetries: Int
 
   """
-  The maximum percentage of failures allowed over the number of total targets.
-  If the failures exceed this threshold, the Deployment Campaign terminates with
-  a failure.
+  The timeout (in seconds) Edgehog has to wait before considering a
+  Deployment lost (and possibly retry). It must be at least 30 seconds.
   """
-  maxFailurePercentage: Float
+  requestTimeoutSeconds: Int
 }
 
 "An object representing the properties of a Deploy deployment campaign mechanism."
@@ -851,6 +851,20 @@ enum ForwarderSessionStatus {
   CONNECTING
 }
 
+enum FileDeleteRequestStatus {
+  "Deletion completed successfully (response_code = 0)"
+  COMPLETED
+
+  "Deletion failed (response_code != 0 or timeout)"
+  FAILED
+
+  "Request created in database, not yet sent to device"
+  PENDING
+
+  "Request sent to device via Astarte, awaiting response"
+  SENT
+}
+
 enum FileUploadRequestStatus {
   "Transfer completed successfully (response_code = 0)"
   COMPLETED
@@ -1005,6 +1019,9 @@ enum DeviceCapability {
 
   "The device supports running applications using containers."
   CONTAINER_MANAGEMENT
+
+  "The device supports deleting files transferred to the device using file transfer storage"
+  FILE_TRANSFER_DELETE
 
   "The device supports reading files from it."
   FILE_TRANSFER_READ
@@ -1237,6 +1254,8 @@ input BaseImageCollectionFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1253,6 +1272,8 @@ input BaseImageCollectionFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1448,6 +1469,8 @@ input BaseImageFilterUrl {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1464,6 +1487,8 @@ input BaseImageFilterStartingVersionRequirement {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1480,6 +1505,8 @@ input BaseImageFilterVersion {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1698,6 +1725,8 @@ input ContainerVolumeFilterTarget {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1899,6 +1928,8 @@ input DeviceMappingFilterCgroupPermissions {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1915,6 +1946,8 @@ input DeviceMappingFilterPathInContainer {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -1931,6 +1964,8 @@ input DeviceMappingFilterPathOnHost {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2174,6 +2209,8 @@ input VolumeFilterDriver {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2190,6 +2227,8 @@ input VolumeFilterLabel {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2494,6 +2533,8 @@ input NetworkFilterDriver {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2510,6 +2551,8 @@ input NetworkFilterLabel {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2675,6 +2718,8 @@ input ReleaseFilterVersion {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2836,6 +2881,8 @@ input ImageCredentialsFilterUsername {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2852,6 +2899,8 @@ input ImageCredentialsFilterLabel {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -2997,6 +3046,8 @@ input ImageFilterReference {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -3136,6 +3187,8 @@ input DeploymentEventFilterMessage {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -3732,6 +3785,8 @@ input ContainerFilterVolumeDriver {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -3852,6 +3907,8 @@ input ContainerFilterNetworkMode {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -3881,6 +3938,8 @@ input ContainerFilterHostname {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4137,6 +4196,8 @@ input ApplicationFilterDescription {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4153,6 +4214,8 @@ input ApplicationFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4254,6 +4317,8 @@ input SystemModelPartNumberFilterPartNumber {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4423,6 +4488,8 @@ input SystemModelFilterPictureUrl {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4439,6 +4506,8 @@ input SystemModelFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4455,6 +4524,8 @@ input SystemModelFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4618,6 +4689,8 @@ input HardwareTypePartNumberFilterPartNumber {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4765,6 +4838,8 @@ input HardwareTypeFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4781,6 +4856,8 @@ input HardwareTypeFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4973,6 +5050,8 @@ input DeviceFilterPartNumber {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -4989,6 +5068,8 @@ input DeviceFilterSerialNumber {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5005,6 +5086,8 @@ input DeviceFilterLastSeenIp {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5060,6 +5143,8 @@ input DeviceFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5076,6 +5161,8 @@ input DeviceFilterDeviceId {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5142,6 +5229,9 @@ input DeviceFilterInput {
 
   "The existing file upload requests for this device"
   fileUploadRequests: FileUploadRequestFilterInput
+
+  "The existing file delete requests for this device"
+  fileDeleteRequests: FileDeleteRequestFilterInput
 
   applicationDeployments: DeploymentFilterInput
 }
@@ -5286,6 +5376,27 @@ type Device implements Node {
     last: Int
   ): FileUploadRequestConnection!
 
+  "The existing file delete requests for this device"
+  fileDeleteRequests(
+    "How to sort the records in the response"
+    sort: [FileDeleteRequestSortInput]
+
+    "A filter to limit the results"
+    filter: FileDeleteRequestFilterInput
+
+    "The number of records to return from the beginning. Maximum 250"
+    first: Int
+
+    "Show records before the specified keyset."
+    before: String
+
+    "Show records after the specified keyset."
+    after: String
+
+    "The number of records to return to the end. Maximum 250"
+    last: Int
+  ): FileDeleteRequestConnection!
+
   applicationDeployments(
     "How to sort the records in the response"
     sort: [DeploymentSortInput]
@@ -5360,6 +5471,154 @@ type Device implements Node {
   systemStatus: SystemStatus
 
   wifiScanResults: [WifiScanResult!]
+}
+
+"The result of the :create_file_delete_request mutation"
+type CreateFileDeleteRequestResult {
+  "The successful result of the mutation"
+  result: FileDeleteRequest
+
+  "Any errors generated, if the mutation failed"
+  errors: [MutationError!]!
+}
+
+input CreateFileDeleteRequestInput {
+  "Force the deletion of the file even if it's currently in use, this could cause errors. Default to false."
+  force: Boolean
+
+  deviceId: ID!
+
+  fileDownloadRequestId: ID!
+}
+
+enum FileDeleteRequestSortField {
+  ID
+  FORCE
+  STATUS
+  RESPONSE_CODE
+}
+
+":file_delete_request connection"
+type FileDeleteRequestConnection {
+  "Total count on all pages"
+  count: Int
+
+  "Page information"
+  pageInfo: PageInfo!
+
+  ":file_delete_request edges"
+  edges: [FileDeleteRequestEdge!]
+}
+
+":file_delete_request edge"
+type FileDeleteRequestEdge {
+  "Cursor"
+  cursor: String!
+
+  ":file_delete_request node"
+  node: FileDeleteRequest!
+}
+
+input FileDeleteRequestFilterResponseCode {
+  isNil: Boolean
+  eq: Int
+  notEq: Int
+  in: [Int]
+  lessThan: Int
+  greaterThan: Int
+  lessThanOrEqual: Int
+  greaterThanOrEqual: Int
+  isDistinctFrom: Int
+  isNotDistinctFrom: Int
+}
+
+input FileDeleteRequestFilterStatus {
+  isNil: Boolean
+  eq: FileDeleteRequestStatus
+  notEq: FileDeleteRequestStatus
+  in: [FileDeleteRequestStatus]
+  lessThan: FileDeleteRequestStatus
+  greaterThan: FileDeleteRequestStatus
+  lessThanOrEqual: FileDeleteRequestStatus
+  greaterThanOrEqual: FileDeleteRequestStatus
+  isDistinctFrom: FileDeleteRequestStatus
+  isNotDistinctFrom: FileDeleteRequestStatus
+}
+
+input FileDeleteRequestFilterForce {
+  isNil: Boolean
+  eq: Boolean
+  notEq: Boolean
+  in: [Boolean]
+  lessThan: Boolean
+  greaterThan: Boolean
+  lessThanOrEqual: Boolean
+  greaterThanOrEqual: Boolean
+  isDistinctFrom: Boolean
+  isNotDistinctFrom: Boolean
+}
+
+input FileDeleteRequestFilterId {
+  isNil: Boolean
+  eq: ID
+  notEq: ID
+  in: [ID!]
+  lessThan: ID
+  greaterThan: ID
+  lessThanOrEqual: ID
+  greaterThanOrEqual: ID
+  isDistinctFrom: ID
+  isNotDistinctFrom: ID
+}
+
+input FileDeleteRequestFilterInput {
+  and: [FileDeleteRequestFilterInput!]
+
+  or: [FileDeleteRequestFilterInput!]
+
+  not: [FileDeleteRequestFilterInput!]
+
+  id: FileDeleteRequestFilterId
+
+  "Force the deletion of the file even if it's currently in use, this could cause errors. Default to false."
+  force: FileDeleteRequestFilterForce
+
+  status: FileDeleteRequestFilterStatus
+
+  "Success or error code for the transfer. A 0 code is a success, errors are POSIX errno."
+  responseCode: FileDeleteRequestFilterResponseCode
+
+  "The device associated with this file delete request."
+  device: DeviceFilterInput
+
+  "The file download request that resulted in the file targeted by this delete request"
+  fileDownloadRequest: FileDownloadRequestFilterInput
+}
+
+input FileDeleteRequestSortInput {
+  order: SortOrder
+  field: FileDeleteRequestSortField!
+}
+
+type FileDeleteRequest {
+  id: ID!
+
+  "Force the deletion of the file even if it's currently in use, this could cause errors. Default to false."
+  force: Boolean
+
+  status: FileDeleteRequestStatus
+
+  "Success or error code for the transfer. A 0 code is a success, errors are POSIX errno."
+  responseCode: Int
+
+  "Optional messages for the response"
+  responseMessages: [String!]
+
+  "The device associated with this file delete request."
+  device: Device!
+
+  "The file download request that resulted in the file targeted by this delete request"
+  fileDownloadRequest: FileDownloadRequest!
 }
 
 type file_upload_requests_by_device_result {
@@ -5450,6 +5709,8 @@ input FileUploadRequestFilterResponseMessage {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5518,6 +5779,8 @@ input FileUploadRequestFilterEncoding {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5547,6 +5810,8 @@ input FileUploadRequestFilterSource {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5563,6 +5828,8 @@ input FileUploadRequestFilterUrl {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5746,6 +6013,7 @@ enum FileDownloadRequestSortField {
   PROGRESS_PERCENTAGE
   RESPONSE_CODE
   RESPONSE_MESSAGE
+  DELETED
 }
 
 ":file_download_request connection"
@@ -5769,6 +6037,19 @@ type FileDownloadRequestEdge {
   node: FileDownloadRequest!
 }
 
+input FileDownloadRequestFilterDeleted {
+  isNil: Boolean
+  eq: Boolean
+  notEq: Boolean
+  in: [Boolean]
+  lessThan: Boolean
+  greaterThan: Boolean
+  lessThanOrEqual: Boolean
+  greaterThanOrEqual: Boolean
+  isDistinctFrom: Boolean
+  isNotDistinctFrom: Boolean
+}
+
 input FileDownloadRequestFilterResponseMessage {
   isNil: Boolean
   eq: String
@@ -5781,6 +6062,8 @@ input FileDownloadRequestFilterResponseMessage {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5849,6 +6132,8 @@ input FileDownloadRequestFilterPathOnDevice {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5865,6 +6150,8 @@ input FileDownloadRequestFilterDestination {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5946,6 +6233,8 @@ input FileDownloadRequestFilterEncoding {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5962,6 +6251,8 @@ input FileDownloadRequestFilterDigest {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -5991,6 +6282,8 @@ input FileDownloadRequestFilterFileName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6007,6 +6300,8 @@ input FileDownloadRequestFilterUrl {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6084,6 +6379,9 @@ input FileDownloadRequestFilterInput {
   "Optional message for the response sent by the device."
   responseMessage: FileDownloadRequestFilterResponseMessage
 
+  "Whether the file transferred with this request was deleted from the device"
+  deleted: FileDownloadRequestFilterDeleted
+
   "The device associated with this file download request."
   device: DeviceFilterInput
 
@@ -6154,6 +6452,9 @@ type FileDownloadRequest {
 
   "Optional message for the response sent by the device."
   responseMessage: String
+
+  "Whether the file transferred with this request was deleted from the device"
+  deleted: Boolean
 
   "The device associated with this file download request."
   device: Device!
@@ -6259,6 +6560,8 @@ input RepositoryFilterDescription {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6275,6 +6578,8 @@ input RepositoryFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6291,6 +6596,8 @@ input RepositoryFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6523,6 +6830,8 @@ input FileFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6752,6 +7061,8 @@ input DeviceGroupFilterSelector {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6768,6 +7079,8 @@ input DeviceGroupFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6784,6 +7097,8 @@ input DeviceGroupFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -6916,6 +7231,8 @@ input TagFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -7057,6 +7374,8 @@ input OtaOperationFilterMessage {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -7112,6 +7431,8 @@ input OtaOperationFilterBaseImageUrl {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -7324,6 +7645,8 @@ input ChannelFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -7340,6 +7663,8 @@ input ChannelFilterHandle {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -7844,6 +8169,8 @@ input CampaignFilterName {
   contains: String
   isDistinctFrom: String
   isNotDistinctFrom: String
+  stringEndsWith: String
+  stringStartsWith: String
   like: String
   ilike: String
 }
@@ -8462,6 +8789,10 @@ type RootMutationType {
   createFileUploadRequest(
     input: CreateFileUploadRequestInput!
   ): CreateFileUploadRequestResult
+
+  createFileDeleteRequest(
+    input: CreateFileDeleteRequestInput!
+  ): CreateFileDeleteRequestResult
 
   "Updates a device."
   updateDevice(id: ID!, input: UpdateDeviceInput): UpdateDeviceResult

--- a/frontend/src/components/DeviceTabs/FilesDownloadTab.tsx
+++ b/frontend/src/components/DeviceTabs/FilesDownloadTab.tsx
@@ -78,10 +78,15 @@ const DEVICE_FILE_UPLOAD_REQUESTS_FRAGMENT = graphql`
     storageFileDownloadRequests: fileDownloadRequests(
       first: $first
       after: $after
-      filter: { destinationType: { eq: STORAGE } }
+      filter: {
+        destinationType: { eq: STORAGE }
+        status: { eq: COMPLETED }
+        deleted: { eq: false }
+      }
     ) {
       edges {
         node {
+          id
           pathOnDevice
           fileName
         }
@@ -321,34 +326,20 @@ const FilesDownloadTab = ({
     return options;
   }, [data.fileTransferCapabilities?.targets, intl]);
 
-  const storageSourceOptions: StorageSourceOption[] = useMemo(() => {
-    const uniqueStorageIds = new Map<string, string>();
-
-    data.storageFileDownloadRequests?.edges?.forEach((edge) => {
-      const request = edge?.node;
-
-      if (!request) {
-        return;
-      }
-
-      const storageId = request.pathOnDevice?.trim();
-
-      if (!storageId || uniqueStorageIds.has(storageId)) {
-        return;
-      }
-
-      const label = request.fileName
-        ? `${request.fileName} (${storageId})`
-        : storageId;
-
-      uniqueStorageIds.set(storageId, label);
-    });
-
-    return Array.from(uniqueStorageIds.entries()).map(([value, label]) => ({
-      value,
-      label,
-    }));
-  }, [data.storageFileDownloadRequests]);
+  const storageSourceOptions: StorageSourceOption[] = useMemo(
+    () =>
+      data.storageFileDownloadRequests?.edges?.flatMap((edge) => {
+        const request = edge?.node;
+        if (!request?.id) return [];
+        return [
+          {
+            value: request.id,
+            label: request.fileName || request.id,
+          },
+        ];
+      }) ?? [],
+    [data.storageFileDownloadRequests],
+  );
 
   const supportedEncodings = useMemo(() => {
     const uniqueEncodings = new Set<string>();


### PR DESCRIPTION
#### What this PR does / why we need it:

- update storage options mapping to use id instead of path-based source
- improve filter of available storage sources to include only
completed ones and ones not deleted

Depends on #1417

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
