### PR TITLE
fix(backend): do not remove containers on release deletion

### DIFF
--- a/backend/lib/edgehog/containers/release/release.ex
+++ b/backend/lib/edgehog/containers/release/release.ex
@@ -25,7 +25,7 @@ defmodule Edgehog.Containers.Release do
     extensions: [AshGraphql.Resource]
 
   alias Edgehog.Containers.Deployment
-  alias Edgehog.Containers.Release.Changes
+  alias Edgehog.Containers.Release
   alias Edgehog.Validations
 
   graphql do
@@ -72,7 +72,7 @@ defmodule Edgehog.Containers.Release do
       primary? true
       require_atomic? false
 
-      change Changes.CheckDeployments
+      validate Release.Validations.CheckDeployments
     end
   end
 

--- a/backend/lib/edgehog/containers/release/release.ex
+++ b/backend/lib/edgehog/containers/release/release.ex
@@ -73,7 +73,6 @@ defmodule Edgehog.Containers.Release do
       require_atomic? false
 
       change Changes.CheckDeployments
-      change {Edgehog.Containers.Changes.MaybeDestroyChildren, children: [:containers]}
     end
   end
 

--- a/backend/lib/edgehog/containers/release/validations/check_deployments.ex
+++ b/backend/lib/edgehog/containers/release/validations/check_deployments.ex
@@ -18,29 +18,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule Edgehog.Containers.Release.Changes.CheckDeployments do
+defmodule Edgehog.Containers.Release.Validations.CheckDeployments do
   @moduledoc false
 
-  use Ash.Resource.Change
+  use Ash.Resource.Validation
 
-  alias Edgehog.Containers
+  require Ash.Query
 
-  @impl Ash.Resource.Change
-  def change(changeset, _opts, context) do
-    release = changeset.data
-    %{tenant: tenant} = context
+  @impl Ash.Resource.Validation
+  def validate(changeset, _opts, %{tenant: tenant}) do
+    id = Ash.Changeset.get_data(changeset, :id)
+    version = Ash.Changeset.get_data(changeset, :version)
 
-    case Containers.deployments_with_release(release.id, tenant: tenant) do
-      {:ok, []} ->
-        changeset
+    deployed? =
+      Edgehog.Containers.Deployment
+      |> Ash.Query.filter(release_id: id)
+      |> Ash.exists?(tenant: tenant)
 
-      {:ok, _deployments} ->
-        Ash.Changeset.add_error(changeset,
-          message: "Cannot delete release with active deployments"
-        )
-
-      {:error, error} ->
-        Ash.Changeset.add_error(changeset, error)
-    end
+    if deployed?,
+      do: {:error, message: "Release with version #{version} has active deployments."},
+      else: :ok
   end
 end

--- a/backend/test/edgehog_web/schema/mutation/delete_release_test.exs
+++ b/backend/test/edgehog_web/schema/mutation/delete_release_test.exs
@@ -23,7 +23,6 @@ defmodule EdgehogWeb.Schema.Mutation.DeleteReleaseTest do
 
   use EdgehogWeb.GraphqlCase, async: true
 
-  import Ash.Expr
   import Edgehog.ContainersFixtures
   import Edgehog.DevicesFixtures
 
@@ -73,50 +72,6 @@ defmodule EdgehogWeb.Schema.Mutation.DeleteReleaseTest do
 
       # Verify release still exists and wasn't deleted
       assert {:ok, _release} = Ash.get(Release, release.id, tenant: tenant)
-    end
-
-    test "cleans up dangling containers and images after release deletion", %{tenant: tenant} do
-      application = application_fixture(tenant: tenant)
-      release = release_fixture(application_id: application.id, tenant: tenant, containers: 2)
-
-      release_id = AshGraphql.Resource.encode_relay_id(release)
-
-      # Get the containers to track them
-      {:ok, release_with_containers} = Ash.load(release, :containers)
-      containers = release_with_containers.containers
-      container_ids = Enum.map(containers, & &1.id)
-      image_ids = Enum.map(containers, & &1.image_id)
-
-      # Delete the release
-      deleted_release =
-        [tenant: tenant, id: release_id]
-        |> delete_release()
-        |> extract_result!()
-
-      assert deleted_release["id"] == release_id
-
-      # Verify containers are cleaned up
-      for container_id <- container_ids do
-        assert {:error, %Invalid{}} =
-                 Ash.get(Container, container_id, tenant: tenant)
-      end
-
-      # Verify images are cleaned up
-      for image_id <- image_ids do
-        assert {:error, %Invalid{}} =
-                 Ash.get(Image, image_id, tenant: tenant)
-      end
-
-      # Verify containers are no longer associated with the deleted release
-      for container_id <- container_ids do
-        release_containers =
-          ReleaseContainers
-          |> Ash.Query.filter(expr(container_id == ^container_id))
-          |> Ash.read!(tenant: tenant)
-
-        # Should have no release associations now
-        assert Enum.empty?(release_containers)
-      end
     end
 
     test "does not delete containers referenced by other releases", %{tenant: tenant} do


### PR DESCRIPTION
#### What this PR does / why we need it:

When container management was not exposed to the user, we had to manually change what to remove. Now that users are allowed to see containers, deleting a release should not remove registered containers anymore.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
