### PR TITLE
refactor: change frontend primary colors and wrap content in cards

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,7 +176,7 @@ function App() {
   // Embedded Mode (No Sidebar)
   if (auth.isAuthenticated && hideNavigationElements) {
     return (
-      <main className="vh-100 flex-grow-1 d-flex overflow-hidden">
+      <main className="vh-100 flex-grow-1 d-flex overflow-hidden bg-light">
         <section className="flex-grow-1 overflow-auto">{RouterElement}</section>
       </main>
     );
@@ -185,7 +185,7 @@ function App() {
   return (
     <div
       data-testid="app"
-      className="d-flex vh-100 flex-column overflow-hidden"
+      className="d-flex vh-100 flex-column overflow-hidden bg-light"
     >
       {showNavigation && <Topbar onToggle={toggleIsMobileMenuOpen} />}
 

--- a/frontend/src/components/ContainerDetails.scss
+++ b/frontend/src/components/ContainerDetails.scss
@@ -25,7 +25,7 @@
 }
 
 .containerSectionCard {
-  border-radius: 12px;
+  border-radius: 0.5rem;
   background: #ffffff;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
   padding: 10px;

--- a/frontend/src/components/ContainersOverview.scss
+++ b/frontend/src/components/ContainersOverview.scss
@@ -27,7 +27,7 @@
 .containerListCard {
   background: #ffffff;
   border: 1px solid #dee2e6;
-  border-radius: 12px;
+  border-radius: 0.5rem;
   padding: 10px;
   overflow-y: auto;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
@@ -40,8 +40,6 @@
   margin-bottom: 6px;
   border: none !important;
   background: transparent !important;
-  color: #212529 !important;
-  box-shadow: none !important;
   transition: all 0.15s ease;
 
   &:hover {
@@ -50,9 +48,9 @@
 
   &.active {
     background: #ffffff !important;
-    border-left: 3px solid #0d6efd !important;
+    border-left: 3px solid var(--bs-primary) !important;
     border-radius: 0%;
-    color: #0d6efd !important;
+    color: var(--bs-primary) !important;
     font-weight: 500;
   }
 

--- a/frontend/src/components/ContainersOverview.tsx
+++ b/frontend/src/components/ContainersOverview.tsx
@@ -29,6 +29,7 @@ import type {
 import Button from "@/components/Button";
 import ContainerDetails from "@/components/ContainerDetails";
 import "@/components/ContainersOverview.scss";
+import { Card } from "react-bootstrap";
 
 const CONTAINERS_TABLE_FRAGMENT = graphql`
   fragment ContainersOverview_ContainerEdgeFragment on ContainerConnection {
@@ -70,14 +71,14 @@ const ContainersOverview = ({
 
   if (containers.length === 0) {
     return (
-      <div className={className}>
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <p>
           <FormattedMessage
             id="components.ContainersOverview.noContainers"
             defaultMessage="No containers available."
           />
         </p>
-      </div>
+      </Card>
     );
   }
 

--- a/frontend/src/components/DeviceTabs/ApplicationsTab.tsx
+++ b/frontend/src/components/DeviceTabs/ApplicationsTab.tsx
@@ -21,6 +21,7 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { graphql, useRefetchableFragment } from "react-relay/hooks";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { ApplicationsTab_deployedApplications$key } from "@/api/__generated__/ApplicationsTab_deployedApplications.graphql";
 import type { ApplicationsTab_deployedApplications_RefetchQuery } from "@/api/__generated__/ApplicationsTab_deployedApplications_RefetchQuery.graphql";
@@ -83,6 +84,7 @@ const DeviceApplicationsTab = ({ deviceRef }: DeviceApplicationsTabProps) => {
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-applications-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.ApplicationsTab.title",
@@ -98,7 +100,7 @@ const DeviceApplicationsTab = ({ deviceRef }: DeviceApplicationsTabProps) => {
       >
         {errorFeedback}
       </Alert>
-      <div className="mt-3">
+      <Card className="h-100 border-0 p-3 shadow-sm mb-3">
         <h5>
           <FormattedMessage
             id="components.DeviceTabs.ApplicationsTab.InstallNewApp"
@@ -112,6 +114,8 @@ const DeviceApplicationsTab = ({ deviceRef }: DeviceApplicationsTabProps) => {
           setErrorFeedback={setErrorFeedback}
           onDeployComplete={handleRefetch}
         />
+      </Card>
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <h5 className="mt-4">
           <FormattedMessage
             id="components.DeviceTabs.ApplicationsTab.DeployedApplications"
@@ -119,7 +123,7 @@ const DeviceApplicationsTab = ({ deviceRef }: DeviceApplicationsTabProps) => {
           />
         </h5>
         <DeployedApplicationsTable deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/BaseImageTab.tsx
+++ b/frontend/src/components/DeviceTabs/BaseImageTab.tsx
@@ -16,8 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { graphql, useFragment } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
+import { graphql, useFragment } from "react-relay/hooks";
 
 import type { BaseImageTab_baseImage$key } from "@/api/__generated__/BaseImageTab_baseImage.graphql";
 
@@ -57,13 +58,14 @@ const DeviceBaseImageTab = ({ deviceRef }: DeviceBaseImageTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-base-image-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.BaseImageTab.title",
         defaultMessage: "Base Image",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <Stack gap={3}>
           {baseImage.name !== null && (
             <FormRow
@@ -122,7 +124,7 @@ const DeviceBaseImageTab = ({ deviceRef }: DeviceBaseImageTabProps) => {
             </FormRow>
           )}
         </Stack>
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/BatteryTab.tsx
+++ b/frontend/src/components/DeviceTabs/BatteryTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { BatteryTab_batteryStatus$key } from "@/api/__generated__/BatteryTab_batteryStatus.graphql";
 
@@ -44,15 +45,16 @@ const DeviceBatteryTab = ({ deviceRef }: DeviceBatteryTabProps) => {
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-battery-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.BatteryTab.title",
         defaultMessage: "Battery",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <BatteryTable deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/CellularConnectionTab.tsx
+++ b/frontend/src/components/DeviceTabs/CellularConnectionTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { CellularConnectionTab_cellularConnection$key } from "@/api/__generated__/CellularConnectionTab_cellularConnection.graphql";
 
@@ -47,15 +48,16 @@ const DeviceCellularConnectionTab = ({
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-cellular-connection-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.CellularConnectionTab.title",
         defaultMessage: "Cellular Connection",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <CellularConnectionTabs deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/FileManagementTab.tsx
+++ b/frontend/src/components/DeviceTabs/FileManagementTab.tsx
@@ -22,6 +22,7 @@ import { useCallback, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { graphql, useFragment } from "react-relay/hooks";
 import Select from "react-select";
+import { Card } from "react-bootstrap";
 
 import type { FileManagementTab_fileManagement$key } from "@/api/__generated__/FileManagementTab_fileManagement.graphql";
 
@@ -214,9 +215,13 @@ const FileManagementTab = ({ deviceRef }: FileManagementTabProps) => {
   };
 
   return (
-    <Tab eventKey="device-file-management-tab" title="File Management">
+    <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
+      eventKey="device-file-management-tab"
+      title="File Management"
+    >
       {modeOptions.length > 1 && (
-        <div className="mt-3">
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
           <Form.Group controlId="file-management-mode" className="mb-0">
             <h5>
               <FormattedMessage
@@ -240,7 +245,7 @@ const FileManagementTab = ({ deviceRef }: FileManagementTabProps) => {
               }}
             />
           </Form.Group>
-        </div>
+        </Card>
       )}
 
       {renderTabContent()}

--- a/frontend/src/components/DeviceTabs/FilesDeleteTab.tsx
+++ b/frontend/src/components/DeviceTabs/FilesDeleteTab.tsx
@@ -20,6 +20,7 @@
 
 import split from "lodash/split";
 import React, { useCallback, useMemo, useState } from "react";
+import { Card } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   ConnectionHandler,
@@ -372,7 +373,7 @@ const FilesDeleteTab = ({
 
   const content = (
     <>
-      <div className="mt-3">
+      <Card className="h-100 border-0 p-3 shadow-sm mb-3">
         <Alert
           show={!!errorFeedback}
           variant="danger"
@@ -392,11 +393,9 @@ const FilesDeleteTab = ({
             onDeleteSuccess={onDeleteSuccess}
           />
         </Stack>
-      </div>
+      </Card>
 
-      <hr />
-
-      <div className="mt-4">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <h5>
           <FormattedMessage
             id="components.DeviceTabs.FilesDeleteTab.requestHistory"
@@ -405,7 +404,7 @@ const FilesDeleteTab = ({
         </h5>
 
         <FileDeleteRequestsTable requests={fileDeleteRequests} />
-      </div>
+      </Card>
     </>
   );
 
@@ -415,6 +414,7 @@ const FilesDeleteTab = ({
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-files-delete-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.FilesDeleteTab.title",

--- a/frontend/src/components/DeviceTabs/FilesDeviceToServerTab.tsx
+++ b/frontend/src/components/DeviceTabs/FilesDeviceToServerTab.tsx
@@ -20,6 +20,7 @@
 
 import split from "lodash/split";
 import React, { useCallback, useMemo, useState } from "react";
+import { Card } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   ConnectionHandler,
@@ -447,7 +448,7 @@ const FilesDeviceToServerTab = ({
 
   const content = (
     <>
-      <div className="mt-3">
+      <Card className="h-100 border-0 p-3 shadow-sm mb-3">
         <Alert
           show={!!errorFeedback}
           variant="danger"
@@ -468,11 +469,11 @@ const FilesDeviceToServerTab = ({
             isOnline={isOnline}
           />
         </Stack>
-      </div>
+      </Card>
 
       <hr />
 
-      <div className="mt-4">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <h5>
           <FormattedMessage
             id="components.DeviceTabs.FilesDeviceToServerTab.requestHistory"
@@ -481,7 +482,7 @@ const FilesDeviceToServerTab = ({
         </h5>
 
         <FilesDeviceToServerTable requests={fileUploadRequests} />
-      </div>
+      </Card>
     </>
   );
 

--- a/frontend/src/components/DeviceTabs/FilesServerToDeviceTab.tsx
+++ b/frontend/src/components/DeviceTabs/FilesServerToDeviceTab.tsx
@@ -25,7 +25,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { ToggleButton, ToggleButtonGroup } from "react-bootstrap";
+import { Card, ToggleButton, ToggleButtonGroup } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import type { PreloadedQuery } from "react-relay/hooks";
 import {
@@ -705,7 +705,7 @@ const FilesServerToDeviceTab = ({
 
   const content = (
     <>
-      <div className="mt-3">
+      <Card className="h-100 border-0 p-3 shadow-sm mb-3">
         <Alert
           show={!!errorFeedback}
           variant="danger"
@@ -785,11 +785,9 @@ const FilesServerToDeviceTab = ({
             )}
           </Stack>
         </Suspense>
-      </div>
+      </Card>
 
-      <hr />
-
-      <div className="mt-4">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <h5>
           <FormattedMessage
             id="components.DeviceTabs.FilesServerToDeviceTab.requestHistory"
@@ -798,7 +796,7 @@ const FilesServerToDeviceTab = ({
         </h5>
 
         <FilesServerToDeviceTable requests={fileDownloadRequests} />
-      </div>
+      </Card>
     </>
   );
 

--- a/frontend/src/components/DeviceTabs/HardwareInfoTab.tsx
+++ b/frontend/src/components/DeviceTabs/HardwareInfoTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { HardwareInfoTab_hardwareInfo$key } from "@/api/__generated__/HardwareInfoTab_hardwareInfo.graphql";
 
@@ -54,13 +55,14 @@ const DeviceHardwareInfoTab = ({ deviceRef }: DeviceHardwareInfoTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-hardware-info-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.HardwareInfoTab.title",
         defaultMessage: "Hardware Info",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <Stack gap={3}>
           {hardwareInfo.cpuArchitecture != null && (
             <FormRow
@@ -148,7 +150,7 @@ const DeviceHardwareInfoTab = ({ deviceRef }: DeviceHardwareInfoTabProps) => {
             </FormRow>
           )}
         </Stack>
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/LocationTab.tsx
+++ b/frontend/src/components/DeviceTabs/LocationTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { LocationTab_location$key } from "@/api/__generated__/LocationTab_location.graphql";
 
@@ -53,13 +54,14 @@ const DeviceLocationTab = ({ deviceRef }: DeviceLocationTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-location-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.LocationTab.title",
         defaultMessage: "Geolocation",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <p>
           <FormattedMessage
             id="components.DeviceTabs.LocationTab.lastUpdateAt"
@@ -90,7 +92,7 @@ const DeviceLocationTab = ({ deviceRef }: DeviceLocationTabProps) => {
             </div>
           }
         />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/NetworkInterfacesTab.tsx
+++ b/frontend/src/components/DeviceTabs/NetworkInterfacesTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { NetworkInterfacesTab_networkInterfaces$key } from "@/api/__generated__/NetworkInterfacesTab_networkInterfaces.graphql";
 
@@ -47,15 +48,16 @@ const DeviceNetworkInterfacesTab = ({
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-network-interfaces-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.NetworkInterfacesTab.title",
         defaultMessage: "Network Interfaces",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <NetworkInterfacesTable deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/OSInfoTab.tsx
+++ b/frontend/src/components/DeviceTabs/OSInfoTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { OSInfoTab_osInfo$key } from "@/api/__generated__/OSInfoTab_osInfo.graphql";
 
@@ -55,13 +56,14 @@ const DeviceOSInfoTab = ({ deviceRef }: DeviceOSInfoTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-os-info-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.OSInfoTab.title",
         defaultMessage: "Operating System",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <Stack gap={3}>
           {osInfo.name !== null && (
             <FormRow
@@ -90,7 +92,7 @@ const DeviceOSInfoTab = ({ deviceRef }: DeviceOSInfoTabProps) => {
             </FormRow>
           )}
         </Stack>
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/RuntimeInfoTab.tsx
+++ b/frontend/src/components/DeviceTabs/RuntimeInfoTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { RuntimeInfoTab_runtimeInfo$key } from "@/api/__generated__/RuntimeInfoTab_runtimeInfo.graphql";
 
@@ -57,13 +58,14 @@ const DeviceRuntimeInfoTab = ({ deviceRef }: DeviceRuntimeInfoTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-runtime-info-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.RuntimeInfoTab.title",
         defaultMessage: "Runtime",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <Stack gap={3}>
           {runtimeInfo.name !== null && (
             <FormRow
@@ -122,7 +124,7 @@ const DeviceRuntimeInfoTab = ({ deviceRef }: DeviceRuntimeInfoTabProps) => {
             </FormRow>
           )}
         </Stack>
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/SoftwareUpdateTab.tsx
+++ b/frontend/src/components/DeviceTabs/SoftwareUpdateTab.tsx
@@ -25,7 +25,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { ToggleButton, ToggleButtonGroup } from "react-bootstrap";
+import { Card, ToggleButton, ToggleButtonGroup } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import type { PreloadedQuery } from "react-relay/hooks";
 import {
@@ -275,13 +275,14 @@ const DeviceSoftwareUpdateTab = ({
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-software-update-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.SoftwareUpdateTab.title",
         defaultMessage: "Software Updates",
       })}
     >
-      <div className="mt-3">
+      <Card className="h-100 border-0 p-3 shadow-sm mb-3">
         <h5>
           <FormattedMessage
             id="components.DeviceTabs.SoftwareUpdateTab.manualOTAUpdate"
@@ -353,14 +354,17 @@ const DeviceSoftwareUpdateTab = ({
             )}
           </Stack>
         </Suspense>
+      </Card>
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <h5 className="mt-4">
           <FormattedMessage
             id="components.DeviceTabs.SoftwareUpdateTab.updatesHistory"
             defaultMessage="History"
           />
         </h5>
+
         <OperationTable otaOperationsRef={otaOperationsRef} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/StorageUsageTab.tsx
+++ b/frontend/src/components/DeviceTabs/StorageUsageTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { StorageUsageTab_storageUsage$key } from "@/api/__generated__/StorageUsageTab_storageUsage.graphql";
 
@@ -43,15 +44,16 @@ const DeviceStorageUsageTab = ({ deviceRef }: DeviceStorageUsageTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-storage-usage-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.StorageUsageTab.title",
         defaultMessage: "Storage",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <StorageTable deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/SystemStatusTab.tsx
+++ b/frontend/src/components/DeviceTabs/SystemStatusTab.tsx
@@ -17,6 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { graphql, useFragment } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import dayjs from "dayjs";
@@ -55,13 +56,14 @@ const DeviceSystemStatusTab = ({ deviceRef }: DeviceSystemStatusTabProps) => {
   }
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-system-status-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.SystemStatusTab.title",
         defaultMessage: "System Status",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <p className="text-muted">
           <FormattedMessage
             id="components.DeviceTabs.SystemStatusTab.lastUpdateAt"
@@ -140,7 +142,7 @@ const DeviceSystemStatusTab = ({ deviceRef }: DeviceSystemStatusTabProps) => {
             </FormRow>
           )}
         </Stack>
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/DeviceTabs/WiFiScanResultsTab.tsx
+++ b/frontend/src/components/DeviceTabs/WiFiScanResultsTab.tsx
@@ -18,6 +18,7 @@
 
 import { graphql, useFragment } from "react-relay/hooks";
 import { useIntl } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { WiFiScanResultsTab_wifiScanResults$key } from "@/api/__generated__/WiFiScanResultsTab_wifiScanResults.graphql";
 
@@ -46,15 +47,16 @@ const DeviceWiFiScanResultsTab = ({
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="device-wifi-scan-results-tab"
       title={intl.formatMessage({
         id: "components.DeviceTabs.WiFiScanResultsTab.title",
         defaultMessage: "WiFi APs",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <WiFiScanResultsTable deviceRef={device} />
-      </div>
+      </Card>
     </Tab>
   );
 };

--- a/frontend/src/components/FormRow.scss
+++ b/frontend/src/components/FormRow.scss
@@ -18,14 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.sort-direction-indicator {
-  font-size: 0.75rem;
-}
-
-.table-header {
-  cursor: default;
-
-  &.is-sortable {
-    cursor: pointer;
-  }
+.form-row-group {
+  margin-bottom: 0.5rem;
 }

--- a/frontend/src/components/FormRow.tsx
+++ b/frontend/src/components/FormRow.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2025 SECO Mind Srl
+  Copyright 2025-2026 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 import { ReactNode } from "react";
 import { Row, Col, Form } from "react-bootstrap";
 
+import "@/components/FormRow.scss";
+
 type FormRowVariant = "form-group" | "simple-row";
 
 export interface FormRowProps {
@@ -35,8 +37,11 @@ export interface FormRowProps {
   valueCol?: number;
 }
 
-export const FormRowWithMargin = (props: FormRowProps) => (
-  <FormRow {...props} className="mb-4" />
+export const FormRowWithMargin = ({ className, ...props }: FormRowProps) => (
+  <FormRow
+    {...props}
+    className={["mb-4", className].filter(Boolean).join(" ")}
+  />
 );
 
 export const SimpleFormRow = (props: FormRowProps) => (
@@ -51,8 +56,8 @@ export const FormRow = ({
   className,
   labelClassName,
   valueColClassName,
-  labelCol = 3,
-  valueCol = 9,
+  labelCol = 2,
+  valueCol = 10,
 }: FormRowProps) => {
   if (layout === "simple-row") {
     return (
@@ -68,7 +73,7 @@ export const FormRow = ({
   }
 
   return (
-    <Form.Group as={Row} controlId={id} className={className}>
+    <Form.Group as={Row} controlId={id} className={`mb-2 ${className}`}>
       <Form.Label column sm={labelCol} className={labelClassName}>
         {label}
       </Form.Label>

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -39,7 +39,11 @@ type PageProps = {
 
 const Page = ({ children, className = "", style }: PageProps) => {
   return (
-    <div data-testid="page" className={`p-4 ${className}`} style={style}>
+    <div
+      data-testid="page"
+      className={`p-4 flex-grow-1 d-flex flex-column gap-3 min-vh-100 ${className}`}
+      style={style}
+    >
       {children}
     </div>
   );
@@ -67,7 +71,10 @@ type PageMainProps = {
 
 const PageMain = ({ children, className = "", style }: PageMainProps) => {
   return (
-    <main className={`mt-4 ${className}`} style={style}>
+    <main
+      className={`flex-grow-1 d-flex flex-column ${className}`}
+      style={style}
+    >
       {children}
     </main>
   );
@@ -251,7 +258,7 @@ const BreadcrumbItems = ({ pageTitle }: BreadcrumbItemsProps) => {
             {...linkProps}
             key={index}
             active={active}
-            className={active ? "fw-bold" : ""}
+            className={`mb-1  ${active ? "fw-bold" : ""}`}
           >
             {label}
           </Breadcrumb.Item>

--- a/frontend/src/components/SearchBox.scss
+++ b/frontend/src/components/SearchBox.scss
@@ -21,15 +21,16 @@
 .custom-search-group {
   border: 1px solid var(--bs-border-color);
   border-radius: 0.5rem;
+  background-color: transparent;
 
   .search-icon-addon {
-    background-color: transparent;
     border: none;
-    color: var(--bs-secondary-color);
+    background-color: transparent;
+    cursor: text;
   }
-
   .search-input {
     border: none;
+    background-color: transparent;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0.25rem;

--- a/frontend/src/components/SearchBox.tsx
+++ b/frontend/src/components/SearchBox.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useId } from "react";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import { useIntl } from "react-intl";
@@ -34,6 +34,7 @@ interface Props {
 
 const SearchBox = ({ className = "", onChange, value }: Props) => {
   const intl = useIntl();
+  const searchInputId = useId();
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
@@ -48,10 +49,15 @@ const SearchBox = ({ className = "", onChange, value }: Props) => {
   return (
     <Form className={`w-100 ${className}`}>
       <InputGroup className="custom-search-group">
-        <InputGroup.Text className="search-icon-addon px-3">
+        <InputGroup.Text
+          as="label"
+          htmlFor={searchInputId}
+          className="search-icon-addon px-3"
+        >
           <Icon icon="search" />
         </InputGroup.Text>
         <Form.Control
+          id={searchInputId}
           className="search-input"
           type="search"
           placeholder={intl.formatMessage({

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -62,7 +62,7 @@ const HIDDEN_COLUMN_IDS: string[] = [];
 const SORT_BY_DEFAULT: SortingState = [];
 
 export type TableProps<T extends RowData> = {
-  columns: ColumnDef<T, unknown>[];
+  columns: ColumnDef<T, any>[];
   data: readonly T[];
   className?: string;
   headerStyle?: React.CSSProperties;

--- a/frontend/src/components/Tabs.scss
+++ b/frontend/src/components/Tabs.scss
@@ -19,7 +19,7 @@
  */
 
 .tab-button.active {
-  color: var(--bs-primary) !important;
+  color: var(--cp-color-accent) !important;
   position: relative;
 
   &::after {
@@ -29,7 +29,7 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: var(--bs-primary);
+    background: var(--cp-color-accent);
     border-top-right-radius: 3px;
     border-top-left-radius: 3px;
   }

--- a/frontend/src/components/Tag.scss
+++ b/frontend/src/components/Tag.scss
@@ -18,14 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.sort-direction-indicator {
-  font-size: 0.75rem;
-}
-
-.table-header {
-  cursor: default;
-
-  &.is-sortable {
-    cursor: pointer;
-  }
+span.badge.tag {
+  background-color: var(--cp-color-accent, #2563eb) !important;
+  color: #ffffff !important;
 }

--- a/frontend/src/components/Tag.tsx
+++ b/frontend/src/components/Tag.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Edgehog.
 
-  Copyright 2022 SECO Mind Srl
+  Copyright 2022-2026 SECO Mind Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,16 +21,13 @@
 import Badge from "react-bootstrap/Badge";
 import type { BadgeProps } from "react-bootstrap/Badge";
 
+import "@/components/Tag.scss";
+
 type Props = Omit<BadgeProps, "pill" | "bg">;
 
 const Tag = ({ children, className, ...restProps }: Props) => {
   return (
-    <Badge
-      bg="primary"
-      pill
-      className={`py-1 px-3 ${className}`}
-      {...restProps}
-    >
+    <Badge pill className={`tag py-1 px-3 ${className}`} {...restProps}>
       {children}
     </Badge>
   );

--- a/frontend/src/forms/CreateContainer.tsx
+++ b/frontend/src/forms/CreateContainer.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
 import Select from "react-select";
+import { Card } from "react-bootstrap";
 
 import type {
   ContainerEnvVarInput,
@@ -126,7 +127,7 @@ const NameSection = ({ form }: { form: UseFormReturn<ContainerInputData> }) => {
   } = form;
 
   return (
-    <div className="ps-2">
+    <Card className="border-0 p-3 shadow-sm mb-2 rounded-3">
       <FormRow
         id="name"
         label={
@@ -139,7 +140,7 @@ const NameSection = ({ form }: { form: UseFormReturn<ContainerInputData> }) => {
         <Form.Control {...register("name")} isInvalid={!!errors.name} />
         <FormFeedback feedback={errors.name?.message} />
       </FormRow>
-    </div>
+    </Card>
   );
 };
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -23,11 +23,17 @@
 );
 
 :root {
+  font-size: 0.9rem;
   --cp-color-accent: #056cee;
   --campaign-target-status_color_idle: var(--bs-gray);
   --campaign-target-status_color_in-progress: var(--bs-warning);
   --campaign-target-status_color_successful: var(--bs-success);
   --campaign-target-status_color_failed: var(--bs-danger);
+}
+
+.form-label {
+  font-weight: bold;
+  color: var(--bs-gray-700);
 }
 
 .custom-scrollbar {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -18,9 +18,12 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-@use "bootstrap/scss/bootstrap.scss" as *;
+@use "bootstrap/scss/bootstrap.scss" as * with (
+  $primary: #312f73
+);
 
 :root {
+  --cp-color-accent: #056cee;
   --campaign-target-status_color_idle: var(--bs-gray);
   --campaign-target-status_color_in-progress: var(--bs-warning);
   --campaign-target-status_color_successful: var(--bs-success);
@@ -30,4 +33,14 @@
 .custom-scrollbar {
   scrollbar-width: thin;
   scrollbar-color: #d0d5dd transparent;
+}
+
+.text-bg-accent {
+  color: var(--bs-light);
+  background: var(--cp-color-accent);
+}
+
+.form-check-input:checked {
+  background-color: var(--cp-color-accent);
+  border-color: var(--cp-color-accent);
 }

--- a/frontend/src/pages/Application.tsx
+++ b/frontend/src/pages/Application.tsx
@@ -19,7 +19,7 @@
  */
 
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
-import { Col, Form, Row } from "react-bootstrap";
+import { Card, Col, Form, Row } from "react-bootstrap";
 import { ErrorBoundary } from "react-error-boundary";
 import { FormattedMessage, useIntl } from "react-intl";
 import type { PreloadedQuery } from "react-relay/hooks";
@@ -321,24 +321,27 @@ const ApplicationContent = ({ application }: ApplicationContentProps) => {
           {errorFeedback}
         </Alert>
 
-        <Form.Group as={Row} controlId="application" className="mt-3 mb-4">
-          <Form.Label column sm={2}>
-            <FormattedMessage
-              id="pages.Application.description"
-              defaultMessage="Description"
-            />
-          </Form.Label>
-          <Col sm={10}>
-            <Form.Control
-              as="textarea"
-              value={application.description ?? ""}
-              rows={5}
-              readOnly
-            />
-          </Col>
-        </Form.Group>
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
+          <Form.Group as={Row} controlId="application" className="mt-3 mb-4">
+            <Form.Label column sm={2}>
+              <FormattedMessage
+                id="pages.Application.description"
+                defaultMessage="Description"
+              />
+            </Form.Label>
+            <Col sm={10}>
+              <Form.Control
+                as="textarea"
+                value={application.description ?? ""}
+                rows={5}
+                readOnly
+              />
+            </Col>
+          </Form.Group>
+        </Card>
 
         <Tabs
+          className="d-flex flex-column flex-grow-1"
           activeKey={currentTabKey}
           tabsOrder={TAB_KEYS}
           onChange={(tabKey) =>
@@ -353,21 +356,24 @@ const ApplicationContent = ({ application }: ApplicationContentProps) => {
         >
           <Tab
             eventKey="releases-tab"
+            className="pt-3 d-flex flex-column flex-grow-1"
             title={intl.formatMessage({
               id: "pages.Application.releases",
               defaultMessage: "Releases",
             })}
           >
-            <SearchBox
-              className="flex-grow-1 pb-2 pt-2"
-              value={searchText || ""}
-              onChange={setSearchText}
-            />
-            <ReleasesLayoutContainer
-              applicationRef={application}
-              searchText={searchText}
-              onDelete={setReleaseToDelete}
-            />
+            <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+              <SearchBox
+                className="pb-2"
+                value={searchText || ""}
+                onChange={setSearchText}
+              />
+              <ReleasesLayoutContainer
+                applicationRef={application}
+                searchText={searchText}
+                onDelete={setReleaseToDelete}
+              />
+            </Card>
             {releaseToDelete && (
               <DeleteReleaseModal
                 releaseToDelete={releaseToDelete}
@@ -380,12 +386,15 @@ const ApplicationContent = ({ application }: ApplicationContentProps) => {
 
           <Tab
             eventKey="devices-tab"
+            className="pt-3 d-flex flex-column flex-grow-1"
             title={intl.formatMessage({
               id: "pages.Application.devices",
               defaultMessage: "Devices",
             })}
           >
-            <DevicesLayoutContainer applicationRef={application} />
+            <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+              <DevicesLayoutContainer applicationRef={application} />
+            </Card>
           </Tab>
         </Tabs>
       </Page.Main>

--- a/frontend/src/pages/ApplicationCreate.tsx
+++ b/frontend/src/pages/ApplicationCreate.tsx
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { ConnectionHandler, graphql, useMutation } from "react-relay/hooks";
 import { ErrorBoundary } from "react-error-boundary";
+import { Card } from "react-bootstrap";
 
 import type { ApplicationCreate_createApplication_Mutation } from "@/api/__generated__/ApplicationCreate_createApplication_Mutation.graphql";
 
@@ -164,7 +165,9 @@ const ApplicationCreatePage = () => {
             }
           />
           <Page.Main>
-            <ApplicationWrapper />
+            <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+              <ApplicationWrapper />
+            </Card>
           </Page.Main>
         </Page>
       </ErrorBoundary>

--- a/frontend/src/pages/Applications.tsx
+++ b/frontend/src/pages/Applications.tsx
@@ -30,6 +30,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { Applications_ApplicationsFragment$key } from "@/api/__generated__/Applications_ApplicationsFragment.graphql";
 import type { Applications_ApplicationSubscription } from "@/api/__generated__/Applications_ApplicationSubscription.graphql";
@@ -267,17 +268,18 @@ const ApplicationsContent = ({
         >
           {errorFeedback}
         </Alert>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <ApplicationsLayoutContainer
-          applicationsData={applicationsData}
-          searchText={searchText}
-          onDelete={setApplicationToDelete}
-        />
-
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <ApplicationsLayoutContainer
+            applicationsData={applicationsData}
+            searchText={searchText}
+            onDelete={setApplicationToDelete}
+          />
+        </Card>
         {applicationToDelete && (
           <DeleteApplicationModal
             applicationToDelete={applicationToDelete}

--- a/frontend/src/pages/BaseImage.tsx
+++ b/frontend/src/pages/BaseImage.tsx
@@ -27,6 +27,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type {
   BaseImage_getBaseImage_Query,
@@ -202,13 +203,15 @@ const BaseImageContent = ({ baseImage, queryRef }: BaseImageContentProps) => {
         >
           {errorFeedback}
         </Alert>
-        <UpdateBaseImageForm
-          baseImageRef={baseImage}
-          optionsRef={queryRef}
-          onSubmit={handleUpdateBaseImage}
-          onDelete={handleShowDeleteModal}
-          isLoading={isUpdatingBaseImage}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <UpdateBaseImageForm
+            baseImageRef={baseImage}
+            optionsRef={queryRef}
+            onSubmit={handleUpdateBaseImage}
+            onDelete={handleShowDeleteModal}
+            isLoading={isUpdatingBaseImage}
+          />
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={baseImage.version}

--- a/frontend/src/pages/BaseImageCollection.tsx
+++ b/frontend/src/pages/BaseImageCollection.tsx
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import { BaseImageCollection_BaseImagesFragment$key } from "@/api/__generated__/BaseImageCollection_BaseImagesFragment.graphql";
 import type { BaseImageCollection_deleteBaseImageCollection_Mutation } from "@/api/__generated__/BaseImageCollection_deleteBaseImageCollection_Mutation.graphql";
@@ -301,43 +302,44 @@ const BaseImageCollectionContent = ({
         >
           {errorFeedback}
         </Alert>
-        <div className="mb-3">
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
           <UpdateBaseImageCollectionForm
             baseImageCollectionRef={baseImageCollection}
             onSubmit={handleUpdateBaseImageCollection}
             onDelete={handleShowDeleteModal}
             isLoading={isUpdatingBaseImageCollection}
           />
-        </div>
-        <hr className="bg-secondary border-2 border-top border-secondary" />
-        <div className="d-flex justify-content-between align-items-center gap-2">
-          <h3>
-            <FormattedMessage
-              id="pages.BaseImageCollection.baseImagesLabel"
-              defaultMessage="Base Images"
-            />
-          </h3>
-          <Button
-            variant="secondary"
-            as={Link}
-            route={Route.baseImagesNew}
-            params={{ baseImageCollectionId }}
-          >
-            <FormattedMessage
-              id="pages.BaseImageCollection.createBaseImageButton"
-              defaultMessage="Create Base Image"
-            />
-          </Button>
-        </div>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <BaseImagesLayoutContainer
-          baseImageCollectionRef={baseImageCollection}
-          searchText={searchText}
-        />
+        </Card>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 pt-2">
+          <div className="d-flex justify-content-between align-items-center gap-2">
+            <h3>
+              <FormattedMessage
+                id="pages.BaseImageCollection.baseImagesLabel"
+                defaultMessage="Base Images"
+              />
+            </h3>
+            <Button
+              variant="secondary"
+              as={Link}
+              route={Route.baseImagesNew}
+              params={{ baseImageCollectionId }}
+            >
+              <FormattedMessage
+                id="pages.BaseImageCollection.createBaseImageButton"
+                defaultMessage="Create Base Image"
+              />
+            </Button>
+          </div>
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <BaseImagesLayoutContainer
+            baseImageCollectionRef={baseImageCollection}
+            searchText={searchText}
+          />
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={baseImageCollection?.handle || ""}

--- a/frontend/src/pages/BaseImageCollectionCreate.tsx
+++ b/frontend/src/pages/BaseImageCollectionCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2023-2025 SECO Mind Srl
+ * Copyright 2023-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import CreateBaseImageCollectionForm, {
   BaseImageCollectionOutputData,
 } from "@/forms/CreateBaseImageCollection";
 import { Link, Route, useNavigate } from "@/Navigation";
+import { Card } from "react-bootstrap";
 
 const CREATE_BASE_IMAGE_COLLECTION_PAGE_QUERY = graphql`
   query BaseImageCollectionCreate_getOptions_Query(
@@ -287,11 +288,13 @@ const BaseImageCollectionCreatePage = () => {
               }
             />
             <Page.Main>
-              <BaseImageCollectionWrapper
-                getBaseImageCollectionOptionsQuery={
-                  getBaseImageCollectionOptionsQuery
-                }
-              />
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+                <BaseImageCollectionWrapper
+                  getBaseImageCollectionOptionsQuery={
+                    getBaseImageCollectionOptionsQuery
+                  }
+                />
+              </Card>
             </Page.Main>
           </Page>
         )}

--- a/frontend/src/pages/BaseImageCollections.tsx
+++ b/frontend/src/pages/BaseImageCollections.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { BaseImageCollections_BaseImageCollectionsFragment$key } from "@/api/__generated__/BaseImageCollections_BaseImageCollectionsFragment.graphql";
 import type { BaseImageCollections_getBaseImageCollections_Query } from "@/api/__generated__/BaseImageCollections_getBaseImageCollections_Query.graphql";
@@ -154,15 +155,17 @@ const BaseImageCollectionsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <BaseImageCollectionsLayoutContainer
-          baseImageCollectionsData={baseImageCollectionsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <BaseImageCollectionsLayoutContainer
+            baseImageCollectionsData={baseImageCollectionsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/BaseImageCreate.tsx
+++ b/frontend/src/pages/BaseImageCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2023-2025 SECO Mind Srl
+ * Copyright 2023-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import Spinner from "@/components/Spinner";
 import CreateBaseImageForm from "@/forms/CreateBaseImage";
 import type { BaseImageOutputData } from "@/forms/CreateBaseImage";
 import { Link, Route, useNavigate } from "@/Navigation";
+import { Card } from "react-bootstrap";
 
 const GET_BASE_IMAGE_COLLECTION_QUERY = graphql`
   query BaseImageCreate_getOptions_Query($baseImageCollectionId: ID!) {
@@ -162,12 +163,14 @@ const BaseImageCreateContent = ({
         >
           {errorFeedback}
         </Alert>
-        <CreateBaseImageForm
-          baseImageCollectionRef={baseImageCollection}
-          optionsRef={queryRef}
-          onSubmit={handleCreateBaseImage}
-          isLoading={isCreatingBaseImage}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <CreateBaseImageForm
+            baseImageCollectionRef={baseImageCollection}
+            optionsRef={queryRef}
+            onSubmit={handleCreateBaseImage}
+            isLoading={isCreatingBaseImage}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -31,6 +31,7 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import { FormattedMessage } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import { Link, Route, useNavigate } from "@/Navigation";
 import Alert from "@/components/Alert";
@@ -249,7 +250,7 @@ const ChannelContent = ({ queryRef, channel }: ChannelContentProps) => {
         >
           {errorFeedback}
         </Alert>
-        <div className="mb-3">
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
           <ChannelForm
             channelRef={channel}
             optionsRef={channelOptions}
@@ -257,7 +258,7 @@ const ChannelContent = ({ queryRef, channel }: ChannelContentProps) => {
             onDelete={handleShowDeleteModal}
             isLoading={isUpdatingChannel}
           />
-        </div>
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={channel.handle}

--- a/frontend/src/pages/ChannelCreate.tsx
+++ b/frontend/src/pages/ChannelCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2023-2025 SECO Mind Srl
+ * Copyright 2023-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import Result from "@/components/Result";
 import Button from "@/components/Button";
 import { RECORDS_TO_LOAD_FIRST } from "@/constants";
 import CreateChannelForm from "@/forms/CreateChannel";
+import { Card } from "react-bootstrap";
 
 const GET_CREATE_CHANNEL_OPTIONS_QUERY = graphql`
   query ChannelCreate_getDeviceGroups_Query(
@@ -143,31 +144,21 @@ const Channel = ({ getCreateChannelOptionsQuery }: ChannelProps) => {
   );
 
   return (
-    <Page>
-      <Page.Header
-        title={
-          <FormattedMessage
-            id="pages.ChannelCreate.title"
-            defaultMessage="Create Channel"
-          />
-        }
+    <>
+      <Alert
+        show={!!errorFeedback}
+        variant="danger"
+        onClose={() => setErrorFeedback(null)}
+        dismissible
+      >
+        {errorFeedback}
+      </Alert>
+      <CreateChannelForm
+        queryRef={channelCreateData}
+        onSubmit={handleCreateChannel}
+        isLoading={isCreatingChannel}
       />
-      <Page.Main>
-        <Alert
-          show={!!errorFeedback}
-          variant="danger"
-          onClose={() => setErrorFeedback(null)}
-          dismissible
-        >
-          {errorFeedback}
-        </Alert>
-        <CreateChannelForm
-          queryRef={channelCreateData}
-          onSubmit={handleCreateChannel}
-          isLoading={isCreatingChannel}
-        />
-      </Page.Main>
-    </Page>
+    </>
   );
 };
 const NoGroups = () => (
@@ -250,9 +241,23 @@ const ChannelCreatePage = () => {
         onReset={fetchCreateChannelOptions}
       >
         {getCreateChannelOptionsQuery && (
-          <ChannelWrapper
-            getCreateChannelOptionsQuery={getCreateChannelOptionsQuery}
-          />
+          <Page>
+            <Page.Header
+              title={
+                <FormattedMessage
+                  id="pages.ChannelCreate.title"
+                  defaultMessage="Create Channel"
+                />
+              }
+            />
+            <Page.Main>
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+                <ChannelWrapper
+                  getCreateChannelOptionsQuery={getCreateChannelOptionsQuery}
+                />
+              </Card>
+            </Page.Main>
+          </Page>
         )}
       </ErrorBoundary>
     </Suspense>

--- a/frontend/src/pages/Channels.tsx
+++ b/frontend/src/pages/Channels.tsx
@@ -28,6 +28,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { Channels_ChannelsFragment$key } from "@/api/__generated__/Channels_ChannelsFragment.graphql";
 import type { Channels_getChannels_Query } from "@/api/__generated__/Channels_getChannels_Query.graphql";
@@ -286,15 +287,17 @@ const ChannelsContent = ({ getChannelsQuery }: ChannelsContentProps) => {
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <ChannelsLayoutContainer
-          channelsData={channelsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <ChannelsLayoutContainer
+            channelsData={channelsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Containers.tsx
+++ b/frontend/src/pages/Containers.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { Containers_ContainersFragment$key } from "@/api/__generated__/Containers_ContainersFragment.graphql";
 import type { Containers_getContainers_Query } from "@/api/__generated__/Containers_getContainers_Query.graphql";
@@ -146,15 +147,17 @@ const ContainersContent = ({ getContainersQuery }: ContainersContentProps) => {
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <ContainersLayoutContainer
-          containersData={containersData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <ContainersLayoutContainer
+            containersData={containersData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/DeploymentCampaign.tsx
+++ b/frontend/src/pages/DeploymentCampaign.tsx
@@ -32,6 +32,7 @@ import {
   useSubscription,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import type {
   DeploymentCampaign_getCampaign_Query,
@@ -399,16 +400,19 @@ const DeploymentCampaignContent = ({
           )}
         </Alert>
 
-        <Row>
-          <Col lg={9}>
-            <DeploymentCampaignForm campaignRef={campaign} />
-          </Col>
-          <Col lg={3}>
-            <CampaignStatsChart campaignRef={campaign} />
-          </Col>
-        </Row>
-        <hr className="bg-secondary border-2 border-top border-secondary" />
-        <DeploymentTargetsTabs campaignRef={campaign} />
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
+          <Row>
+            <Col lg={9}>
+              <DeploymentCampaignForm campaignRef={campaign} />
+            </Col>
+            <Col lg={3}>
+              <CampaignStatsChart campaignRef={campaign} />
+            </Col>
+          </Row>
+        </Card>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <DeploymentTargetsTabs campaignRef={campaign} />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/DeploymentCampaignCreate.tsx
+++ b/frontend/src/pages/DeploymentCampaignCreate.tsx
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type {
   DeploymentCampaignCreate_getOptions_Query,
@@ -279,9 +280,11 @@ const DeploymentCampaignCreatePage = () => {
               }
             />
             <Page.Main>
-              <DeploymentCampaignWrapper
-                getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
-              />
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+                <DeploymentCampaignWrapper
+                  getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
+                />
+              </Card>
             </Page.Main>
           </Page>
         )}

--- a/frontend/src/pages/DeploymentCampaigns.tsx
+++ b/frontend/src/pages/DeploymentCampaigns.tsx
@@ -30,6 +30,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { DeploymentCampaigns_DeploymentCampaignsFragment$key } from "@/api/__generated__/DeploymentCampaigns_DeploymentCampaignsFragment.graphql";
 import type { DeploymentCampaigns_getCampaigns_Query } from "@/api/__generated__/DeploymentCampaigns_getCampaigns_Query.graphql";
@@ -380,15 +381,17 @@ const DeploymentCampaignsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <DeploymentCampaignsLayoutContainer
-          campaignsData={campaignsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <DeploymentCampaignsLayoutContainer
+            campaignsData={campaignsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Deployments.tsx
+++ b/frontend/src/pages/Deployments.tsx
@@ -28,6 +28,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { Deployments_DeploymentsFragment$key } from "@/api/__generated__/Deployments_DeploymentsFragment.graphql";
 import type { Deployments_deployment_created_Subscription } from "@/api/__generated__/Deployments_deployment_created_Subscription.graphql";
@@ -322,15 +323,17 @@ const DeploymentsContent = ({
         }
       ></Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <DeploymentsLayoutContainer
-          deploymentsData={deploymentsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <DeploymentsLayoutContainer
+            deploymentsData={deploymentsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Device.tsx
+++ b/frontend/src/pages/Device.tsx
@@ -40,6 +40,7 @@ import {
 import type { PreloadedQuery } from "react-relay/hooks";
 import type { PayloadError } from "relay-runtime";
 import { FormattedMessage } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type { Device_connectionStatus$key } from "@/api/__generated__/Device_connectionStatus.graphql";
 import type { Device_getDevice_Query } from "@/api/__generated__/Device_getDevice_Query.graphql";
@@ -261,7 +262,7 @@ const TAB_KEYS = [
 ];
 
 const FormRow = (props: FormRowProps) => (
-  <BaseFormRow {...props} labelCol={4} valueCol={8} />
+  <BaseFormRow {...props} labelCol={3} valueCol={9} />
 );
 
 const FormValue = (params: { children: React.ReactNode }) => {
@@ -716,224 +717,229 @@ const DeviceContent = ({
           >
             {errorFeedback}
           </Alert>
-          <Row>
-            <Col md="5" lg="4" xl="3">
-              <div>
-                <Figure
-                  alt={device.name}
-                  src={device.systemModel?.pictureUrl || assets.images.devices}
-                />
-              </div>
-            </Col>
-            <Col md="7" lg="8" xl="9">
-              <Form className="ms-3">
-                <Stack gap={3}>
-                  <FormRow
-                    id="form-device-name"
-                    label={
-                      <FormattedMessage
-                        id="pages.Device.name"
-                        defaultMessage="Name"
-                      />
+          <Card className="h-100 border-0 p-3 shadow-sm mb-2">
+            <Row>
+              <Col md="5" lg="4" xl="3">
+                <div>
+                  <Figure
+                    alt={device.name}
+                    src={
+                      device.systemModel?.pictureUrl || assets.images.devices
                     }
-                  >
-                    <Form.Control
-                      type="text"
-                      value={deviceDraftName}
-                      onChange={(e) => handleDeviceNameChange(e.target.value)}
-                    />
-                  </FormRow>
-                  <FormRow
-                    id="form-device-tags"
-                    label={
-                      <FormattedMessage
-                        id="pages.Device.tags"
-                        defaultMessage="Tags"
-                      />
-                    }
-                  >
-                    <MultiSelect
-                      creatable
-                      value={deviceTags}
-                      options={tags}
-                      onChange={(newTags) =>
-                        handleTagsChange(newTags.map(({ value }) => value))
-                      }
-                      isValidNewOption={isValidNewTag}
-                      onCreateOption={(inputValue) => {
-                        const newTag = inputValue.trim().toLowerCase();
-                        handleAddDeviceTags([newTag]);
-                      }}
-                    />
-                  </FormRow>
-                  <FormRow
-                    id="form-device-deviceId"
-                    label={
-                      <FormattedMessage
-                        id="pages.Device.deviceId"
-                        defaultMessage="Device ID"
-                      />
-                    }
-                  >
-                    <Form.Control
-                      type="text"
-                      value={device.deviceId}
-                      readOnly
-                    />
-                  </FormRow>
-                  {device.serialNumber && (
+                  />
+                </div>
+              </Col>
+              <Col md="7" lg="8" xl="9">
+                <Form className="ms-3">
+                  <Stack gap={3}>
                     <FormRow
-                      id="form-device-serialNumber"
+                      id="form-device-name"
                       label={
                         <FormattedMessage
-                          id="pages.Device.serialNumber"
-                          defaultMessage="Serial Number"
+                          id="pages.Device.name"
+                          defaultMessage="Name"
                         />
                       }
                     >
                       <Form.Control
                         type="text"
-                        value={device.serialNumber}
-                        readOnly
+                        value={deviceDraftName}
+                        onChange={(e) => handleDeviceNameChange(e.target.value)}
                       />
                     </FormRow>
-                  )}
-                  {device.partNumber && (
                     <FormRow
-                      id="device-hardware-info-part-number"
+                      id="form-device-tags"
                       label={
                         <FormattedMessage
-                          id="pages.Device.partNumber"
-                          defaultMessage="Part Number"
+                          id="pages.Device.tags"
+                          defaultMessage="Tags"
+                        />
+                      }
+                    >
+                      <MultiSelect
+                        creatable
+                        value={deviceTags}
+                        options={tags}
+                        onChange={(newTags) =>
+                          handleTagsChange(newTags.map(({ value }) => value))
+                        }
+                        isValidNewOption={isValidNewTag}
+                        onCreateOption={(inputValue) => {
+                          const newTag = inputValue.trim().toLowerCase();
+                          handleAddDeviceTags([newTag]);
+                        }}
+                      />
+                    </FormRow>
+                    <FormRow
+                      id="form-device-deviceId"
+                      label={
+                        <FormattedMessage
+                          id="pages.Device.deviceId"
+                          defaultMessage="Device ID"
                         />
                       }
                     >
                       <Form.Control
                         type="text"
-                        value={device.partNumber}
+                        value={device.deviceId}
                         readOnly
                       />
                     </FormRow>
-                  )}
-                  {device.systemModel && (
-                    <>
+                    {device.serialNumber && (
                       <FormRow
-                        id="form-device-system-model"
+                        id="form-device-serialNumber"
                         label={
                           <FormattedMessage
-                            id="pages.Device.systemModel"
-                            defaultMessage="System Model"
+                            id="pages.Device.serialNumber"
+                            defaultMessage="Serial Number"
                           />
                         }
                       >
                         <Form.Control
                           type="text"
-                          value={device.systemModel.name}
+                          value={device.serialNumber}
                           readOnly
                         />
                       </FormRow>
+                    )}
+                    {device.partNumber && (
                       <FormRow
-                        id="form-device-hardware-type"
+                        id="device-hardware-info-part-number"
                         label={
                           <FormattedMessage
-                            id="pages.Device.hardwareType"
-                            defaultMessage="Hardware Type"
+                            id="pages.Device.partNumber"
+                            defaultMessage="Part Number"
                           />
                         }
                       >
                         <Form.Control
                           type="text"
-                          value={device.systemModel.hardwareType?.name}
+                          value={device.partNumber}
                           readOnly
                         />
                       </FormRow>
-                    </>
-                  )}
-                  <FormRow
-                    id="form-device-deviceGroups"
-                    label={
-                      <FormattedMessage
-                        id="pages.Device.groups"
-                        defaultMessage="Groups"
-                      />
-                    }
-                  >
-                    <Stack direction="horizontal" gap={3}>
-                      {device.deviceGroups.map((deviceGroup) => (
-                        <Link
-                          key={`device-group-link-${deviceGroup.id}`}
-                          route={Route.deviceGroupsEdit}
-                          params={{ deviceGroupId: deviceGroup.id }}
-                        >
-                          {deviceGroup.name}
-                        </Link>
-                      ))}
-                    </Stack>
-                  </FormRow>
-                  <DeviceConnectionFormRows deviceRef={device} />
-                  {device.capabilities.includes("LED_BEHAVIORS") && (
-                    <FormRow
-                      id="form-device-check-my-device"
-                      label={
-                        <FormattedMessage
-                          id="pages.Device.checkMyDevice"
-                          defaultMessage="Check my Device"
-                        />
-                      }
-                    >
-                      <LedBehaviorDropdown
-                        deviceId={device.id}
-                        disabled={!device.online}
-                        onError={setErrorFeedback}
-                      />
-                    </FormRow>
-                  )}
-                  {isRemoteTerminalSupported && (
-                    <FormRow
-                      id="form-device-open-remote-terminal"
-                      label={
-                        <FormattedMessage
-                          id="pages.Device.remoteTerminal.label"
-                          defaultMessage="Remote Terminal"
-                        />
-                      }
-                    >
+                    )}
+                    {device.systemModel && (
                       <>
-                        <Button
-                          variant="secondary"
-                          onClick={handleRequestForwarderSession}
-                          disabled={
-                            !device.online ||
-                            isRequestingForwarderSession ||
-                            isOpeningRemoteTerminal
+                        <FormRow
+                          id="form-device-system-model"
+                          label={
+                            <FormattedMessage
+                              id="pages.Device.systemModel"
+                              defaultMessage="System Model"
+                            />
                           }
                         >
-                          {(isRequestingForwarderSession ||
-                            isOpeningRemoteTerminal) && (
-                            <Spinner size="sm" className="me-2" />
-                          )}
-                          <FormattedMessage
-                            id="pages.Device.remoteTerminal.openTerminalButton"
-                            defaultMessage="Open"
+                          <Form.Control
+                            type="text"
+                            value={device.systemModel.name}
+                            readOnly
                           />
-                        </Button>
-                        <Alert
-                          show={!!remoteTerminalErrorFeedback}
-                          variant="danger"
-                          onClose={() => setRemoteTerminalErrorFeedback(null)}
-                          dismissible
-                          className="mt-3"
+                        </FormRow>
+                        <FormRow
+                          id="form-device-hardware-type"
+                          label={
+                            <FormattedMessage
+                              id="pages.Device.hardwareType"
+                              defaultMessage="Hardware Type"
+                            />
+                          }
                         >
-                          {remoteTerminalErrorFeedback}
-                        </Alert>
+                          <Form.Control
+                            type="text"
+                            value={device.systemModel.hardwareType?.name}
+                            readOnly
+                          />
+                        </FormRow>
                       </>
+                    )}
+                    <FormRow
+                      id="form-device-deviceGroups"
+                      label={
+                        <FormattedMessage
+                          id="pages.Device.groups"
+                          defaultMessage="Groups"
+                        />
+                      }
+                    >
+                      <Stack direction="horizontal" gap={3}>
+                        {device.deviceGroups.map((deviceGroup) => (
+                          <Link
+                            key={`device-group-link-${deviceGroup.id}`}
+                            route={Route.deviceGroupsEdit}
+                            params={{ deviceGroupId: deviceGroup.id }}
+                          >
+                            {deviceGroup.name}
+                          </Link>
+                        ))}
+                      </Stack>
                     </FormRow>
-                  )}
-                </Stack>
-              </Form>
-            </Col>
-          </Row>
+                    <DeviceConnectionFormRows deviceRef={device} />
+                    {device.capabilities.includes("LED_BEHAVIORS") && (
+                      <FormRow
+                        id="form-device-check-my-device"
+                        label={
+                          <FormattedMessage
+                            id="pages.Device.checkMyDevice"
+                            defaultMessage="Check my Device"
+                          />
+                        }
+                      >
+                        <LedBehaviorDropdown
+                          deviceId={device.id}
+                          disabled={!device.online}
+                          onError={setErrorFeedback}
+                        />
+                      </FormRow>
+                    )}
+                    {isRemoteTerminalSupported && (
+                      <FormRow
+                        id="form-device-open-remote-terminal"
+                        label={
+                          <FormattedMessage
+                            id="pages.Device.remoteTerminal.label"
+                            defaultMessage="Remote Terminal"
+                          />
+                        }
+                      >
+                        <>
+                          <Button
+                            variant="secondary"
+                            onClick={handleRequestForwarderSession}
+                            disabled={
+                              !device.online ||
+                              isRequestingForwarderSession ||
+                              isOpeningRemoteTerminal
+                            }
+                          >
+                            {(isRequestingForwarderSession ||
+                              isOpeningRemoteTerminal) && (
+                              <Spinner size="sm" className="me-2" />
+                            )}
+                            <FormattedMessage
+                              id="pages.Device.remoteTerminal.openTerminalButton"
+                              defaultMessage="Open"
+                            />
+                          </Button>
+                          <Alert
+                            show={!!remoteTerminalErrorFeedback}
+                            variant="danger"
+                            onClose={() => setRemoteTerminalErrorFeedback(null)}
+                            dismissible
+                            className="mt-3"
+                          >
+                            {remoteTerminalErrorFeedback}
+                          </Alert>
+                        </>
+                      </FormRow>
+                    )}
+                  </Stack>
+                </Form>
+              </Col>
+            </Row>
+          </Card>
           <Tabs
+            className="pt-1 d-flex flex-column flex-grow-1"
             activeKey={currentTabKey}
             tabsOrder={TAB_KEYS}
             onChange={(tabKey) =>

--- a/frontend/src/pages/DeviceGroup.tsx
+++ b/frontend/src/pages/DeviceGroup.tsx
@@ -30,6 +30,7 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import { FormattedMessage } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type {
   DeviceGroup_getDeviceGroup_Query,
@@ -308,19 +309,22 @@ const DeviceGroupContent = ({ deviceGroup }: DeviceGroupContentProps) => {
         >
           {errorFeedback}
         </Alert>
-        <div className="mb-3">
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
           <UpdateDeviceGroupForm
             deviceGroupRef={deviceGroup}
             onSubmit={handleUpdateDeviceGroup}
             onDelete={handleShowDeleteModal}
             isLoading={isUpdatingDeviceGroup}
           />
-        </div>
+        </Card>
         {/* TODO This component is being temporarily used
             to display devices in a group. It should be removed once the
             backend returns DeviceConnection objects in the group query
             and DevicesTable should be used in its place. */}
-        <DevicesGroupsTable devicesRef={deviceGroup.devices} hideSearch />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <DevicesGroupsTable devicesRef={deviceGroup.devices} hideSearch />
+        </Card>
+
         {showDeleteModal && (
           <DeleteModal
             confirmText={deviceGroup.handle}

--- a/frontend/src/pages/DeviceGroupCreate.tsx
+++ b/frontend/src/pages/DeviceGroupCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2022-2025 SECO Mind Srl
+ * Copyright 2022-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 import { useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { ConnectionHandler, graphql, useMutation } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { DeviceGroupCreate_createDeviceGroup_Mutation } from "@/api/__generated__/DeviceGroupCreate_createDeviceGroup_Mutation.graphql";
 import Alert from "@/components/Alert";
@@ -143,10 +144,12 @@ const DeviceGroupCreatePage = () => {
         >
           {errorFeedback}
         </Alert>
-        <DeviceGroupCreateForm
-          onSubmit={handleCreateDeviceGroup}
-          isLoading={isCreatingDeviceGroup}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <DeviceGroupCreateForm
+            onSubmit={handleCreateDeviceGroup}
+            isLoading={isCreatingDeviceGroup}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/DeviceGroups.tsx
+++ b/frontend/src/pages/DeviceGroups.tsx
@@ -28,6 +28,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { DeviceGroups_DeviceGroupsFragment$key } from "@/api/__generated__/DeviceGroups_DeviceGroupsFragment.graphql";
 import type { DeviceGroups_getDeviceGroups_Query } from "@/api/__generated__/DeviceGroups_getDeviceGroups_Query.graphql";
@@ -286,15 +287,17 @@ const DeviceGroupsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <DeviceGroupsLayoutContainer
-          deviceGroupsData={deviceGroupsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <DeviceGroupsLayoutContainer
+            deviceGroupsData={deviceGroupsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Devices.tsx
+++ b/frontend/src/pages/Devices.tsx
@@ -28,6 +28,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import { Devices_DevicesFragment$key } from "@/api/__generated__/Devices_DevicesFragment.graphql";
 import type { Devices_getDevices_Query } from "@/api/__generated__/Devices_getDevices_Query.graphql";
@@ -261,15 +262,17 @@ const DevicesContent = ({ getDevicesQuery }: DevicesContentProps) => {
         }
       />
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <DevicesLayoutContainer
-          devicesData={devicesData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <DevicesLayoutContainer
+            devicesData={devicesData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/FileCreate.tsx
+++ b/frontend/src/pages/FileCreate.tsx
@@ -30,6 +30,7 @@ import {
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
 import { PayloadError } from "relay-runtime";
+import { Card } from "react-bootstrap";
 
 import type { FileCreate_createFile_Mutation } from "@/api/__generated__/FileCreate_createFile_Mutation.graphql";
 import type {
@@ -177,12 +178,13 @@ const FileCreateContent = ({ repository }: FileCreateContentProps) => {
         >
           {errorFeedback}
         </Alert>
-
-        <CreateFileForm
-          repositoryRef={repository}
-          onSubmit={handleCreateFile}
-          isLoading={isCreatingFile || isUploading}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <CreateFileForm
+            repositoryRef={repository}
+            onSubmit={handleCreateFile}
+            isLoading={isCreatingFile || isUploading}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/FileDownloadCampaign.tsx
+++ b/frontend/src/pages/FileDownloadCampaign.tsx
@@ -33,6 +33,7 @@ import {
   useSubscription,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import type {
   FileDownloadCampaign_getCampaign_Query,
@@ -387,18 +388,19 @@ const FileDownloadCampaignContent = ({
             </div>
           )}
         </Alert>
-
-        <Row>
-          <Col lg={9}>
-            <FileDownloadCampaignForm campaignRef={campaign} />
-          </Col>
-          <Col lg={3}>
-            <CampaignStatsChart campaignRef={campaign} />
-          </Col>
-        </Row>
-
-        <hr className="bg-secondary border-2 border-top border-secondary" />
-        <FileDownloadTargetsTabs campaignRef={campaign} />
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
+          <Row>
+            <Col lg={9}>
+              <FileDownloadCampaignForm campaignRef={campaign} />
+            </Col>
+            <Col lg={3}>
+              <CampaignStatsChart campaignRef={campaign} />
+            </Col>
+          </Row>
+        </Card>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <FileDownloadTargetsTabs campaignRef={campaign} />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/FileDownloadCampaignCreate.tsx
+++ b/frontend/src/pages/FileDownloadCampaignCreate.tsx
@@ -29,6 +29,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { FileDownloadCampaignCreate_createCampaign_Mutation } from "@/api/__generated__/FileDownloadCampaignCreate_createCampaign_Mutation.graphql";
 import type {
@@ -286,9 +287,11 @@ const FileDownloadCampaignCreatePage = () => {
               }
             />
             <Page.Main>
-              <FileDownloadCampaignWrapper
-                getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
-              />
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+                <FileDownloadCampaignWrapper
+                  getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
+                />
+              </Card>
             </Page.Main>
           </Page>
         )}

--- a/frontend/src/pages/FileDownloadCampaigns.tsx
+++ b/frontend/src/pages/FileDownloadCampaigns.tsx
@@ -30,6 +30,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { FileDownloadCampaigns_FileDownloadCampaignsFragment$key } from "@/api/__generated__/FileDownloadCampaigns_FileDownloadCampaignsFragment.graphql";
 import type { FileDownloadCampaigns_getCampaigns_Query } from "@/api/__generated__/FileDownloadCampaigns_getCampaigns_Query.graphql";
@@ -319,16 +320,18 @@ const FileDownloadCampaignsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
 
-        <FileDownloadCampaignsLayoutContainer
-          campaignsData={campaignsData}
-          searchText={searchText}
-        />
+          <FileDownloadCampaignsLayoutContainer
+            campaignsData={campaignsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/HardwareType.tsx
+++ b/frontend/src/pages/HardwareType.tsx
@@ -28,6 +28,7 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import { FormattedMessage } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type {
   HardwareType_getHardwareType_Query,
@@ -196,12 +197,14 @@ const HardwareTypeContent = ({ hardwareType }: HardwareTypeContentProps) => {
         >
           {errorFeedback}
         </Alert>
-        <UpdateHardwareTypeForm
-          hardwareTypeRef={hardwareType}
-          onSubmit={handleUpdateHardwareType}
-          onDelete={handleShowDeleteModal}
-          isLoading={isUpdatingHardwareType}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <UpdateHardwareTypeForm
+            hardwareTypeRef={hardwareType}
+            onSubmit={handleUpdateHardwareType}
+            onDelete={handleShowDeleteModal}
+            isLoading={isUpdatingHardwareType}
+          />
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={hardwareType.handle}

--- a/frontend/src/pages/HardwareTypeCreate.tsx
+++ b/frontend/src/pages/HardwareTypeCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2021-2025 SECO Mind Srl
+ * Copyright 2021-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import Page from "@/components/Page";
 import CreateHardwareTypeForm from "@/forms/CreateHardwareType";
 import type { HardwareTypeOutputData } from "@/forms/CreateHardwareType";
 import { Route, useNavigate } from "@/Navigation";
+import { Card } from "react-bootstrap";
 
 const CREATE_HARDWARE_TYPE_MUTATION = graphql`
   mutation HardwareTypeCreate_createHardwareType_Mutation(
@@ -128,10 +129,12 @@ const HardwareTypeCreatePage = () => {
         >
           {errorFeedback}
         </Alert>
-        <CreateHardwareTypeForm
-          onSubmit={handleCreateHardwareType}
-          isLoading={isCreatingHardwareType}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <CreateHardwareTypeForm
+            onSubmit={handleCreateHardwareType}
+            isLoading={isCreatingHardwareType}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/HardwareTypes.tsx
+++ b/frontend/src/pages/HardwareTypes.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { HardwareTypes_getHardwareTypes_Query } from "@/api/__generated__/HardwareTypes_getHardwareTypes_Query.graphql";
 import { HardwareTypes_HardwareTypesFragment$key } from "@/api/__generated__/HardwareTypes_HardwareTypesFragment.graphql";
@@ -160,23 +161,25 @@ const HardwareTypesContent = ({
       </Page.Header>
       <Page.Main>
         {hardwareTypesData.hardwareTypes?.count === 0 ? (
-          <Result.EmptyList
-            title={
+          <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+            <Result.EmptyList
+              title={
+                <FormattedMessage
+                  id="pages.HardwareTypes.noHardwareTypes.title"
+                  defaultMessage="This space is empty"
+                />
+              }
+            >
               <FormattedMessage
-                id="pages.HardwareTypes.noHardwareTypes.title"
-                defaultMessage="This space is empty"
+                id="pages.HardwareTypes.noHardwareTypes.message"
+                defaultMessage="You haven't created any hardware type yet."
               />
-            }
-          >
-            <FormattedMessage
-              id="pages.HardwareTypes.noHardwareTypes.message"
-              defaultMessage="You haven't created any hardware type yet."
-            />
-          </Result.EmptyList>
+            </Result.EmptyList>
+          </Card>
         ) : (
-          <>
+          <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
             <SearchBox
-              className="flex-grow-1 pb-2"
+              className="pb-2"
               value={searchText}
               onChange={setSearchText}
             />
@@ -184,7 +187,7 @@ const HardwareTypesContent = ({
               hardwareTypesData={hardwareTypesData}
               searchText={searchText}
             />
-          </>
+          </Card>
         )}
       </Page.Main>
     </Page>

--- a/frontend/src/pages/ImageCredential.tsx
+++ b/frontend/src/pages/ImageCredential.tsx
@@ -19,7 +19,7 @@
  */
 
 import { ReactNode, Suspense, useCallback, useEffect, useState } from "react";
-import { Alert } from "react-bootstrap";
+import { Alert, Card } from "react-bootstrap";
 import { ErrorBoundary } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
 import {
@@ -131,10 +131,12 @@ const ImageCredentialContent = ({
         >
           {errorFeedback}
         </Alert>
-        <UpdateImageCredentialForm
-          imageCredentialRef={imageCredential}
-          onDelete={handleShowDeleteModal}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <UpdateImageCredentialForm
+            imageCredentialRef={imageCredential}
+            onDelete={handleShowDeleteModal}
+          />
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={imageCredential.label}

--- a/frontend/src/pages/ImageCredentialCreate.tsx
+++ b/frontend/src/pages/ImageCredentialCreate.tsx
@@ -21,6 +21,7 @@
 import { ReactNode, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, useMutation } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { ImageCredentialCreate_imageCredentialCreate_Mutation } from "@/api/__generated__/ImageCredentialCreate_imageCredentialCreate_Mutation.graphql";
 
@@ -103,10 +104,12 @@ const ImageCredentialCreatePage = () => {
         >
           {errorFeedback}
         </Alert>
-        <CreateImageCredentialForm
-          onSubmit={handleCreateImageCredential}
-          isLoading={isCreatingImageCredential}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <CreateImageCredentialForm
+            onSubmit={handleCreateImageCredential}
+            isLoading={isCreatingImageCredential}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/ImageCredentials.tsx
+++ b/frontend/src/pages/ImageCredentials.tsx
@@ -28,6 +28,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay";
+import { Card } from "react-bootstrap";
 
 import type { ImageCredentials_getImageCredentials_Query } from "@/api/__generated__/ImageCredentials_getImageCredentials_Query.graphql";
 import { ImageCredentials_ImageCredentialsFragment$key } from "@/api/__generated__/ImageCredentials_ImageCredentialsFragment.graphql";
@@ -150,15 +151,17 @@ const ImageCredentialsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <ImageCredentialsLayoutContainer
-          imageCredentialsData={imageCredentialsData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+          <SearchBox
+            className=" pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <ImageCredentialsLayoutContainer
+            imageCredentialsData={imageCredentialsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Network.tsx
+++ b/frontend/src/pages/Network.tsx
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Suspense, useCallback, useEffect, useState } from "react";
-import { Form, Stack } from "react-bootstrap";
+import { Card, Form, Stack } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -139,82 +139,86 @@ const NetworkContent = ({ network }: NetworkContentProps) => {
         >
           {errorFeedback}
         </Alert>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <FormRow
+            id="networkLabel"
+            label={
+              <FormattedMessage
+                id="pages.Network.label"
+                defaultMessage="Label"
+              />
+            }
+          >
+            <Form.Control value={network.label ?? ""} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="networkLabel"
-          label={
-            <FormattedMessage id="pages.Network.label" defaultMessage="Label" />
-          }
-        >
-          <Form.Control value={network.label ?? ""} readOnly />
-        </FormRow>
+          <FormRow
+            id="networkDriver"
+            label={
+              <FormattedMessage
+                id="pages.Network.driver"
+                defaultMessage="Driver"
+              />
+            }
+          >
+            <Form.Control value={network.driver ?? ""} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="networkDriver"
-          label={
-            <FormattedMessage
-              id="pages.Network.driver"
-              defaultMessage="Driver"
+          <FormRow
+            id="networkOptions"
+            label={
+              <FormattedMessage
+                id="pages.Network.options"
+                defaultMessage="Options"
+              />
+            }
+          >
+            <MonacoJsonEditor
+              value={getPrettyOptions()}
+              onChange={() => {}}
+              defaultValue={getPrettyOptions()}
+              readonly={true}
+              initialLines={1}
             />
-          }
-        >
-          <Form.Control value={network.driver ?? ""} readOnly />
-        </FormRow>
+          </FormRow>
 
-        <FormRow
-          id="networkOptions"
-          label={
-            <FormattedMessage
-              id="pages.Network.options"
-              defaultMessage="Options"
-            />
-          }
-        >
-          <MonacoJsonEditor
-            value={getPrettyOptions()}
-            onChange={() => {}}
-            defaultValue={getPrettyOptions()}
-            readonly={true}
-            initialLines={1}
-          />
-        </FormRow>
+          <FormRow
+            id="networkInternal"
+            label={
+              <FormattedMessage
+                id="pages.Network.internal"
+                defaultMessage="Internal"
+              />
+            }
+          >
+            <Form.Check type="checkbox" checked={network.internal} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="networkInternal"
-          label={
-            <FormattedMessage
-              id="pages.Network.internal"
-              defaultMessage="Internal"
-            />
-          }
-        >
-          <Form.Check type="checkbox" checked={network.internal} readOnly />
-        </FormRow>
+          <FormRow
+            id="networkLabelEnableIpv6"
+            label={
+              <FormattedMessage
+                id="pages.Network.enableIpv6"
+                defaultMessage="Enable IPv6"
+              />
+            }
+          >
+            <Form.Check type="checkbox" checked={network.enableIpv6} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="networkLabelEnableIpv6"
-          label={
-            <FormattedMessage
-              id="pages.Network.enableIpv6"
-              defaultMessage="Enable IPv6"
-            />
-          }
-        >
-          <Form.Check type="checkbox" checked={network.enableIpv6} readOnly />
-        </FormRow>
-
-        <Stack
-          direction="horizontal"
-          gap={3}
-          className="justify-content-end align-items-center"
-        >
-          <Button variant="danger" onClick={handleShowDeleteModal}>
-            <FormattedMessage
-              id="pages.Network.deleteButton"
-              defaultMessage="Delete"
-            />
-          </Button>
-        </Stack>
+          <Stack
+            direction="horizontal"
+            gap={3}
+            className="justify-content-end align-items-center"
+          >
+            <Button variant="danger" onClick={handleShowDeleteModal}>
+              <FormattedMessage
+                id="pages.Network.deleteButton"
+                defaultMessage="Delete"
+              />
+            </Button>
+          </Stack>
+        </Card>
 
         {showDeleteModal && (
           <DeleteModal

--- a/frontend/src/pages/NetworkCreate.tsx
+++ b/frontend/src/pages/NetworkCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2025 SECO Mind Srl
+ * Copyright 2025-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import Page from "@/components/Page";
 import { Route, useNavigate } from "@/Navigation";
 import CreateNetworkForm from "@/forms/CreateNetwork";
 import { NetworkFormData } from "@/forms/validation";
+import { Card } from "react-bootstrap";
 
 const CREATE_NETWORK_MUTATION = graphql`
   mutation NetworkCreate_networkCreate_Mutation($input: CreateNetworkInput!) {
@@ -134,10 +135,12 @@ const NetworkCreatePage = () => {
         >
           {errorFeedback}
         </Alert>
-        <CreateNetworkForm
-          onSubmit={handleCreateNetwork}
-          isLoading={isCreatingNetwork}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <CreateNetworkForm
+            onSubmit={handleCreateNetwork}
+            isLoading={isCreatingNetwork}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Networks.tsx
+++ b/frontend/src/pages/Networks.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { Networks_getNetworks_Query } from "@/api/__generated__/Networks_getNetworks_Query.graphql";
 import { Networks_NetworksFragment$key } from "@/api/__generated__/Networks_NetworksFragment.graphql";
@@ -142,15 +143,17 @@ const NetworksContent = ({ getNetworksQuery }: NetworksContentProps) => {
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <NetworksLayoutContainer
-          networksData={networksData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <NetworksLayoutContainer
+            networksData={networksData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Release.tsx
+++ b/frontend/src/pages/Release.tsx
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import { Containers_PaginationQuery } from "@/api/__generated__/Containers_PaginationQuery.graphql";
 import { Release_ContainersFragment$key } from "@/api/__generated__/Release_ContainersFragment.graphql";
@@ -120,11 +121,7 @@ const ContainersLayoutContainer = ({
     return null;
   }
 
-  return (
-    <div className="mt-3">
-      <ContainersOverview containersRef={containersRef} />
-    </div>
-  );
+  return <ContainersOverview containersRef={containersRef} />;
 };
 
 interface SystemModelsTabProps {
@@ -136,15 +133,16 @@ const SystemModelsTab = ({ release }: SystemModelsTabProps) => {
 
   return (
     <Tab
+      className="pt-3 d-flex flex-column flex-grow-1"
       eventKey="system-models-tab"
       title={intl.formatMessage({
         id: "pages.Release.systemModels",
         defaultMessage: "System Models",
       })}
     >
-      <div className="mt-3">
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
         <ReleaseSystemModelsTable systemModelsRef={release} />
-      </div>
+      </Card>
     </Tab>
   );
 };
@@ -174,13 +172,13 @@ const ReleaseDevicesLayoutContainer = ({
   }
 
   return (
-    <div className="mt-3">
+    <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
       <ReleaseDevicesTable
         deploymentsRef={deploymentsRef}
         loading={isLoadingNext}
         onLoadMore={onLoadMore}
       />
-    </div>
+    </Card>
   );
 };
 
@@ -213,6 +211,7 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
         </Alert>
 
         <Tabs
+          className="pt-3 d-flex flex-column flex-grow-1"
           activeKey={currentTabKey}
           tabsOrder={TAB_KEYS}
           onChange={(tabKey) =>
@@ -226,6 +225,7 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
           }
         >
           <Tab
+            className="pt-3 d-flex flex-column flex-grow-1"
             eventKey="containers-tab"
             title={intl.formatMessage({
               id: "pages.Release.containers",
@@ -238,6 +238,7 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
           <SystemModelsTab release={release} />
 
           <Tab
+            className="pt-3 d-flex flex-column flex-grow-1"
             eventKey="devices-tab"
             title={intl.formatMessage({
               id: "pages.Release.devices",

--- a/frontend/src/pages/ReleaseCreate.tsx
+++ b/frontend/src/pages/ReleaseCreate.tsx
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import type {
   CreateReleaseInput,
@@ -184,7 +185,9 @@ const ReleaseWrapper = ({ getReleaseOptionsQuery }: ReleaseWrapperProps) => {
         }
       />
       <Page.Main>
-        <Release releaseOptions={releaseOptions} />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <Release releaseOptions={releaseOptions} />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { Repositories_getRepositories_Query } from "@/api/__generated__/Repositories_getRepositories_Query.graphql";
 import { Repositories_PaginationQuery } from "@/api/__generated__/Repositories_PaginationQuery.graphql";
@@ -148,15 +149,17 @@ const RepositoriesContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <RepositoriesLayoutContainer
-          repositoriesData={repositoriesData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <RepositoriesLayoutContainer
+            repositoriesData={repositoriesData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Repository.tsx
+++ b/frontend/src/pages/Repository.tsx
@@ -31,6 +31,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import { Files_PaginationQuery } from "@/api/__generated__/Files_PaginationQuery.graphql";
 import { Repository_FilesFragment$key } from "@/api/__generated__/Repository_FilesFragment.graphql";
@@ -286,43 +287,46 @@ const RepositoryContent = ({ repository }: RepositoryContentProps) => {
         >
           {errorFeedback}
         </Alert>
-        <div className="mb-3">
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
           <UpdateRepositoryForm
             repositoryRef={repository}
             onSubmit={handleUpdateRepository}
             onDelete={handleShowDeleteModal}
             isLoading={isUpdatingRepository}
           />
-        </div>
-        <hr className="bg-secondary border-2 border-top border-secondary" />
-        <div className="d-flex justify-content-between align-items-end">
-          <h3 className="m-0">
-            <FormattedMessage
-              id="pages.Repository.filesLabel"
-              defaultMessage="Files"
-            />
-          </h3>
-          <Button
-            variant="secondary"
-            as={Link}
-            route={Route.filesNew}
-            params={{ repositoryId }}
-          >
-            <FormattedMessage
-              id="pages.Repository.createFileButton"
-              defaultMessage="Create File"
-            />
-          </Button>
-        </div>
-        <SearchBox
-          className="flex-grow-1 pt-2 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <FilesLayoutContainer
-          repositoryRef={repository}
-          searchText={searchText}
-        />
+        </Card>
+
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 pt-2">
+          <div className="d-flex justify-content-between align-items-end">
+            <h3 className="m-0">
+              <FormattedMessage
+                id="pages.Repository.filesLabel"
+                defaultMessage="Files"
+              />
+            </h3>
+            <Button
+              variant="secondary"
+              as={Link}
+              route={Route.filesNew}
+              params={{ repositoryId }}
+            >
+              <FormattedMessage
+                id="pages.Repository.createFileButton"
+                defaultMessage="Create File"
+              />
+            </Button>
+          </div>
+          <SearchBox
+            className="pt-2 pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <FilesLayoutContainer
+            repositoryRef={repository}
+            searchText={searchText}
+          />
+        </Card>
+
         {showDeleteModal && (
           <DeleteModal
             confirmText={repository.handle}

--- a/frontend/src/pages/RepositoryCreate.tsx
+++ b/frontend/src/pages/RepositoryCreate.tsx
@@ -22,6 +22,7 @@ import { Suspense, useCallback, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
 import { ConnectionHandler, graphql, useMutation } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { RepositoryCreate_createRepository_Mutation } from "@/api/__generated__/RepositoryCreate_createRepository_Mutation.graphql";
 
@@ -129,10 +130,12 @@ const Repository = () => {
       >
         {errorFeedback}
       </Alert>
-      <CreateRepositoryForm
-        onSubmit={handleCreateRepository}
-        isLoading={isCreatingRepository}
-      />
+      <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+        <CreateRepositoryForm
+          onSubmit={handleCreateRepository}
+          isLoading={isCreatingRepository}
+        />
+      </Card>
     </>
   );
 };

--- a/frontend/src/pages/SystemModel.tsx
+++ b/frontend/src/pages/SystemModel.tsx
@@ -28,6 +28,7 @@ import {
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
 import { FormattedMessage } from "react-intl";
+import { Card } from "react-bootstrap";
 
 import type {
   SystemModel_getSystemModel_Query,
@@ -229,13 +230,15 @@ const SystemModelContent = ({
         >
           {errorFeedback}
         </Alert>
-        <UpdateSystemModelForm
-          systemModelRef={systemModel}
-          optionsRef={queryRef}
-          onSubmit={handleUpdateSystemModel}
-          onDelete={handleShowDeleteModal}
-          isLoading={isUpdatingSystemModel}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ptb-2">
+          <UpdateSystemModelForm
+            systemModelRef={systemModel}
+            optionsRef={queryRef}
+            onSubmit={handleUpdateSystemModel}
+            onDelete={handleShowDeleteModal}
+            isLoading={isUpdatingSystemModel}
+          />
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={systemModel.handle}

--- a/frontend/src/pages/SystemModelCreate.tsx
+++ b/frontend/src/pages/SystemModelCreate.tsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2021-2025 SECO Mind Srl
+ * Copyright 2021-2026 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type {
   SystemModelCreate_getOptions_Query,
@@ -255,11 +256,13 @@ const SystemModelCreatePage = () => {
               }
             />
             <Page.Main>
-              <SystemModelWrapper
-                getCreateSystemModelOptionsQuery={
-                  getCreateSystemModelOptionsQuery
-                }
-              />
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
+                <SystemModelWrapper
+                  getCreateSystemModelOptionsQuery={
+                    getCreateSystemModelOptionsQuery
+                  }
+                />
+              </Card>
             </Page.Main>
           </Page>
         )}

--- a/frontend/src/pages/SystemModels.tsx
+++ b/frontend/src/pages/SystemModels.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { SystemModels_getSystemModels_Query } from "@/api/__generated__/SystemModels_getSystemModels_Query.graphql";
 import { SystemModels_PaginationQuery } from "@/api/__generated__/SystemModels_PaginationQuery.graphql";
@@ -166,23 +167,25 @@ const SystemModelsContent = ({
       </Page.Header>
       <Page.Main>
         {systemModelsData.systemModels?.count === 0 ? (
-          <Result.EmptyList
-            title={
+          <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+            <Result.EmptyList
+              title={
+                <FormattedMessage
+                  id="pages.SystemModels.noSystemModels.title"
+                  defaultMessage="This space is empty"
+                />
+              }
+            >
               <FormattedMessage
-                id="pages.SystemModels.noSystemModels.title"
-                defaultMessage="This space is empty"
+                id="pages.SystemModels.noSystemModels.message"
+                defaultMessage="You haven't created any system model yet."
               />
-            }
-          >
-            <FormattedMessage
-              id="pages.SystemModels.noSystemModels.message"
-              defaultMessage="You haven't created any system model yet."
-            />
-          </Result.EmptyList>
+            </Result.EmptyList>
+          </Card>
         ) : (
-          <>
+          <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4 ">
             <SearchBox
-              className="flex-grow-1 pb-2"
+              className="pb-2"
               value={searchText || ""}
               onChange={setSearchText}
             />
@@ -190,7 +193,7 @@ const SystemModelsContent = ({
               systemModelsData={systemModelsData}
               searchText={searchText}
             />
-          </>
+          </Card>
         )}
       </Page.Main>
     </Page>

--- a/frontend/src/pages/UpdateCampaign.tsx
+++ b/frontend/src/pages/UpdateCampaign.tsx
@@ -32,6 +32,7 @@ import {
   useSubscription,
 } from "react-relay/hooks";
 import { useParams } from "react-router-dom";
+import { Card } from "react-bootstrap";
 
 import type {
   UpdateCampaign_getCampaign_Query,
@@ -384,16 +385,19 @@ const UpdateCampaignContent = ({
             </div>
           )}
         </Alert>
-        <Row>
-          <Col lg={9}>
-            <UpdateCampaignForm campaignRef={campaign} />
-          </Col>
-          <Col lg={3}>
-            <CampaignStatsChart campaignRef={campaign} />
-          </Col>
-        </Row>
-        <hr className="bg-secondary border-2 border-top border-secondary" />
-        <UpdateTargetsTabs campaignRef={campaign} />
+        <Card className="h-100 border-0 p-3 shadow-sm mb-3">
+          <Row>
+            <Col lg={9}>
+              <UpdateCampaignForm campaignRef={campaign} />
+            </Col>
+            <Col lg={3}>
+              <CampaignStatsChart campaignRef={campaign} />
+            </Col>
+          </Row>
+        </Card>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <UpdateTargetsTabs campaignRef={campaign} />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/UpdateCampaignCreate.tsx
+++ b/frontend/src/pages/UpdateCampaignCreate.tsx
@@ -29,6 +29,7 @@ import {
   useQueryLoader,
 } from "react-relay/hooks";
 import type { PreloadedQuery } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type {
   UpdateCampaignCreate_getOptions_Query,
@@ -282,9 +283,11 @@ const UpdateCampaignCreatePage = () => {
               }
             />
             <Page.Main>
-              <UpdateCampaignWrapper
-                getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
-              />
+              <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+                <UpdateCampaignWrapper
+                  getCreateCampaignOptionsQuery={getCreateCampaignOptionsQuery}
+                />
+              </Card>
             </Page.Main>
           </Page>
         )}

--- a/frontend/src/pages/UpdateCampaigns.tsx
+++ b/frontend/src/pages/UpdateCampaigns.tsx
@@ -30,6 +30,7 @@ import {
   useQueryLoader,
   useSubscription,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { UpdateCampaigns_getCampaigns_Query } from "@/api/__generated__/UpdateCampaigns_getCampaigns_Query.graphql";
 import { UpdateCampaigns_PaginationQuery } from "@/api/__generated__/UpdateCampaigns_PaginationQuery.graphql";
@@ -321,15 +322,17 @@ const UpdateCampaignsContent = ({
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <UpdateCampaignsLayoutContainer
-          campaignsData={campaignsData}
-          searchText={searchText}
-        />{" "}
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <UpdateCampaignsLayoutContainer
+            campaignsData={campaignsData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Volume.tsx
+++ b/frontend/src/pages/Volume.tsx
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Suspense, useCallback, useEffect, useState } from "react";
-import { Form, Stack } from "react-bootstrap";
+import { Card, Form, Stack } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -137,59 +137,62 @@ const VolumeContent = ({ volume }: VolumeContentProps) => {
         >
           {errorFeedback}
         </Alert>
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <FormRow
+            id="volumeLabel"
+            label={
+              <FormattedMessage
+                id="pages.Volume.label"
+                defaultMessage="Label"
+              />
+            }
+          >
+            <Form.Control value={volume.label ?? ""} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="volumeLabel"
-          label={
-            <FormattedMessage id="pages.Volume.label" defaultMessage="Label" />
-          }
-        >
-          <Form.Control value={volume.label ?? ""} readOnly />
-        </FormRow>
+          <FormRow
+            id="volumeDriver"
+            label={
+              <FormattedMessage
+                id="pages.Volume.driver"
+                defaultMessage="Driver"
+              />
+            }
+          >
+            <Form.Control value={volume.driver ?? ""} readOnly />
+          </FormRow>
 
-        <FormRow
-          id="volumeDriver"
-          label={
-            <FormattedMessage
-              id="pages.Volume.driver"
-              defaultMessage="Driver"
+          <FormRow
+            id="volumeOptions"
+            label={
+              <FormattedMessage
+                id="pages.Volume.options"
+                defaultMessage="Options"
+              />
+            }
+          >
+            <MonacoJsonEditor
+              value={getPrettyOptions()}
+              onChange={() => {}}
+              defaultValue={getPrettyOptions()}
+              readonly={true}
+              initialLines={1}
             />
-          }
-        >
-          <Form.Control value={volume.driver ?? ""} readOnly />
-        </FormRow>
+          </FormRow>
 
-        <FormRow
-          id="volumeOptions"
-          label={
-            <FormattedMessage
-              id="pages.Volume.options"
-              defaultMessage="Options"
-            />
-          }
-        >
-          <MonacoJsonEditor
-            value={getPrettyOptions()}
-            onChange={() => {}}
-            defaultValue={getPrettyOptions()}
-            readonly={true}
-            initialLines={1}
-          />
-        </FormRow>
-
-        <Stack
-          direction="horizontal"
-          gap={3}
-          className="justify-content-end align-items-center"
-        >
-          <Button variant="danger" onClick={handleShowDeleteModal}>
-            <FormattedMessage
-              id="pages.Volume.deleteButton"
-              defaultMessage="Delete"
-            />
-          </Button>
-        </Stack>
-
+          <Stack
+            direction="horizontal"
+            gap={3}
+            className="justify-content-end align-items-center"
+          >
+            <Button variant="danger" onClick={handleShowDeleteModal}>
+              <FormattedMessage
+                id="pages.Volume.deleteButton"
+                defaultMessage="Delete"
+              />
+            </Button>
+          </Stack>
+        </Card>
         {showDeleteModal && (
           <DeleteModal
             confirmText={volume.label}

--- a/frontend/src/pages/VolumeCreate.tsx
+++ b/frontend/src/pages/VolumeCreate.tsx
@@ -21,6 +21,7 @@
 import { ReactNode, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { graphql, useMutation } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { VolumeCreate_volumeCreate_Mutation } from "@/api/__generated__/VolumeCreate_volumeCreate_Mutation.graphql";
 
@@ -132,10 +133,12 @@ const VolumeCreatePage = () => {
         >
           {errorFeedback}
         </Alert>
-        <CreateVolumeForm
-          onSubmit={handleCreateVolume}
-          isLoading={isCreatingVolume}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <CreateVolumeForm
+            onSubmit={handleCreateVolume}
+            isLoading={isCreatingVolume}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );

--- a/frontend/src/pages/Volumes.tsx
+++ b/frontend/src/pages/Volumes.tsx
@@ -26,6 +26,7 @@ import {
   usePreloadedQuery,
   useQueryLoader,
 } from "react-relay/hooks";
+import { Card } from "react-bootstrap";
 
 import type { Volumes_getVolumes_Query } from "@/api/__generated__/Volumes_getVolumes_Query.graphql";
 import { Volumes_PaginationQuery } from "@/api/__generated__/Volumes_PaginationQuery.graphql";
@@ -139,15 +140,17 @@ const VolumesContent = ({ getVolumesQuery }: VolumesContentProps) => {
         </Button>
       </Page.Header>
       <Page.Main>
-        <SearchBox
-          className="flex-grow-1 pb-2"
-          value={searchText || ""}
-          onChange={setSearchText}
-        />
-        <VolumesLayoutContainer
-          volumesData={volumesData}
-          searchText={searchText}
-        />
+        <Card className="gap-2 border-0 shadow-sm flex-grow-1 p-4">
+          <SearchBox
+            className="pb-2"
+            value={searchText || ""}
+            onChange={setSearchText}
+          />
+          <VolumesLayoutContainer
+            volumesData={volumesData}
+            searchText={searchText}
+          />
+        </Card>
       </Page.Main>
     </Page>
   );


### PR DESCRIPTION
#### What this PR does / why we need it:
based on #1489 
- Updates frontend primary colors
- Wraps content in Cards for better visual separation and organization.
- Updates SearchBox to look consistent with the new design.
- Updates Table styles to match the new design and improve readability.
- Updates FormRow styles to align with the new design and enhance
form layout.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:
<details><summary>Details</summary>
<p>
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-19-37" src="https://github.com/user-attachments/assets/04d7d963-b1ab-417a-9b79-f1c970af83dd" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-19-56" src="https://github.com/user-attachments/assets/d21e0a10-3416-480f-8711-d3a0baf2bf41" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-20-16" src="https://github.com/user-attachments/assets/21e0ed0e-74b8-46cc-beb8-0e9488297702" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-20-26" src="https://github.com/user-attachments/assets/543e97f1-271b-43bd-a36c-517c0cad0ab6" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-20-37" src="https://github.com/user-attachments/assets/cfb54767-02a6-4444-b290-5c3df18f19ba" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-20-51" src="https://github.com/user-attachments/assets/5a928799-1406-460c-bc73-61e62cddd166" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-20-58" src="https://github.com/user-attachments/assets/e82db9b1-a190-4cb7-8917-22a58ff4ce79" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-21-06" src="https://github.com/user-attachments/assets/cf146680-e3dc-4aa6-a48a-5fe617693f46" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-21-14" src="https://github.com/user-attachments/assets/22e4534c-9508-402f-8daa-faa601ce5d53" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-21-29" src="https://github.com/user-attachments/assets/7473b9f4-b78f-43a7-aa97-7531c644d3b0" />
<img width="2564" height="1347" alt="Screenshot from 2026-06-09 15-21-44" src="https://github.com/user-attachments/assets/794d5ceb-dd8d-4c2a-920b-b97c92bee65b" />


</p>
</details> 
<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
