### PR TITLE
docs: use colors based on the theme

### DIFF
--- a/backend/docs/style/cards.css
+++ b/backend/docs/style/cards.css
@@ -26,8 +26,8 @@
 }
 
 .feature-card {
-    background: #ffffff;
-    border: 1px solid #e8e8e8;
+    background: var(--background-color);
+    border: 1px solid var(--border-color);
     border-radius: 12px;
     padding: 1.5rem;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
@@ -42,18 +42,19 @@
     justify-content: center;
     font-size: 1.5rem;
     margin-bottom: 1rem;
+    background: var(--secondary-background);
 }
 
 .feature-card h3 {
     font-size: 1rem;
     font-weight: 700;
     margin: 0 0 0.5rem 0;
-    color: #1a1a1a;
+    color: var(--text-color);
 }
 
 .feature-card p {
     font-size: 0.9rem;
-    color: #555;
+    color: var(--text-color-light);
     line-height: 1.6;
     margin: 0;
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

The cards in the documentation used fixed colors. This was a problem when switching to dark mode where every color changes.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
