### PR TITLE
style: absorb boilerplate in fga service

### DIFF
--- a/backend/lib/edgehog/auth/fga_service.ex
+++ b/backend/lib/edgehog/auth/fga_service.ex
@@ -28,46 +28,35 @@ defmodule Edgehog.Auth.FGAService do
   alias Edgehog.Config
 
   def check(subj, rel, obj) do
-    tuple = {subj, rel, obj}
-
-    provider = Keyword.fetch!(Config.authz_config!(), :provider)
-    config = Keyword.fetch!(Config.authz_config!(), :config)
-
-    with {:ok, context} <- provider.init_context(config) do
-      provider.check(tuple, context)
-    end
+    with_provider_context(fn provider, context ->
+      provider.check({subj, rel, obj}, context)
+    end)
   end
 
   def write(subj, rel, obj) do
-    tuple = {subj, rel, obj}
-
-    provider = Keyword.fetch!(Config.authz_config!(), :provider)
-    config = Keyword.fetch!(Config.authz_config!(), :config)
-
-    with {:ok, context} <- provider.init_context(config) do
-      provider.write(tuple, context)
-    end
+    with_provider_context(fn provider, context ->
+      provider.write({subj, rel, obj}, context)
+    end)
   end
 
   def list_objects(subj, rel, type) do
-    tuple = {subj, rel, type}
-
-    provider = Keyword.fetch!(Config.authz_config!(), :provider)
-    config = Keyword.fetch!(Config.authz_config!(), :config)
-
-    with {:ok, context} <- provider.init_context(config) do
-      provider.list_objects(tuple, context)
-    end
+    with_provider_context(fn provider, context ->
+      provider.list_objects({subj, rel, type}, context)
+    end)
   end
 
   def stream_list_objects(subj, rel, type) do
-    tuple = {subj, rel, type}
+    with_provider_context(fn provider, context ->
+      provider.stream_list_objects({subj, rel, type}, context)
+    end)
+  end
 
+  defp with_provider_context(function) do
     provider = Keyword.fetch!(Config.authz_config!(), :provider)
     config = Keyword.fetch!(Config.authz_config!(), :config)
 
     with {:ok, context} <- provider.init_context(config) do
-      provider.stream_list_objects(tuple, context)
+      function.(provider, context)
     end
   end
 end


### PR DESCRIPTION
#### What this PR does / why we need it:

depends-on #1420 

Since each time a fga request is made we have to compute the provider and configuration, we can move the boilerplate into a function.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
