### PR TITLE
fix: allow max retries retries

### DIFF
--- a/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
@@ -215,9 +215,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     retries = Map.fetch!(state, :retries)
     max_retries = Application.get_env(:edgehog, :max_device_mapping_deployment_retries, 100)
 
-    if retries > max_retries do
-      {:stop, {:shutdown, :max_retries}, state}
-    else
+    if retries < max_retries do
       timeout = timeout(state)
       timeout_seconds = round(timeout / 1000)
 
@@ -229,6 +227,8 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
       """)
 
       {:noreply, increase_retries(state), timeout}
+    else
+      {:stop, {:shutdown, :max_retries}, state}
     end
   end
 

--- a/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
@@ -178,7 +178,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
 
     Phoenix.PubSub.broadcast(
       Edgehog.PubSub,
-      "ready:device_mapping_deployment:#{id}",
+      "ready:device_mapping_deployments:#{id}",
       {:ready, device_mapping_deployment}
     )
 
@@ -204,7 +204,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     """)
 
     # Unsubscribe from events, we're terminating
-    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_mapping_deployment:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_mapping_deployments:#{id}")
   end
 
   defp retry_or_stop(error, state) do

--- a/backend/lib/edgehog/containers/image/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/image/deployment/provisioner.ex
@@ -217,9 +217,7 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
     retries = Map.fetch!(state, :retries)
     max_retries = Application.get_env(:edgehog, :max_image_deployment_retries, 100)
 
-    if retries > max_retries do
-      {:stop, {:shutdown, :max_retries}, state}
-    else
+    if retries < max_retries do
       timeout = timeout(state)
       timeout_seconds = round(timeout / 1000)
 
@@ -231,6 +229,8 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
       """)
 
       {:noreply, increase_retries(state), timeout}
+    else
+      {:stop, {:shutdown, :max_retries}, state}
     end
   end
 

--- a/backend/lib/edgehog/containers/image/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/image/deployment/provisioner.ex
@@ -181,7 +181,7 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
 
     Phoenix.PubSub.broadcast(
       Edgehog.PubSub,
-      "ready:image_deployment:#{id}",
+      "ready:image_deployments:#{id}",
       {:ready, image_deployment}
     )
 
@@ -206,7 +206,7 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
     """)
 
     # Unsubscribe from events, we're terminating
-    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "image_deployment:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "image_deployments:#{id}")
   end
 
   defp retry_or_stop(error, state) do

--- a/backend/lib/edgehog/containers/network/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/network/deployment/provisioner.ex
@@ -178,7 +178,7 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
 
     Phoenix.PubSub.broadcast(
       Edgehog.PubSub,
-      "ready:network_deployment:#{id}",
+      "ready:network_deployments:#{id}",
       {:ready, network_deployment}
     )
 
@@ -204,7 +204,7 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
     """)
 
     # Unsubscribe from events, we're terminating
-    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "network_deployment:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "network_deployments:#{id}")
   end
 
   defp retry_or_stop(error, state) do

--- a/backend/lib/edgehog/containers/network/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/network/deployment/provisioner.ex
@@ -215,9 +215,7 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
     retries = Map.fetch!(state, :retries)
     max_retries = Application.get_env(:edgehog, :max_network_deployment_retries, 100)
 
-    if retries > max_retries do
-      {:stop, {:shutdown, :max_retries}, state}
-    else
+    if retries < max_retries do
       timeout = timeout(state)
       timeout_seconds = round(timeout / 1000)
 
@@ -229,6 +227,8 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
       """)
 
       {:noreply, increase_retries(state), timeout}
+    else
+      {:stop, {:shutdown, :max_retries}, state}
     end
   end
 

--- a/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
+++ b/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
@@ -205,7 +205,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.subscribe(
         Edgehog.PubSub,
-        "ready:device_mapping_deployment:#{device_mapping_deployment.id}"
+        "ready:device_mapping_deployments:#{device_mapping_deployment.id}"
       )
 
       Provisioner.start(provisioner)
@@ -217,7 +217,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(
         Edgehog.PubSub,
-        "ready:device_mapping_deployment:#{device_mapping_deployment.id}"
+        "ready:device_mapping_deployments:#{device_mapping_deployment.id}"
       )
     end
   end

--- a/backend/test/edgehog/containers/image/provisioner_test.exs
+++ b/backend/test/edgehog/containers/image/provisioner_test.exs
@@ -181,7 +181,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Phoenix.PubSub.subscribe(Edgehog.PubSub, "ready:image_deployment:#{image_deployment.id}")
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, "ready:image_deployments:#{image_deployment.id}")
 
       Provisioner.start(provisioner)
 
@@ -190,7 +190,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
       assert new_image_deployment.id == image_deployment.id
       assert new_image_deployment.is_ready
 
-      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "ready:image_deployment:#{image_deployment.id}")
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "ready:image_deployments:#{image_deployment.id}")
     end
   end
 end

--- a/backend/test/edgehog/containers/network/provisioner_test.exs
+++ b/backend/test/edgehog/containers/network/provisioner_test.exs
@@ -211,7 +211,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.subscribe(
         Edgehog.PubSub,
-        "ready:network_deployment:#{network_deployment.id}"
+        "ready:network_deployments:#{network_deployment.id}"
       )
 
       Provisioner.start(provisioner)
@@ -223,7 +223,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(
         Edgehog.PubSub,
-        "ready:network_deployment:#{network_deployment.id}"
+        "ready:network_deployments:#{network_deployment.id}"
       )
     end
   end


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds  couple of fixes to the refactor:
 
- switches statement to check for max retries, actually making `max_retries` as expected
- standardizes pubsub topics, using
  + `<resource>_deployments:#{id}` for general events about a deployment
  + `ready:<resource>_deployments:#{id}` for readiness events

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md