### PR TITLE
perf(backend): use built-in `&log/3` function

### DIFF
--- a/backend/lib/edgehog/changes/log.ex
+++ b/backend/lib/edgehog/changes/log.ex
@@ -155,14 +155,14 @@ defmodule Edgehog.Changes.Log do
 
   # Before action / transaction
   defp log(opts, changeset) do
-    do_log(opts[@log_level], opts[@message], opts[@log_meta])
+    Logger.log(opts[@log_level], opts[@message], opts[@log_meta])
 
     changeset
   end
 
   # After transaction, success
   defp log(opts, _changeset, {:ok, _result} = data) do
-    do_log(opts[@log_level], opts[@message_success], opts[@log_meta])
+    Logger.log(opts[@log_level], opts[@message_success], opts[@log_meta])
 
     data
   end
@@ -175,31 +175,16 @@ defmodule Edgehog.Changes.Log do
       |> Keyword.fetch!(@log_meta)
       |> Keyword.put_new(:error, error)
 
-    do_log(opts[@log_level], opts[@message_fail], log_meta)
+    Logger.log(opts[@log_level], opts[@message_fail], log_meta)
 
     data
   end
 
   # After action
   defp log(opts, _changeset, result) do
-    do_log(opts[@log_level], opts[@message], opts[@log_meta])
+    Logger.log(opts[@log_level], opts[@message], opts[@log_meta])
 
     {:ok, result}
-  end
-
-  # Although there exists the `&log/3` function, the logger documentation speaks
-  # against that. Check it out: https://hexdocs.pm/logger/Logger.html#log/3
-  defp do_log(level, message, metadata) do
-    case level do
-      :emergency -> Logger.emergency(message, metadata)
-      :alert -> Logger.alert(message, metadata)
-      :critical -> Logger.critical(message, metadata)
-      :error -> Logger.error(message, metadata)
-      :warning -> Logger.warning(message, metadata)
-      :notice -> Logger.notice(message, metadata)
-      :info -> Logger.info(message, metadata)
-      :debug -> Logger.debug(message, metadata)
-    end
   end
 
   defp error_if_not_present(key, {opts, errors}) do


### PR DESCRIPTION
#### What this PR does / why we need it:

Uses built in logger function instead of manually match for the logger level

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
