### PR TITLE
Require device mapping and request interfaces

### DIFF
--- a/backend/lib/edgehog/capabilities.ex
+++ b/backend/lib/edgehog/capabilities.ex
@@ -93,6 +93,16 @@ defmodule Edgehog.Capabilities do
         minor: 1
       },
       %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableDeviceMappings",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.AvailableDeviceRequests",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
         name: "io.edgehog.devicemanager.apps.CreateContainerRequest",
         major: 0,
         minor: 1
@@ -114,6 +124,16 @@ defmodule Edgehog.Capabilities do
       },
       %Astarte.InterfaceID{
         name: "io.edgehog.devicemanager.apps.CreateVolumeRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateDeviceMappingRequest",
+        major: 0,
+        minor: 1
+      },
+      %Astarte.InterfaceID{
+        name: "io.edgehog.devicemanager.apps.CreateDeviceRequest",
         major: 0,
         minor: 1
       },

--- a/backend/test/edgehog/capabilities_test.exs
+++ b/backend/test/edgehog/capabilities_test.exs
@@ -110,11 +110,27 @@ defmodule Edgehog.CapabilitiesTest do
         "io.edgehog.devicemanager.apps.DeploymentUpdate" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.apps.AvailableNetworks" => %InterfaceVersion{major: 0, minor: 1},
         "io.edgehog.devicemanager.apps.AvailableVolumes" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableDeviceMappings" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableDeviceRequests" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
         "io.edgehog.devicemanager.apps.CreateNetworkRequest" => %InterfaceVersion{
           major: 0,
           minor: 1
         },
         "io.edgehog.devicemanager.apps.CreateVolumeRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeviceRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeviceMappingRequest" => %InterfaceVersion{
           major: 0,
           minor: 1
         }
@@ -354,6 +370,108 @@ defmodule Edgehog.CapabilitiesTest do
       refute :file_transfer_stream in device_capabilities
       refute :file_transfer_storage in device_capabilities
       refute :file_transfer_read in device_capabilities
+    end
+
+    test "does not return container management capability when device request interfaces are missing" do
+      device_introspection = %{
+        "io.edgehog.devicemanager.apps.AvailableContainers" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableDeployments" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableImages" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentEvent" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.CreateContainerRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeploymentRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateImageRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.DeploymentCommand" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentUpdate" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableNetworks" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableVolumes" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableDeviceMappings" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateNetworkRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateVolumeRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeviceMappingRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        }
+      }
+
+      device_capabilities = Capabilities.from_introspection(device_introspection)
+
+      refute :container_management in device_capabilities
+    end
+
+    test "does not return container management capability when device mapping interfaces are missing" do
+      device_introspection = %{
+        "io.edgehog.devicemanager.apps.AvailableContainers" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableDeployments" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.AvailableImages" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentEvent" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.CreateContainerRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeploymentRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateImageRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.DeploymentCommand" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.DeploymentUpdate" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableNetworks" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableVolumes" => %InterfaceVersion{major: 0, minor: 1},
+        "io.edgehog.devicemanager.apps.AvailableDeviceRequests" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateNetworkRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateVolumeRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        },
+        "io.edgehog.devicemanager.apps.CreateDeviceRequest" => %InterfaceVersion{
+          major: 0,
+          minor: 1
+        }
+      }
+
+      device_capabilities = Capabilities.from_introspection(device_introspection)
+
+      refute :container_management in device_capabilities
     end
   end
 end


### PR DESCRIPTION
#### What this PR does / why we need it:

Devices up to now could have the container management feature without having device mappings and requests necessary interfaces. This created a distrust in the user that tried to use a feature the device was not compatible with.

Edgehog will now block devices that are not compatible with the feature (i.e., devices without the necessary interfaces).

Device mappings interfaces
[io.edgehog.devicemanager.apps.AvailableDeviceMappings.json](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/blob/main/io.edgehog.devicemanager.apps.AvailableDeviceMappings.json)
[io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/blob/main/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json)

Device request interfaces
[io.edgehog.devicemanager.apps.AvailableDeviceRequests.json](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/blob/main/io.edgehog.devicemanager.apps.AvailableDeviceRequests.json)
[io.edgehog.devicemanager.apps.CreateDeviceRequest.json](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/blob/main/io.edgehog.devicemanager.apps.CreateDeviceRequest.json)

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
