### PR TITLE
chore: improve vulnerability alert handling and npm update behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,9 @@
 
   "vulnerabilityAlerts": {
     "enabled": true,
-    "addLabels": ["security"]
+    "addLabels": ["security"],
+    "schedule": [],
+    "transitiveRemediation": true
   },
 
   "lockFileMaintenance": {
@@ -49,6 +51,12 @@
   },
 
   "packageRules": [
+    {
+      "description": "Ensure security vulnerabilities are automerged immediately",
+      "isVulnerabilityAlert": true,
+      "automerge": true,
+      "schedule": []
+    },
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
@@ -59,7 +67,8 @@
     {
       "description": "Semantic commit prefix for frontend: chore(deps)",
       "matchManagers": ["npm"],
-      "semanticCommitType": "chore"
+      "semanticCommitType": "chore",
+      "postUpdateOptions": ["npmDedupe"]
     },
     {
       "description": "Semantic commit prefix for GitHub Actions: ci(deps)",
@@ -167,7 +176,7 @@
       "groupName": "tools releases (major)",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true,
-      "addLabels": ["dependencies", "tools", "automerge"]
+      "addLabels": ["dependencies", "tools", "major"]
     }
   ]
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

- auto-merge vulnerability alerts immediately via package rules
- enable transitiveRemediation for security fixes
- disable scheduling for vulnerability alerts
- add npmDedupe post-update option for npm dependencies


#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
