### PR TITLE
chore(backend): erase FGA tenant tuple on deletion

### DIFF
--- a/backend/lib/edgehog/auth/changes/erase_tenant.ex
+++ b/backend/lib/edgehog/auth/changes/erase_tenant.ex
@@ -1,0 +1,92 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Auth.Changes.EraseTenant do
+  @moduledoc """
+  Erase tenant-resource tuples
+  """
+
+  use Ash.Resource.Change
+
+  alias Edgehog.Auth.FGAService
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def init(opts) do
+    errors =
+      if Keyword.has_key?(opts, :obj),
+        do: [],
+        else: [:obj_missing]
+
+    errors =
+      if Keyword.has_key?(opts, :obj_id),
+        do: errors,
+        else: [:obj_id_missing | errors]
+
+    if Enum.empty?(errors),
+      do: {:ok, opts},
+      else: {:error, errors}
+  end
+
+  @impl Ash.Resource.Change
+  def change(changeset, opts, context) do
+    Ash.Changeset.after_transaction(changeset, &erase_tenant_tuple(&1, &2, opts, context))
+  end
+
+  defp erase_tenant_tuple(_changeset, {:ok, result}, opts, %{tenant: tenant}) do
+    # Erases the tuple
+    # {"tenant:slug", "tenant", "obj:obj_id"}
+
+    obj =
+      opts
+      |> Keyword.fetch!(:obj)
+      |> to_string()
+
+    obj_id = opts[:obj_id]
+
+    obj_id =
+      result
+      |> Ash.load!(obj_id)
+      |> Map.get(obj_id)
+      |> to_string()
+
+    obj = "#{obj}:#{obj_id}"
+
+    rel = "tenant"
+
+    slug = tenant.slug
+    subj = "tenant:#{slug}"
+
+    with {:ok, _res} <- FGAService.delete(subj, rel, obj) do
+      {:ok, result}
+    end
+  end
+
+  defp erase_tenant_tuple(_changeset, error, opts, context) do
+    Logger.debug("Error while executing DB transaction. Skipping erasing tuple on the provider.",
+      error: error,
+      opts: opts,
+      context: context
+    )
+
+    error
+  end
+end

--- a/backend/lib/edgehog/auth/fga_service.ex
+++ b/backend/lib/edgehog/auth/fga_service.ex
@@ -39,6 +39,17 @@ defmodule Edgehog.Auth.FGAService do
     end)
   end
 
