### PR TITLE
refactor: Add SegmentedControl and improve Tabs component ecosystems

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -27,12 +27,15 @@ import {
   generatePath as routerGeneratePath,
   useNavigate as useRouterNavigate,
 } from "react-router";
-import type { LinkProps as RouterLinkProps } from "react-router-dom";
+import type {
+  LinkProps as RouterLinkProps,
+  NavigateOptions,
+} from "react-router-dom";
 import { Link as RouterLink } from "react-router-dom";
 
 enum Route {
   devices = "/devices",
-  devicesEdit = "/devices/:deviceId/edit",
+  devicesEdit = "/devices/:deviceId/edit/:activeTab?",
   deviceGroups = "/device-groups",
   deviceGroupsEdit = "/device-groups/:deviceGroupId/edit",
   deviceGroupsNew = "/device-groups/new",
@@ -52,11 +55,11 @@ enum Route {
   channelsNew = "/channels/new",
   updateCampaigns = "/update-campaigns",
   updateCampaignsNew = "/update-campaigns/new",
-  updateCampaignsEdit = "/update-campaigns/:updateCampaignId",
+  updateCampaignsEdit = "/update-campaigns/:updateCampaignId/:activeTab?",
   applications = "/applications",
   applicationNew = "/applications/new",
-  application = "/applications/:applicationId",
-  release = "/applications/:applicationId/release/:releaseId",
+  application = "/applications/:applicationId/:activeTab?",
+  release = "/applications/:applicationId/release/:releaseId/:activeTab?",
   releaseNew = "/applications/:applicationId/release/new",
   containers = "/containers",
   containersEdit = "/containers/:containerId",
@@ -74,14 +77,14 @@ enum Route {
   deploymentEdit = "/devices/:deviceId/deployment/:deploymentId",
   deploymentCampaigns = "/deployment-campaigns",
   deploymentCampaignsNew = "/deployment-campaigns/new",
-  deploymentCampaignsEdit = "/deployment-campaigns/:deploymentCampaignId",
+  deploymentCampaignsEdit = "/deployment-campaigns/:deploymentCampaignId/:activeTab?",
   repositories = "/repositories",
   repositoryNew = "/repositories/new",
   repositoryEdit = "/repositories/:repositoryId/edit",
   filesNew = "/repositories/:repositoryId/files/new",
   fileDownloadCampaigns = "/file-download-campaigns",
   fileDownloadCampaignsNew = "/file-download-campaigns/new",
-  fileDownloadCampaignsEdit = "/file-download-campaigns/:fileDownloadCampaignId",
+  fileDownloadCampaignsEdit = "/file-download-campaigns/:fileDownloadCampaignId/:activeTab?",
   login = "/login",
   logout = "/logout",
 }
@@ -99,7 +102,7 @@ type RouteKeys = keyof typeof Route;
 type RouteWithParams<T extends string> =
   T extends ParamParseKey<T>
     ? { route: T }
-    : { route: T; params: { [P in ParamParseKey<T>]: string } };
+    : { route: T; params: { [P in ParamParseKey<T>]?: string } };
 
 type ParametricRoute = {
   [K in RouteKeys]: RouteWithParams<(typeof Route)[K]>;
@@ -161,9 +164,10 @@ const matchingParametricRoute = (
       return params && typeof params["deviceId"] === "string"
         ? {
             route,
-            params: { deviceId: params.deviceId },
+            params: { deviceId: params.deviceId, activeTab: params.activeTab },
           }
         : null;
+
     case Route.deploymentEdit:
       return params &&
         typeof params["deploymentId"] === "string" &&
@@ -242,7 +246,10 @@ const matchingParametricRoute = (
       return params && typeof params["updateCampaignId"] === "string"
         ? {
             route,
-            params: { updateCampaignId: params.updateCampaignId },
+            params: {
+              updateCampaignId: params.updateCampaignId,
+              activeTab: params.activeTab,
+            },
           }
         : null;
 
@@ -250,7 +257,10 @@ const matchingParametricRoute = (
       return params && typeof params["applicationId"] === "string"
         ? {
             route,
-            params: { applicationId: params.applicationId },
+            params: {
+              applicationId: params.applicationId,
+              activeTab: params.activeTab,
+            },
           }
         : null;
 
@@ -263,6 +273,7 @@ const matchingParametricRoute = (
             params: {
               applicationId: params.applicationId,
               releaseId: params.releaseId,
+              activeTab: params.activeTab,
             },
           }
         : null;
@@ -311,7 +322,10 @@ const matchingParametricRoute = (
       return params && typeof params["deploymentCampaignId"] === "string"
         ? {
             route,
-            params: { deploymentCampaignId: params.deploymentCampaignId },
+            params: {
+              deploymentCampaignId: params.deploymentCampaignId,
+              activeTab: params.activeTab,
+            },
           }
         : null;
 
@@ -335,7 +349,10 @@ const matchingParametricRoute = (
       return params && typeof params["fileDownloadCampaignId"] === "string"
         ? {
             route,
-            params: { fileDownloadCampaignId: params.fileDownloadCampaignId },
+            params: {
+              fileDownloadCampaignId: params.fileDownloadCampaignId,
+              activeTab: params.activeTab,
+            },
           }
         : null;
   }
@@ -370,9 +387,9 @@ const Link = (props: LinkProps) => {
 const useNavigate = () => {
   const routerNavigate = useRouterNavigate();
   const navigate = useCallback(
-    (route: ParametricRoute | `${Route}`) => {
+    (route: ParametricRoute | `${Route}`, options?: NavigateOptions) => {
       const path = typeof route === "string" ? route : generatePath(route);
-      routerNavigate(path);
+      routerNavigate(path, options);
     },
     [routerNavigate],
   );

--- a/frontend/src/components/ApplicationDevicesTable.tsx
+++ b/frontend/src/components/ApplicationDevicesTable.tsx
@@ -120,7 +120,10 @@ const ApplicationDevicesTable = ({
       cell: ({ row, getValue }) => (
         <Link
           route={Route.devicesEdit}
-          params={{ deviceId: row.original.device?.id || "" }}
+          params={{
+            deviceId: row.original.device?.id || "",
+            activeTab: "device-applications-tab",
+          }}
         >
           {getValue()}
         </Link>

--- a/frontend/src/components/DeploymentTargetsTable.tsx
+++ b/frontend/src/components/DeploymentTargetsTable.tsx
@@ -100,7 +100,10 @@ const columns = [
     cell: ({ row, getValue }) => (
       <Link
         route={Route.devicesEdit}
-        params={{ deviceId: row.original.device.id }}
+        params={{
+          deviceId: row.original.device.id,
+          activeTab: "device-applications-tab",
+        }}
       >
         {getValue()}
       </Link>

--- a/frontend/src/components/DeploymentTargetsTabs.tsx
+++ b/frontend/src/components/DeploymentTargetsTabs.tsx
@@ -19,9 +19,6 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import Nav from "react-bootstrap/Nav";
-import NavItem from "react-bootstrap/NavItem";
-import NavLink from "react-bootstrap/NavLink";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
 
@@ -38,7 +35,9 @@ import DeploymentTargetsTable, {
 } from "@/components/DeploymentTargetsTable";
 import { RECORDS_TO_LOAD_FIRST } from "@/constants";
 import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
-import Spinner from "./Spinner";
+import Button from "@/components/Button";
+import SegmentedControl from "@/components/SegmentedControl";
+import Spinner from "@/components/Spinner";
 
 /* eslint-disable relay/unused-fields */
 const DEPLOYMENT_TARGETS_FRAGMENT = graphql`
@@ -148,22 +147,28 @@ const DeploymentTargetsTabs = ({ campaignRef }: Props) => {
           defaultMessage="Devices"
         />
       </h3>
+
       <div>
-        <Nav role="tablist" as="ul" className="nav-tabs">
-          {campaignTargetTabs.map((tab) => (
-            <NavItem key={tab} as="li" role="presentation">
-              <NavLink
-                as="button"
-                type="button"
-                active={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
-              >
-                <CampaignTargetStatus status={tab} />
-              </NavLink>
-            </NavItem>
-          ))}
-        </Nav>
-        <div>
+        <SegmentedControl
+          activeId={activeTab}
+          items={campaignTargetTabs}
+          getItemId={(tab) => tab}
+          onChange={(tab) => setActiveTab(tab)}
+          showControls
+        >
+          {(tab, isActive) => (
+            <Button
+              variant="text"
+              className={`tab-button border-0 ${
+                isActive ? "px-4 py-3 fw-bold active" : "px-4 py-2 text-muted"
+              }`}
+            >
+              <CampaignTargetStatus status={tab} />
+            </Button>
+          )}
+        </SegmentedControl>
+
+        <div className="mt-3">
           {isTabDataLoading ? (
             <Spinner />
           ) : (

--- a/frontend/src/components/DeploymentTargetsTabs.tsx
+++ b/frontend/src/components/DeploymentTargetsTabs.tsx
@@ -21,6 +21,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
+import { useParams } from "react-router-dom";
 
 import { DeploymentCampaign_getCampaign_Query$data } from "@/api/__generated__/DeploymentCampaign_getCampaign_Query.graphql";
 import { DeploymentTargets_PaginationQuery } from "@/api/__generated__/DeploymentTargets_PaginationQuery.graphql";
@@ -38,6 +39,7 @@ import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
 import Button from "@/components/Button";
 import SegmentedControl from "@/components/SegmentedControl";
 import Spinner from "@/components/Spinner";
+import { useNavigate, Route } from "@/Navigation";
 
 /* eslint-disable relay/unused-fields */
 const DEPLOYMENT_TARGETS_FRAGMENT = graphql`
@@ -90,8 +92,11 @@ type Props = {
 };
 
 const DeploymentTargetsTabs = ({ campaignRef }: Props) => {
-  const [activeTab, setActiveTab] =
-    useState<CampaignTargetStatusType>("SUCCESSFUL");
+  const { deploymentCampaignId = "", activeTab: urlTab } = useParams();
+  const navigate = useNavigate();
+
+  const activeTab = (urlTab as CampaignTargetStatusType) || "SUCCESSFUL";
+
   const [committedTab, setCommittedTab] = useState(activeTab);
 
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -103,11 +108,6 @@ const DeploymentTargetsTabs = ({ campaignRef }: Props) => {
   const isTabDataLoading = activeTab !== committedTab;
 
   useEffect(() => {
-    // Only refetch if the tab has actually changed
-    if (activeTab === committedTab) {
-      return;
-    }
-
     refetch(
       {
         first: RECORDS_TO_LOAD_FIRST,
@@ -120,7 +120,7 @@ const DeploymentTargetsTabs = ({ campaignRef }: Props) => {
         },
       },
     );
-  }, [activeTab, committedTab, refetch]);
+  }, [activeTab, refetch]);
 
   const { onLoadMore } = useRelayConnectionPagination({
     hasNext,
@@ -153,7 +153,15 @@ const DeploymentTargetsTabs = ({ campaignRef }: Props) => {
           activeId={activeTab}
           items={campaignTargetTabs}
           getItemId={(tab) => tab}
-          onChange={(tab) => setActiveTab(tab)}
+          onChange={(tab) =>
+            navigate(
+              {
+                route: Route.deploymentCampaignsEdit,
+                params: { deploymentCampaignId, activeTab: tab },
+              },
+              { replace: true },
+            )
+          }
           showControls
         >
           {(tab, isActive) => (

--- a/frontend/src/components/DeviceTabs/ApplicationsTab.tsx
+++ b/frontend/src/components/DeviceTabs/ApplicationsTab.tsx
@@ -83,7 +83,7 @@ const DeviceApplicationsTab = ({ deviceRef }: DeviceApplicationsTabProps) => {
 
   return (
     <Tab
-      eventKey="applications-tab"
+      eventKey="device-applications-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.ApplicationsTab.title",
         defaultMessage: "Applications",

--- a/frontend/src/components/FileDownloadTargetsTable.tsx
+++ b/frontend/src/components/FileDownloadTargetsTable.tsx
@@ -89,7 +89,10 @@ const columns = [
     cell: ({ row, getValue }) => (
       <Link
         route={Route.devicesEdit}
-        params={{ deviceId: row.original.device.id }}
+        params={{
+          deviceId: row.original.device.id,
+          activeTab: "device-file-management-tab",
+        }}
       >
         {getValue()}
       </Link>

--- a/frontend/src/components/FileDownloadTargetsTabs.tsx
+++ b/frontend/src/components/FileDownloadTargetsTabs.tsx
@@ -19,9 +19,6 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import Nav from "react-bootstrap/Nav";
-import NavItem from "react-bootstrap/NavItem";
-import NavLink from "react-bootstrap/NavLink";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
 
@@ -38,7 +35,9 @@ import FileDownloadTargetsTable, {
 } from "@/components/FileDownloadTargetsTable";
 import { RECORDS_TO_LOAD_FIRST } from "@/constants";
 import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
-import Spinner from "./Spinner";
+import Button from "@/components/Button";
+import SegmentedControl from "@/components/SegmentedControl";
+import Spinner from "@/components/Spinner";
 
 const FILE_DOWNLOAD_TARGETS_FRAGMENT = graphql`
   fragment FileDownloadTargetsTabs_FileDownloadTargetsFragment on Campaign
@@ -166,22 +165,26 @@ const FileDownloadTargetsTabs = ({
       </h3>
 
       <div>
-        <Nav role="tablist" as="ul" className="nav-tabs">
-          {campaignTargetTabs.map((tab) => (
-            <NavItem key={tab} as="li" role="presentation">
-              <NavLink
-                as="button"
-                type="button"
-                active={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
-              >
-                <CampaignTargetStatus status={tab} />
-              </NavLink>
-            </NavItem>
-          ))}
-        </Nav>
+        <SegmentedControl
+          activeId={activeTab}
+          items={campaignTargetTabs}
+          getItemId={(tab) => tab}
+          onChange={(tab) => setActiveTab(tab)}
+          showControls
+        >
+          {(tab, isActive) => (
+            <Button
+              variant="text"
+              className={`tab-button border-0 ${
+                isActive ? "px-4 py-3 fw-bold active" : "px-4 py-2 text-muted"
+              }`}
+            >
+              <CampaignTargetStatus status={tab} />
+            </Button>
+          )}
+        </SegmentedControl>
 
-        <div>
+        <div className="mt-3">
           {isTabDataLoading ? (
             <Spinner />
           ) : (

--- a/frontend/src/components/FileDownloadTargetsTabs.tsx
+++ b/frontend/src/components/FileDownloadTargetsTabs.tsx
@@ -21,6 +21,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
+import { useParams } from "react-router-dom";
 
 import type { FileDownloadCampaign_getCampaign_Query$data } from "@/api/__generated__/FileDownloadCampaign_getCampaign_Query.graphql";
 import type { FileDownloadTargetsTabs_FileDownloadTargetsFragment$key } from "@/api/__generated__/FileDownloadTargetsTabs_FileDownloadTargetsFragment.graphql";
@@ -38,6 +39,7 @@ import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
 import Button from "@/components/Button";
 import SegmentedControl from "@/components/SegmentedControl";
 import Spinner from "@/components/Spinner";
+import { useNavigate, Route } from "@/Navigation";
 
 const FILE_DOWNLOAD_TARGETS_FRAGMENT = graphql`
   fragment FileDownloadTargetsTabs_FileDownloadTargetsFragment on Campaign
@@ -94,8 +96,11 @@ type FileDownloadTargetsTabsProps = {
 const FileDownloadTargetsTabs = ({
   campaignRef,
 }: FileDownloadTargetsTabsProps) => {
-  const [activeTab, setActiveTab] =
-    useState<CampaignTargetStatusType>("SUCCESSFUL");
+  const { fileDownloadCampaignId = "", activeTab: urlTab } = useParams();
+  const navigate = useNavigate();
+
+  const activeTab = (urlTab as CampaignTargetStatusType) || "SUCCESSFUL";
+
   const [committedTab, setCommittedTab] = useState(activeTab);
 
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -107,10 +112,6 @@ const FileDownloadTargetsTabs = ({
   const isTabDataLoading = activeTab !== committedTab;
 
   useEffect(() => {
-    if (activeTab === committedTab) {
-      return;
-    }
-
     refetch(
       {
         first: RECORDS_TO_LOAD_FIRST,
@@ -123,7 +124,7 @@ const FileDownloadTargetsTabs = ({
         },
       },
     );
-  }, [activeTab, committedTab, refetch]);
+  }, [activeTab, refetch]);
 
   const { onLoadMore } = useRelayConnectionPagination({
     hasNext,
@@ -169,7 +170,15 @@ const FileDownloadTargetsTabs = ({
           activeId={activeTab}
           items={campaignTargetTabs}
           getItemId={(tab) => tab}
-          onChange={(tab) => setActiveTab(tab)}
+          onChange={(tab) =>
+            navigate(
+              {
+                route: Route.fileDownloadCampaignsEdit,
+                params: { fileDownloadCampaignId, activeTab: tab },
+              },
+              { replace: true },
+            )
+          }
           showControls
         >
           {(tab, isActive) => (

--- a/frontend/src/components/ReleaseDevicesTable.tsx
+++ b/frontend/src/components/ReleaseDevicesTable.tsx
@@ -101,7 +101,10 @@ const ReleaseDevicesTable = ({
       cell: ({ row, getValue }) => (
         <Link
           route={Route.devicesEdit}
-          params={{ deviceId: row.original.device?.id || "" }}
+          params={{
+            deviceId: row.original.device?.id || "",
+            activeTab: "device-applications-tab",
+          }}
         >
           {getValue()}
         </Link>

--- a/frontend/src/components/SegmentedControl.tsx
+++ b/frontend/src/components/SegmentedControl.tsx
@@ -1,0 +1,176 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2026 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useRef } from "react";
+import Nav from "react-bootstrap/Nav";
+
+import Button from "@/components/Button";
+import Icon from "@/components/Icon";
+import Stack, { StackProps } from "@/components/Stack";
+
+const SegmentedControlStack = React.forwardRef((props: StackProps, ref) => (
+  <Stack ref={ref} as="ul" {...props} />
+));
+
+type Props<Item, ItemId = Item> = {
+  activeId?: ItemId;
+  children: (item: Item, isActive: boolean) => React.ReactNode;
+  className?: string;
+  getItemId?: (item: Item) => ItemId;
+  items: Item[];
+  onChange?: (itemId: ItemId) => void;
+  showControls?: boolean;
+};
+
+const DEFAULT_GET_ITEM_ID = <Item, ItemId>(item: Item) =>
+  item as unknown as ItemId;
+
+function SegmentedControl<Item, ItemId = Item>({
+  activeId,
+  children,
+  className = "",
+  getItemId = DEFAULT_GET_ITEM_ID,
+  items,
+  onChange = () => {},
+  showControls = false,
+}: Props<Item, ItemId>) {
+  const itemsRef = useRef<HTMLUListElement>(null);
+
+  const totalItems = items.length;
+  const activeItemIndex = items.findIndex(
+    (item) => getItemId(item) === activeId,
+  );
+
+  const prevItemIndex =
+    totalItems > 0 ? (activeItemIndex - 1 + totalItems) % totalItems : 0;
+  const nextItemIndex = totalItems > 0 ? (activeItemIndex + 1) % totalItems : 0;
+
+  const canNavigate = totalItems > 1 && activeItemIndex !== -1;
+
+  useEffect(() => {
+    const itemsNode = itemsRef.current;
+    if (!itemsNode) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      if (e.deltaY !== 0) {
+        e.preventDefault();
+        itemsNode.scrollLeft += e.deltaY;
+      }
+    };
+
+    itemsNode.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      itemsNode.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (activeItemIndex === -1) return;
+
+    const itemsNode = itemsRef.current;
+    const itemNode = itemsNode?.querySelector<HTMLLIElement>(
+      `li[data-index="${activeItemIndex}"]`,
+    );
+
+    if (itemsNode && itemNode) {
+      const itemWidth = itemNode.offsetWidth;
+      const offsetToItemLeft = itemNode.offsetLeft - itemsNode.offsetLeft;
+      const offsetToItemCenter = offsetToItemLeft + itemWidth / 2;
+      const containerVisibleWidth = itemsNode.clientWidth;
+
+      itemsNode.scrollTo({
+        left: offsetToItemCenter - containerVisibleWidth / 2,
+        behavior: "smooth",
+      });
+    }
+  }, [activeItemIndex]);
+
+  const handleChangeItem = (index: number) => {
+    const item = items[index];
+    if (item) {
+      onChange(getItemId(item));
+    }
+  };
+
+  return (
+    <div
+      className={`border-0 overflow-auto hstack gap-2 custom-scrollbar ${className}`}
+    >
+      {showControls && (
+        <Button
+          variant="text"
+          className="border-0"
+          disabled={!canNavigate}
+          onClick={() => handleChangeItem(prevItemIndex)}
+        >
+          <Icon icon="anglesLeft" />
+        </Button>
+      )}
+      <Nav
+        ref={itemsRef}
+        role="tablist"
+        variant="pills"
+        className="nav-tabs border-0 flex-grow-1 flex-nowrap overflow-auto custom-scrollbar"
+        as={SegmentedControlStack}
+        direction="horizontal"
+        gap={2}
+      >
+        {items.map((item, index) => {
+          const itemId = getItemId(item);
+          const isActive = itemId === activeId;
+
+          const itemKey =
+            getItemId === DEFAULT_GET_ITEM_ID && typeof item === "object"
+              ? index
+              : String(itemId);
+
+          return (
+            <Nav.Item
+              key={itemKey}
+              as="li"
+              data-index={index}
+              role="presentation"
+              className="flex-shrink-0"
+              onClick={(event: React.MouseEvent) => {
+                if (event.preventDefault) event.preventDefault();
+                handleChangeItem(index);
+              }}
+            >
+              {children(item, isActive)}
+            </Nav.Item>
+          );
+        })}
+      </Nav>
+      {showControls && (
+        <Button
+          variant="text"
+          className="text-muted border-0"
+          disabled={!canNavigate}
+          onClick={() => handleChangeItem(nextItemIndex)}
+        >
+          <Icon icon="anglesRight" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export default SegmentedControl;

--- a/frontend/src/components/Sidebar.scss
+++ b/frontend/src/components/Sidebar.scss
@@ -241,8 +241,3 @@ $active-text: #ffffff;
     }
   }
 }
-
-.custom-scrollbar {
-  scrollbar-width: thin;
-  scrollbar-color: #d0d5dd transparent;
-}

--- a/frontend/src/components/Stack.tsx
+++ b/frontend/src/components/Stack.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2021 SECO Mind Srl
+  Copyright 2021-2026 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import Stack from "react-bootstrap/Stack";
+import Stack, { StackProps } from "react-bootstrap/Stack";
+
+export type { StackProps };
 
 export default Stack;

--- a/frontend/src/components/Tabs.scss
+++ b/frontend/src/components/Tabs.scss
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2026 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.tab-button.active {
+  color: var(--bs-primary) !important;
+  position: relative;
+
+  &::after {
+    position: absolute;
+    content: "";
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--bs-primary);
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px;
+  }
+}

--- a/frontend/src/components/Tabs.test.tsx
+++ b/frontend/src/components/Tabs.test.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2023-2024 SECO Mind Srl
+  Copyright 2023-2026 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,18 +18,22 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-import { it, expect, describe } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { it, expect, describe, beforeAll, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Tabs, { Tab } from "./Tabs";
+
+beforeAll(() => {
+  Element.prototype.scrollTo = vi.fn();
+});
 
 describe("Tabs", () => {
   it("assigns className to the Tabs component", () => {
     render(<Tabs className="custom-tabs-class">Tabs Content</Tabs>);
 
-    const tabsElement = screen.getByText("Tabs Content");
-    expect(tabsElement).toHaveClass("custom-tabs-class");
+    const tabsWrapper = screen.getByText("Tabs Content");
+    expect(tabsWrapper).toHaveClass("custom-tabs-class");
   });
 
   describe("defaultActiveKey", () => {
@@ -45,9 +49,10 @@ describe("Tabs", () => {
         </Tabs>,
       );
 
-      expect(
-        screen.getByRole("tab", { name: "Tab 1", selected: true }),
-      ).toBeVisible();
+      const tab1Button = screen.getByRole("button", { name: "Tab 1" });
+      expect(tab1Button).toBeVisible();
+      expect(tab1Button).toHaveClass("active");
+
       expect(screen.getByTestId("tab1-content")).toBeVisible();
     });
 
@@ -63,9 +68,10 @@ describe("Tabs", () => {
         </Tabs>,
       );
 
-      expect(
-        screen.getByRole("tab", { name: "Tab 2", selected: true }),
-      ).toBeVisible();
+      const tab2Button = screen.getByRole("button", { name: "Tab 2" });
+      expect(tab2Button).toBeVisible();
+      expect(tab2Button).toHaveClass("active");
+
       expect(screen.getByTestId("tab2-content")).toBeVisible();
     });
 
@@ -81,14 +87,16 @@ describe("Tabs", () => {
         </Tabs>,
       );
 
-      expect(
-        screen.getByRole("tab", { name: "Tab 2", selected: false }),
-      ).toBeVisible();
+      const tab2Button = screen.getByRole("button", { name: "Tab 2" });
+      expect(tab2Button).toBeVisible();
+      expect(tab2Button).not.toHaveClass("active");
+
       expect(screen.queryByTestId("tab2-content")).not.toBeInTheDocument();
     });
   });
 
   it("changes active tab correctly", async () => {
+    const user = userEvent.setup();
     render(
       <Tabs defaultActiveKey="tab1">
         <Tab eventKey="tab1" title="Tab 1">
@@ -100,26 +108,21 @@ describe("Tabs", () => {
       </Tabs>,
     );
 
-    expect(
-      screen.getByRole("tab", { name: "Tab 1", selected: true }),
-    ).toBeVisible();
+    const tab1Button = screen.getByRole("button", { name: "Tab 1" });
+    const tab2Button = screen.getByRole("button", { name: "Tab 2" });
+
+    expect(tab1Button).toHaveClass("active");
     expect(screen.getByTestId("tab1-content")).toBeVisible();
 
-    expect(
-      screen.getByRole("tab", { name: "Tab 2", selected: false }),
-    ).toBeVisible();
+    expect(tab2Button).not.toHaveClass("active");
     expect(screen.queryByTestId("tab2-content")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("tab", { name: "Tab 2" }));
+    await user.click(tab2Button);
 
-    expect(
-      screen.getByRole("tab", { name: "Tab 1", selected: false }),
-    ).toBeVisible();
+    expect(tab1Button).not.toHaveClass("active");
     expect(screen.queryByTestId("tab1-content")).not.toBeInTheDocument();
 
-    expect(
-      screen.getByRole("tab", { name: "Tab 2", selected: true }),
-    ).toBeVisible();
+    expect(tab2Button).toHaveClass("active");
     expect(screen.getByTestId("tab2-content")).toBeVisible();
   });
 
@@ -132,7 +135,10 @@ describe("Tabs", () => {
           <Tab eventKey="tabThree" title="Tab 3" />
         </Tabs>,
       );
-      const tabs = screen.getAllByRole("tab");
+
+      const tablist = screen.getByRole("tablist");
+      const tabs = within(tablist).getAllByRole("button");
+
       expect(tabs[0]).toHaveTextContent("Tab 1");
       expect(tabs[1]).toHaveTextContent("Tab 2");
       expect(tabs[2]).toHaveTextContent("Tab 3");
@@ -146,7 +152,10 @@ describe("Tabs", () => {
           <Tab eventKey="tabThree" title="Tab 3" />
         </Tabs>,
       );
-      const tabs = screen.getAllByRole("tab");
+
+      const tablist = screen.getByRole("tablist");
+      const tabs = within(tablist).getAllByRole("button");
+
       expect(tabs[0]).toHaveTextContent("Tab 2");
       expect(tabs[1]).toHaveTextContent("Tab 1");
       expect(tabs[2]).toHaveTextContent("Tab 3");
@@ -161,7 +170,10 @@ describe("Tabs", () => {
           <Tab eventKey="tabFour" title="Tab 4" />
         </Tabs>,
       );
-      const tabs = screen.getAllByRole("tab");
+
+      const tablist = screen.getByRole("tablist");
+      const tabs = within(tablist).getAllByRole("button");
+
       expect(tabs[0]).toHaveTextContent("Tab 3");
       expect(tabs[1]).toHaveTextContent("Tab 1");
       expect(tabs[2]).toHaveTextContent("Tab 2");
@@ -178,7 +190,7 @@ describe("Tab", () => {
       </Tabs>,
     );
 
-    expect(screen.getByRole("tab", { name: "Tab 1" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Tab 1" })).toBeVisible();
   });
 
   it("renders tab content correctly", () => {

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -68,6 +68,7 @@ const TabButton = ({ isActive, tabRef }: TabButtonProps) => {
 type TabsProps = {
   children?: React.ReactNode;
   className?: string;
+  activeKey?: EventKey;
   defaultActiveKey?: EventKey;
   tabsOrder?: EventKey[];
   onChange?: (tabKey: string) => void;
@@ -76,6 +77,7 @@ type TabsProps = {
 const Tabs = ({
   children,
   className,
+  activeKey: controlledActiveKey,
   defaultActiveKey,
   tabsOrder = [],
   onChange = () => {},
@@ -84,6 +86,9 @@ const Tabs = ({
     defaultActiveKey,
   );
   const [tabRefs, setTabRefs] = useState<TabRef[]>([]);
+
+  const currentSelectedKey =
+    controlledActiveKey !== undefined ? controlledActiveKey : selectedKey;
 
   const registerTab = useCallback((tabRef: TabRef) => {
     setTabRefs((prev) => {
@@ -98,10 +103,10 @@ const Tabs = ({
 
   const activeKey = useMemo(
     () =>
-      tabRefs.some((tabRef) => tabRef.eventKey === selectedKey)
-        ? selectedKey
+      tabRefs.some((tabRef) => tabRef.eventKey === currentSelectedKey)
+        ? currentSelectedKey
         : tabRefs[0]?.eventKey,
-    [tabRefs, selectedKey],
+    [tabRefs, currentSelectedKey],
   );
 
   const contextValue = useMemo(
@@ -127,10 +132,12 @@ const Tabs = ({
 
   const handleOnChange = useCallback(
     (key: string) => {
-      setSelectedKey(key);
+      if (controlledActiveKey === undefined) {
+        setSelectedKey(key);
+      }
       onChange(key);
     },
-    [onChange],
+    [onChange, controlledActiveKey],
   );
 
   return (

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -16,12 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import intersection from "lodash/intersection";
-import keyBy from "lodash/keyBy";
-import keys from "lodash/keys";
-import union from "lodash/union";
-import uniqBy from "lodash/uniqBy";
-import {
+import React, {
   createContext,
   useCallback,
   useContext,
@@ -29,15 +24,16 @@ import {
   useMemo,
   useState,
 } from "react";
-import Nav from "react-bootstrap/Nav";
-import NavItem from "react-bootstrap/NavItem";
-import NavLink from "react-bootstrap/NavLink";
+
+import Button from "@/components/Button";
+import SegmentedControl from "@/components/SegmentedControl";
+import "@/components/Tabs.scss";
 
 type EventKey = string;
 
 type TabRef = {
   eventKey: EventKey;
-  title: React.ReactNode;
+  title?: React.ReactNode;
 };
 
 type TabsContextValue = {
@@ -46,19 +42,35 @@ type TabsContextValue = {
   unregisterTab: (eventKey: EventKey) => void;
 };
 
-const defaultContextValue: TabsContextValue = {
+const TabsContext = createContext<TabsContextValue>({
   activeKey: undefined,
   registerTab: () => {},
   unregisterTab: () => {},
+});
+
+type TabButtonProps = {
+  isActive: boolean;
+  tabRef: TabRef;
 };
 
-const TabsContext = createContext<TabsContextValue>(defaultContextValue);
+const TabButton = ({ isActive, tabRef }: TabButtonProps) => {
+  const dynamicClasses = isActive
+    ? "px-4 py-3 fw-bold active"
+    : "px-4 py-2 text-muted";
+
+  return (
+    <Button variant="text" className={`tab-button border-0 ${dynamicClasses}`}>
+      {tabRef.title}
+    </Button>
+  );
+};
 
 type TabsProps = {
   children?: React.ReactNode;
   className?: string;
   defaultActiveKey?: EventKey;
   tabsOrder?: EventKey[];
+  onChange?: (tabKey: string) => void;
 };
 
 const Tabs = ({
@@ -66,88 +78,97 @@ const Tabs = ({
   className,
   defaultActiveKey,
   tabsOrder = [],
+  onChange = () => {},
 }: TabsProps) => {
-  const [activeKey, setActiveKey] = useState<EventKey | undefined>(
+  const [selectedKey, setSelectedKey] = useState<EventKey | undefined>(
     defaultActiveKey,
   );
   const [tabRefs, setTabRefs] = useState<TabRef[]>([]);
 
   const registerTab = useCallback((tabRef: TabRef) => {
-    setTabRefs((refs) => uniqBy([...refs, tabRef], "eventKey"));
+    setTabRefs((prev) => {
+      if (prev.some((ref) => ref.eventKey === tabRef.eventKey)) return prev;
+      return [...prev, tabRef];
+    });
   }, []);
 
   const unregisterTab = useCallback((eventKey: EventKey) => {
-    setTabRefs((tabRefs) =>
-      tabRefs.filter((tabRef) => tabRef.eventKey !== eventKey),
-    );
-    // If the active tab is removed, clear the state so it falls back to the sorted default
-    setActiveKey((prevKey) => (prevKey === eventKey ? undefined : prevKey));
+    setTabRefs((prev) => prev.filter((tabRef) => tabRef.eventKey !== eventKey));
   }, []);
 
-  const sortedTabRefs = useMemo(() => {
-    const tabRefsByEventKey = keyBy(tabRefs, "eventKey");
-    const eventKeys = keys(tabRefsByEventKey);
-    // 1. intersect tabsOrder with eventKeys to pick eventKeys in the correct order
-    // 2. union the result with eventKeys to pick the remaining eventKeys
-    const sortedEventKeys = union(
-      intersection(tabsOrder, eventKeys),
-      eventKeys,
-    );
-    return sortedEventKeys.map((eventKey) => tabRefsByEventKey[eventKey]);
-  }, [tabRefs, tabsOrder]);
-
-  const effectiveActiveKey =
-    activeKey ?? defaultActiveKey ?? sortedTabRefs[0]?.eventKey;
+  const activeKey = useMemo(
+    () =>
+      tabRefs.some((tabRef) => tabRef.eventKey === selectedKey)
+        ? selectedKey
+        : tabRefs[0]?.eventKey,
+    [tabRefs, selectedKey],
+  );
 
   const contextValue = useMemo(
     () => ({
-      activeKey: effectiveActiveKey,
+      activeKey,
       registerTab,
       unregisterTab,
     }),
-    [effectiveActiveKey, registerTab, unregisterTab],
+    [activeKey, registerTab, unregisterTab],
+  );
+
+  const sortedTabRefs = useMemo(() => {
+    const refMap = new Map(tabRefs.map((ref) => [ref.eventKey, ref]));
+
+    const orderedKeys = tabsOrder.filter((key) => refMap.has(key));
+
+    const remainingKeys = tabRefs
+      .map((ref) => ref.eventKey)
+      .filter((key) => !tabsOrder.includes(key));
+
+    return [...orderedKeys, ...remainingKeys].map((key) => refMap.get(key)!);
+  }, [tabRefs, tabsOrder]);
+
+  const handleOnChange = useCallback(
+    (key: string) => {
+      setSelectedKey(key);
+      onChange(key);
+    },
+    [onChange],
   );
 
   return (
     <TabsContext.Provider value={contextValue}>
       <div className={className}>
         {sortedTabRefs.length > 0 && (
-          <Nav role="tablist" as="ul" className="nav-tabs">
-            {sortedTabRefs.map((tabRef) => (
-              <NavItem key={tabRef.eventKey} as="li" role="presentation">
-                <NavLink
-                  as="button"
-                  type="button"
-                  active={effectiveActiveKey === tabRef.eventKey}
-                  onClick={() => setActiveKey(tabRef.eventKey)}
-                >
-                  {tabRef.title}
-                </NavLink>
-              </NavItem>
-            ))}
-          </Nav>
+          <SegmentedControl
+            activeId={activeKey}
+            items={sortedTabRefs}
+            getItemId={(tabRef) => tabRef.eventKey}
+            onChange={handleOnChange}
+            showControls
+          >
+            {(tabRef, isActive) => (
+              <TabButton tabRef={tabRef} isActive={isActive} />
+            )}
+          </SegmentedControl>
         )}
         {children}
       </div>
     </TabsContext.Provider>
   );
 };
+
 const useTabs = (): TabsContextValue => {
   const tabsContextValue = useContext(TabsContext);
-  if (tabsContextValue == null) {
-    throw new Error("TabsContext has not been Provided");
+  if (!tabsContextValue) {
+    throw new Error("useTabs must be used within a <Tabs /> provider");
   }
   return tabsContextValue;
 };
 
-type TabProps = {
-  children?: React.ReactNode;
-  className?: string;
+type TabProps = React.ComponentPropsWithoutRef<"div"> & {
   eventKey: EventKey;
-  title?: string;
+  title?: React.ReactNode;
 };
 
-const Tab = ({ children, className, eventKey, title }: TabProps) => {
+const Tab = ({ eventKey, title, ...restProps }: TabProps) => {
   const { registerTab, unregisterTab, activeKey } = useTabs();
 
   useEffect(() => {
@@ -155,13 +176,11 @@ const Tab = ({ children, className, eventKey, title }: TabProps) => {
     return () => unregisterTab(eventKey);
   }, [registerTab, unregisterTab, eventKey, title]);
 
-  const isActive = activeKey === eventKey;
-
-  if (!isActive) {
+  if (activeKey !== eventKey) {
     return null;
   }
 
-  return <div className={className}>{children}</div>;
+  return <div {...restProps} />;
 };
 
 export { Tab };

--- a/frontend/src/components/UpdateTargetsTable.tsx
+++ b/frontend/src/components/UpdateTargetsTable.tsx
@@ -193,7 +193,10 @@ const columns = [
     cell: ({ row, getValue }) => (
       <Link
         route={Route.devicesEdit}
-        params={{ deviceId: row.original.device.id }}
+        params={{
+          deviceId: row.original.device.id,
+          activeTab: "device-software-update-tab",
+        }}
       >
         {getValue()}
       </Link>

--- a/frontend/src/components/UpdateTargetsTabs.tsx
+++ b/frontend/src/components/UpdateTargetsTabs.tsx
@@ -21,6 +21,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, usePaginationFragment } from "react-relay/hooks";
+import { useParams } from "react-router-dom";
 
 import { UpdateCampaign_getCampaign_Query$data } from "@/api/__generated__/UpdateCampaign_getCampaign_Query.graphql";
 import { UpdateTargets_PaginationQuery } from "@/api/__generated__/UpdateTargets_PaginationQuery.graphql";
@@ -36,6 +37,7 @@ import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
 import Button from "@/components/Button";
 import SegmentedControl from "@/components/SegmentedControl";
 import Spinner from "@/components/Spinner";
+import { useNavigate, Route } from "@/Navigation";
 
 /* eslint-disable relay/unused-fields */
 const UPDATE_TARGETS_FRAGMENT = graphql`
@@ -86,8 +88,11 @@ type Props = {
 };
 
 const UpdateTargetsTabs = ({ campaignRef }: Props) => {
-  const [activeTab, setActiveTab] =
-    useState<CampaignTargetStatusType>("SUCCESSFUL");
+  const { updateCampaignId = "", activeTab: urlTab } = useParams();
+  const navigate = useNavigate();
+
+  const activeTab = (urlTab as CampaignTargetStatusType) || "SUCCESSFUL";
+
   const [committedTab, setCommittedTab] = useState(activeTab);
 
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -99,11 +104,6 @@ const UpdateTargetsTabs = ({ campaignRef }: Props) => {
   const isTabDataLoading = activeTab !== committedTab;
 
   useEffect(() => {
-    // Only refetch if the tab has actually changed
-    if (activeTab === committedTab) {
-      return;
-    }
-
     refetch(
       {
         first: RECORDS_TO_LOAD_FIRST,
@@ -116,7 +116,7 @@ const UpdateTargetsTabs = ({ campaignRef }: Props) => {
         },
       },
     );
-  }, [activeTab, committedTab, refetch]);
+  }, [activeTab, refetch]);
 
   const { onLoadMore } = useRelayConnectionPagination({
     hasNext,
@@ -149,7 +149,15 @@ const UpdateTargetsTabs = ({ campaignRef }: Props) => {
           activeId={activeTab}
           items={campaignTargetTabs}
           getItemId={(tab) => tab}
-          onChange={(tab) => setActiveTab(tab)}
+          onChange={(tab) =>
+            navigate(
+              {
+                route: Route.updateCampaignsEdit,
+                params: { updateCampaignId, activeTab: tab },
+              },
+              { replace: true },
+            )
+          }
           showControls
         >
           {(tab, isActive) => (

--- a/frontend/src/components/UpdateTargetsTabs.tsx
+++ b/frontend/src/components/UpdateTargetsTabs.tsx
@@ -33,10 +33,9 @@ import type { ColumnId } from "@/components/UpdateTargetsTable";
 import UpdateTargetsTable, { columnIds } from "@/components/UpdateTargetsTable";
 import { RECORDS_TO_LOAD_FIRST } from "@/constants";
 import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
-import Nav from "react-bootstrap/Nav";
-import NavItem from "react-bootstrap/NavItem";
-import NavLink from "react-bootstrap/NavLink";
-import Spinner from "./Spinner";
+import Button from "@/components/Button";
+import SegmentedControl from "@/components/SegmentedControl";
+import Spinner from "@/components/Spinner";
 
 /* eslint-disable relay/unused-fields */
 const UPDATE_TARGETS_FRAGMENT = graphql`
@@ -135,6 +134,7 @@ const UpdateTargetsTabs = ({ campaignRef }: Props) => {
   if (!updateTargetsRef) {
     return null;
   }
+
   return (
     <div>
       <h3>
@@ -143,23 +143,28 @@ const UpdateTargetsTabs = ({ campaignRef }: Props) => {
           defaultMessage="Devices"
         />
       </h3>
-      <div>
-        <Nav role="tablist" as="ul" className="nav-tabs">
-          {campaignTargetTabs.map((tab) => (
-            <NavItem key={tab} as="li" role="presentation">
-              <NavLink
-                as="button"
-                type="button"
-                active={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
-              >
-                <CampaignTargetStatus status={tab} />
-              </NavLink>
-            </NavItem>
-          ))}
-        </Nav>
 
-        <div>
+      <div>
+        <SegmentedControl
+          activeId={activeTab}
+          items={campaignTargetTabs}
+          getItemId={(tab) => tab}
+          onChange={(tab) => setActiveTab(tab)}
+          showControls
+        >
+          {(tab, isActive) => (
+            <Button
+              variant="text"
+              className={`tab-button border-0 ${
+                isActive ? "px-4 py-3 fw-bold active" : "px-4 py-2 text-muted"
+              }`}
+            >
+              <CampaignTargetStatus status={tab} />
+            </Button>
+          )}
+        </SegmentedControl>
+
+        <div className="mt-3">
           {isTabDataLoading ? (
             <Spinner />
           ) : (

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -26,3 +26,8 @@
   --campaign-target-status_color_successful: var(--bs-success);
   --campaign-target-status_color_failed: var(--bs-danger);
 }
+
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #d0d5dd transparent;
+}

--- a/frontend/src/pages/Application.tsx
+++ b/frontend/src/pages/Application.tsx
@@ -40,7 +40,7 @@ import type {
 } from "@/api/__generated__/Application_getApplication_Query.graphql";
 import { Releases_PaginationQuery } from "@/api/__generated__/Releases_PaginationQuery.graphql";
 
-import { Link, Route } from "@/Navigation";
+import { Link, Route, useNavigate } from "@/Navigation";
 import Alert from "@/components/Alert";
 import ApplicationDevicesTable from "@/components/ApplicationDevicesTable";
 import Button from "@/components/Button";
@@ -107,6 +107,8 @@ const RELEASE_SUBSCRIPTION = graphql`
     }
   }
 `;
+
+const TAB_KEYS = ["releases-tab", "devices-tab"];
 
 type SelectedRelease = ReleaseTableRecord;
 
@@ -289,7 +291,11 @@ const ApplicationContent = ({ application }: ApplicationContentProps) => {
   const [searchText, setSearchText] = useState<string | null>(null);
   const [releaseToDelete, setReleaseToDelete] =
     useState<SelectedRelease | null>(null);
-  const { applicationId = "" } = useParams();
+
+  const { applicationId = "", activeTab } = useParams();
+  const navigate = useNavigate();
+
+  const currentTabKey = activeTab || TAB_KEYS[0];
 
   return (
     <Page>
@@ -333,8 +339,17 @@ const ApplicationContent = ({ application }: ApplicationContentProps) => {
         </Form.Group>
 
         <Tabs
-          defaultActiveKey="releases-tab"
-          tabsOrder={["releases-tab", "devices-tab"]}
+          activeKey={currentTabKey}
+          tabsOrder={TAB_KEYS}
+          onChange={(tabKey) =>
+            navigate(
+              {
+                route: Route.application,
+                params: { applicationId, activeTab: tabKey },
+              },
+              { replace: true },
+            )
+          }
         >
           <Tab
             eventKey="releases-tab"

--- a/frontend/src/pages/Deployment.tsx
+++ b/frontend/src/pages/Deployment.tsx
@@ -357,7 +357,7 @@ const DeploymentContent = ({
             if (deviceId) {
               navigate({
                 route: Route.devicesEdit,
-                params: { deviceId },
+                params: { deviceId, activeTab: "device-applications-tab" },
               });
             }
           });

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -49,7 +49,7 @@ import type { Device_removeDeviceTags_Mutation } from "@/api/__generated__/Devic
 import type { Device_requestForwarderSession_Mutation } from "@/api/__generated__/Device_requestForwarderSession_Mutation.graphql";
 import type { Device_getForwarderSession_Query } from "@/api/__generated__/Device_getForwarderSession_Query.graphql";
 import type { Device_getExistingDeviceTags_Query } from "@/api/__generated__/Device_getExistingDeviceTags_Query.graphql";
-import { Link, Route } from "@/Navigation";
+import { Link, Route, useNavigate } from "@/Navigation";
 import Alert from "@/components/Alert";
 import Button from "@/components/Button";
 import Center from "@/components/Center";
@@ -243,6 +243,23 @@ const GET_FORWARDER_SESSION_QUERY = graphql`
 
 const TTYD_PORT = 7681;
 
+const TAB_KEYS = [
+  "device-hardware-info-tab",
+  "device-os-info-tab",
+  "device-runtime-info-tab",
+  "device-base-image-tab",
+  "device-system-status-tab",
+  "device-storage-usage-tab",
+  "device-battery-tab",
+  "device-location-tab",
+  "device-cellular-connection-tab",
+  "device-network-interfaces-tab",
+  "device-wifi-scan-results-tab",
+  "device-software-update-tab",
+  "device-file-management-tab",
+  "device-applications-tab",
+];
+
 const FormRow = (props: FormRowProps) => (
   <BaseFormRow {...props} labelCol={4} valueCol={8} />
 );
@@ -351,7 +368,8 @@ const DeviceContent = ({
   getTagsQuery,
   refreshTags,
 }: DeviceContentProps) => {
-  const { deviceId = "" } = useParams();
+  const { deviceId = "", activeTab } = useParams();
+  const navigate = useNavigate();
   const relayEnvironment = useRelayEnvironment();
   const deviceData = usePreloadedQuery(GET_DEVICE_QUERY, getDeviceQuery);
   const tagsData = usePreloadedQuery(GET_TAGS_QUERY, getTagsQuery);
@@ -660,6 +678,8 @@ const DeviceContent = ({
     [deviceTags, handleAddDeviceTags, handleRemoveDeviceTags],
   );
 
+  const currentTabKey = activeTab || TAB_KEYS[0];
+
   if (!device) {
     return (
       <Result.NotFound
@@ -914,22 +934,17 @@ const DeviceContent = ({
             </Col>
           </Row>
           <Tabs
-            tabsOrder={[
-              "device-hardware-info-tab",
-              "device-os-info-tab",
-              "device-runtime-info-tab",
-              "device-base-image-tab",
-              "device-system-status-tab",
-              "device-storage-usage-tab",
-              "device-battery-tab",
-              "device-location-tab",
-              "device-cellular-connection-tab",
-              "device-network-interfaces-tab",
-              "device-wifi-scan-results-tab",
-              "device-software-update-tab",
-              "device-file-management-tab",
-              "applications-tab",
-            ]}
+            activeKey={currentTabKey}
+            tabsOrder={TAB_KEYS}
+            onChange={(tabKey) =>
+              navigate(
+                {
+                  route: Route.devicesEdit,
+                  params: { deviceId, activeTab: tabKey },
+                },
+                { replace: true },
+              )
+            }
           >
             <DeviceHardwareInfoTab deviceRef={device} />
             <DeviceOSInfoTab deviceRef={device} />

--- a/frontend/src/pages/Release.tsx
+++ b/frontend/src/pages/Release.tsx
@@ -50,7 +50,7 @@ import Spinner from "@/components/Spinner";
 import Tabs, { Tab } from "@/components/Tabs";
 import { RECORDS_TO_LOAD_FIRST } from "@/constants";
 import useRelayConnectionPagination from "@/hooks/useRelayConnectionPagination";
-import { Link, Route } from "@/Navigation";
+import { Link, Route, useNavigate } from "@/Navigation";
 
 const GET_RELEASE_QUERY = graphql`
   query Release_getRelease_Query($releaseId: ID!, $first: Int, $after: String) {
@@ -97,6 +97,8 @@ const CONTAINERS_FRAGMENT = graphql`
     }
   }
 `;
+
+const TAB_KEYS = ["containers-tab", "system-models-tab", "devices-tab"];
 
 type Release = NonNullable<Release_getRelease_Query$data["release"]>;
 
@@ -190,6 +192,11 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
   const intl = useIntl();
   const [errorFeedback, setErrorFeedback] = useState<React.ReactNode>(null);
 
+  const { applicationId = "", releaseId = "", activeTab } = useParams();
+  const navigate = useNavigate();
+
+  const currentTabKey = activeTab || TAB_KEYS[0];
+
   return (
     <Page>
       <Page.Header
@@ -206,8 +213,17 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
         </Alert>
 
         <Tabs
-          defaultActiveKey="containers-tab"
-          tabsOrder={["containers-tab", "system-models-tab", "devices-tab"]}
+          activeKey={currentTabKey}
+          tabsOrder={TAB_KEYS}
+          onChange={(tabKey) =>
+            navigate(
+              {
+                route: Route.release,
+                params: { applicationId, releaseId, activeTab: tabKey },
+              },
+              { replace: true },
+            )
+          }
         >
           <Tab
             eventKey="containers-tab"


### PR DESCRIPTION


#### What this PR does / why we need it:

- Implement circular list wrapping navigation tabs
- Add mouse wheel event tracking to map vertical scrolling
- Drop lodash dependencies in Tabs component, migrating to native Map and modern JS selectors.
- Deprecate custom legacy TS type overrides in favor of native ComponentPropsWithoutRef bindings.
- Refactor `CampaignTargetsTabs` to ingest the new SegmentedControl component directly for campaign target status tabs.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:


<details><summary>Screenshots</summary>
<p>

Old:
<img width="1644" height="904" alt="image" src="https://github.com/user-attachments/assets/35bfa1d9-e45f-4123-91aa-cabc8fe1393a" />

<img width="840" height="695" alt="image" src="https://github.com/user-attachments/assets/41b504d5-dd17-4e58-b5dd-3e855c9373ff" />

<img width="1624" height="717" alt="image" src="https://github.com/user-attachments/assets/7e6836dd-4ae1-4339-a24d-f1f818264314" />


New:
<img width="1634" height="973" alt="image" src="https://github.com/user-attachments/assets/fad9e1ba-bfdc-4780-8010-4bf26b336413" />

<img width="840" height="695" alt="image" src="https://github.com/user-attachments/assets/02e9c654-e348-4a0e-852a-3a4dd87f347c" />

<img width="1624" height="717" alt="image" src="https://github.com/user-attachments/assets/3a81b40a-7fa1-4d80-a559-62a895d63c27" />


</p>
</details> 

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
