### PR TITLE
fix: deployments state not updating

### DIFF
--- a/backend/lib/edgehog/containers/deployment/changes/log_started.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/log_started.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.LogStarted do
+  @moduledoc """
+  Logs a started container status.
+  """
+
+  use Ash.Resource.Change
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    context = Ash.Changeset.get_data(changeset, :context)
+    state = Ash.Changeset.get_data(changeset, :state)
+
+    metadata = [
+      resource: Edgehog.Containers.Deployment,
+      action: :mark_as_started
+    ]
+
+    case {context, state} do
+      {nil, :sent} -> Logger.info("Deployment successfully provisioned.", metadata)
+      {:start_message_sent, _} -> Logger.info("Deployment successfully started.", metadata)
+      _ -> :ok
+    end
+
+    changeset
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/changes/log_stopped.ex
+++ b/backend/lib/edgehog/containers/deployment/changes/log_stopped.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Deployment.Changes.LogStopped do
+  @moduledoc """
+  Logs a stopped container status.
+  """
+
+  use Ash.Resource.Change
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    context = Ash.Changeset.get_data(changeset, :context)
+    state = Ash.Changeset.get_data(changeset, :state)
+
+    metadata = [
+      resource: Edgehog.Containers.Deployment,
+      action: :mark_as_stopped
+    ]
+
+    case {context, state} do
+      {nil, :sent} -> Logger.info("Deployment successfully provisioned.", metadata)
+      {:stop_message_sent, _} -> Logger.info("Deployment successfully stopped.", metadata)
+      {:upgrade_message_sent, _} -> Logger.info("Deployment successfully upgraded.", metadata)
+      _ -> :ok
+    end
+
+    changeset
+  end
+end

--- a/backend/lib/edgehog/containers/deployment/deployment.ex
+++ b/backend/lib/edgehog/containers/deployment/deployment.ex
@@ -236,38 +236,16 @@ defmodule Edgehog.Containers.Deployment do
       change set_attribute(:state, :started)
       change set_attribute(:context, nil)
 
-      change {Edgehog.Changes.Log, message: "Deployment started successfully."}
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully provisioned."} do
-        where [data_one_of(:state, [:pending, :sent])]
-      end
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully started."} do
-        where [data_one_of(:context, [:start_message_sent])]
-      end
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully upgraded."} do
-        where [data_one_of(:context, [:upgrade_message_sent])]
-      end
+      change Changes.LogStarted
+      require_atomic? false
     end
 
     update :mark_as_stopped do
       change set_attribute(:state, :stopped)
       change set_attribute(:context, nil)
 
-      change {Edgehog.Changes.Log, message: "Deployment stopped successfully."}
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully provisioned."} do
-        where [data_one_of(:state, [:pending, :sent])]
-      end
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully stopped."} do
-        where [data_one_of(:context, [:stop_message_sent])]
-      end
-
-      change {Edgehog.Changes.Log, message: "Deployment successfully upgraded."} do
-        where [data_one_of(:context, [:upgrade_message_sent])]
-      end
+      change Changes.LogStopped
+      require_atomic? false
     end
 
     update :mark_as_timed_out do

--- a/backend/lib/edgehog/triggers/incoming_data/handlers/available_deployments.ex
+++ b/backend/lib/edgehog/triggers/incoming_data/handlers/available_deployments.ex
@@ -44,13 +44,15 @@ defmodule Edgehog.Triggers.IncomingData.Handlers.AvailableDeployments do
   end
 
   defp change_state("Started", %Deployment{} = deployment, tenant) do
-    Containers.mark_deployment_as_started(deployment, tenant: tenant)
-    Containers.deployment_update_resources_state(deployment, tenant: tenant)
+    with {:ok, deployment} <- Containers.mark_deployment_as_started(deployment, tenant: tenant) do
+      Containers.deployment_update_resources_state(deployment, tenant: tenant)
+    end
   end
 
   defp change_state("Stopped", %Deployment{} = deployment, tenant) do
-    Containers.mark_deployment_as_stopped(deployment, tenant: tenant)
-    Containers.deployment_update_resources_state(deployment, tenant: tenant)
+    with {:ok, deployment} <- Containers.mark_deployment_as_stopped(deployment, tenant: tenant) do
+      Containers.deployment_update_resources_state(deployment, tenant: tenant)
+    end
   end
 
   defp change_state(nil, %Deployment{} = deployment, tenant) do


### PR DESCRIPTION
#### What this PR does / why we need it:

When a new trigger from the device was recived we did not handle triggers
accordingly, overwriting a first mark of the deployment with an update of an old
instance of it.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
When a new trigger from the device was recived we did not handle triggers
accordingly, overwriting a first mark of the deployment with an update of an old
instance of it.