+  def delete(subj, rel, obj) do
+    tuple = {subj, rel, obj}
+
+    provider = Keyword.fetch!(Config.authz_config!(), :provider)
+    config = Keyword.fetch!(Config.authz_config!(), :config)
+
+    with {:ok, context} <- provider.init_context(config) do
+      provider.delete(tuple, context)
+    end
+  end
+
   def list_objects(subj, rel, type) do
     with_provider_context(fn provider, context ->
       provider.list_objects({subj, rel, type}, context)

--- a/backend/lib/edgehog/auth/providers/behaviour.ex
+++ b/backend/lib/edgehog/auth/providers/behaviour.ex
@@ -48,6 +48,18 @@ defmodule Edgehog.Auth.Providers.Behaviour do
   @callback write(tuple :: fga_tuple(), context :: context()) :: {:ok, term()} | {:error, term()}
 
   @doc """
+  Delete a tuple from the provider.
+
+  - tuple :: the fga tuple, composed of `subject`, `relationship` and `object`
+  - context :: the context from `init_context`
+
+  A delete can return
+  - {:ok, result}   :: if the delete was successful
+  - {:error, error} :: if some error was encountered while deleting
+  """
+  @callback delete(tuple :: fga_tuple(), context :: context()) :: {:ok, term()} | {:error, term()}
+
+  @doc """
   A check call checks a tuple against the provider
 
   - subj :: is some id of the person making the request, ideally a OpenID Connect UUID

--- a/backend/lib/edgehog/auth/providers/none.ex
+++ b/backend/lib/edgehog/auth/providers/none.ex
@@ -63,4 +63,11 @@ defmodule Edgehog.Auth.Providers.None do
     # Result actually not important here
     {:ok, nil}
   end
+
+  @impl Behaviour
+  def delete(tuple, _context) do
+    Logger.debug("Deleting tuple from the service", tuple: tuple)
+
+    {:ok, nil}
+  end
 end

--- a/backend/lib/edgehog/auth/providers/openfga.ex
+++ b/backend/lib/edgehog/auth/providers/openfga.ex
@@ -105,4 +105,25 @@ defmodule Edgehog.Auth.Providers.OpenFGA do
 
     Stub.write(channel, request)
   end
+
+  @impl Behaviour
+  def delete({subj, rel, obj}, %{channel: channel, store_id: store_id}) do
+    tuple = %Openfga.V1.TupleKeyWithoutCondition{
+      user: subj,
+      relation: rel,
+      object: obj
+    }
+
+    to_write = %Openfga.V1.WriteRequestDeletes{
+      tuple_keys: [tuple],
+      on_missing: "error"
+    }
+
+    request = %Openfga.V1.WriteRequest{
+      store_id: store_id,
+      deletes: to_write
+    }
+
+    Stub.write(channel, request)
+  end
 end

--- a/backend/lib/edgehog/base_images/base_image_collection.ex
+++ b/backend/lib/edgehog/base_images/base_image_collection.ex
@@ -78,6 +78,8 @@ defmodule Edgehog.BaseImages.BaseImageCollection do
     destroy :destroy do
       description "Deletes a base image collection."
       primary? true
+
+      require_atomic? false
     end
   end
 

--- a/backend/lib/edgehog/campaigns/campaign/campaign.ex
+++ b/backend/lib/edgehog/campaigns/campaign/campaign.ex
@@ -184,6 +184,8 @@ defmodule Edgehog.Campaigns.Campaign do
     destroy :destroy do
       description "Deletes a Campaign"
       primary? true
+
+      require_atomic? false
     end
   end
 

--- a/backend/lib/edgehog/devices/hardware_type.ex
+++ b/backend/lib/edgehog/devices/hardware_type.ex
@@ -104,6 +104,8 @@ defmodule Edgehog.Devices.HardwareType do
     destroy :destroy do
       description "Deletes a hardware type."
       primary? true
+
+      require_atomic? false
     end
   end
 

--- a/backend/lib/edgehog/groups/device_group/device_group.ex
+++ b/backend/lib/edgehog/groups/device_group/device_group.ex
@@ -81,6 +81,8 @@ defmodule Edgehog.Groups.DeviceGroup do
     destroy :destroy do
       description "Deletes a device group."
       primary? true
+
+      require_atomic? false
     end
   end
 

--- a/backend/lib/edgehog/multitenant_resource.ex
+++ b/backend/lib/edgehog/multitenant_resource.ex
@@ -69,6 +69,10 @@ defmodule Edgehog.MultitenantResource do
           change {Edgehog.Auth.Changes.WriteTenant,
                   obj: unquote(fga_type), obj_id: unquote(fga_id_attribute)},
                  on: :create
+
+          change {Edgehog.Auth.Changes.EraseTenant,
+                  obj: unquote(opts[:fga_type]), obj_id: unquote(opts[:fga_id_attribute])},
+                 on: :destroy
         end
       end
 

--- a/backend/test/edgehog/auth/providers/openfga_integration_test.exs
+++ b/backend/test/edgehog/auth/providers/openfga_integration_test.exs
@@ -82,6 +82,47 @@ defmodule Edgehog.Auth.Providers.OpenFGAIntegrationTests do
     end
   end
 
+  describe "delete/2" do
+    setup do
+      config = Edgehog.Config.authz_config!()[:config]
+
+      {:ok, ctx} = OpenFGA.init_context(config)
+
+      %{context: ctx}
+    end
+
+    test "Deletes correct tuples", %{context: context} do
+      opts = [
+        subj_type: "user",
+        subj_id: System.unique_integer([:positive]),
+        rel: "owner",
+        obj_type: "tenant",
+        obj_id: "test"
+      ]
+
+      tuple = TupleFixtures.tuple(opts)
+      {:ok, _} = OpenFGA.write(tuple, context)
+
+      assert {:ok, _} = OpenFGA.delete(tuple, context)
+    end
+
+    test "is invoked correctly after operations with Ash", %{context: context} do
+      tenant = tenant_fixture()
+      tenant_fga_id = "tenant:#{tenant.slug}"
+      realm = realm_fixture(tenant: tenant)
+
+      assert {:ok, %{objects: [object]}} =
+               OpenFGA.list_objects({tenant_fga_id, "tenant", "realm"}, context)
+
+      assert "realm:#{realm.name}" == object
+
+      Ash.destroy!(realm, tenant: tenant)
+
+      assert {:ok, %{objects: []}} =
+               OpenFGA.list_objects({tenant_fga_id, "tenant", "realm"}, context)
+    end
+  end
+
   describe "check/2" do
     setup do
       config = Edgehog.Config.authz_config!()[:config]


### PR DESCRIPTION
#### What this PR does / why we need it:
Add api for deleting tuples to the FGA service and providers.

Create Ash Change to erase tenant tuple on deletion of a resource.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:
Based on #1423 

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
