### PR TITLE
fix: Finish scheduled campaigns with no targets

### DIFF
--- a/backend/lib/edgehog/campaigns/campaign/changes/compute_campaign_targets.ex
+++ b/backend/lib/edgehog/campaigns/campaign/changes/compute_campaign_targets.ex
@@ -91,8 +91,25 @@ defmodule Edgehog.Campaigns.Campaign.Changes.ComputeCampaignTargets do
     end
   end
 
+  defp calculate_scheduled_at(nil, _now), do: nil
+
+  defp calculate_scheduled_at(current_scheduled_at, now) do
+    case DateTime.compare(current_scheduled_at, now) do
+      :gt -> now
+      _ -> current_scheduled_at
+    end
+  end
+
   defp apply_targets(changeset, [], _tenant) do
+    now = DateTime.utc_now()
+    current_scheduled_at = Ash.Changeset.get_attribute(changeset, :scheduled_at_timestamp)
+
     changeset
+    |> Ash.Changeset.change_attribute(
+      :scheduled_at_timestamp,
+      calculate_scheduled_at(current_scheduled_at, now)
+    )
+    |> Ash.Changeset.change_attribute(:completion_timestamp, now)
     |> Ash.Changeset.change_attribute(:status, :finished)
     |> Ash.Changeset.change_attribute(:outcome, :success)
   end

--- a/backend/test/edgehog/campaigns/campaign/changes/compute_campaign_targets_test.exs
+++ b/backend/test/edgehog/campaigns/campaign/changes/compute_campaign_targets_test.exs
@@ -196,6 +196,29 @@ defmodule Edgehog.Campaigns.Campaign.Changes.ComputeCampaignTargetsTest do
       campaign = Ash.load!(campaign, :campaign_targets, tenant: tenant)
       assert campaign.campaign_targets == []
     end
+
+    test "finishes immediately when no devices match a scheduled campaign", %{
+      tenant: tenant,
+      release: release,
+      channel: channel
+    } do
+      future_scheduled_at = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+      campaign =
+        campaign_fixture(
+          name: "Test Scheduled Start Campaign",
+          mechanism_type: :deployment_start,
+          release_id: release.id,
+          channel_id: channel.id,
+          scheduled_at_timestamp: future_scheduled_at,
+          tenant: tenant
+        )
+
+      assert campaign.status == :finished
+      assert campaign.outcome == :success
+      assert campaign.completion_timestamp != nil
+      assert DateTime.compare(campaign.scheduled_at_timestamp, future_scheduled_at) == :lt
+    end
   end
 
   describe "compute_campaign_targets for deployment_stop operation" do


### PR DESCRIPTION
#### What this PR does / why we need it:

Previously, if a campaign was scheduled to start but had no targets, it would be marked as finished but would still show that it is scheduled to start

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<details><summary>Issue example</summary>
<p>

<img width="1648" height="722" alt="image" src="https://github.com/user-attachments/assets/2655aa63-d297-4db8-a351-4e1e6634b110" />


</p>
</details> 

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
