### PR TITLE
chore(backend): stop deployment provisioners on device offline

### DIFF
--- a/backend/lib/edgehog/containers/container/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/container/deployment/provisioner.ex
@@ -22,7 +22,7 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
   @moduledoc """
   A container deployment provisioner.
 
-  Each and every time an container should be deployed, it can be done through this
+  Each and every time a container should be deployed, it can be done through this
   provisioner. The provisioner sends the appropriate messages to the device and
   emits a `ready:container_deployments:id` event whenever container is present in the
   device.
@@ -64,7 +64,7 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
   #### API
 
   @doc """
-  Starts the provisioner of an container deployment.
+  Starts the provisioner of a container deployment.
 
   Equivalent to starting the provisioner through `start_link/1` with opts
   ```
@@ -86,7 +86,7 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
   end
 
   @doc """
-  Starts a provisioner for an container deployment.
+  Starts a provisioner for a container deployment.
 
   A provision for this resource follows the following flow:
 
@@ -105,9 +105,23 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    container_deployment = Keyword.fetch!(args, :container_deployment)
+    container_deployment = args |> Keyword.fetch!(:container_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :container_deployment, container_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(container_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for a container deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    container_deployment = args |> Keyword.fetch!(:container_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :container_deployment, container_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(container_deployment))
   end
 
   @doc """
@@ -123,15 +137,15 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -146,31 +160,45 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      container_deployment
+
     state = %{
       container_deployment: container_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = container_deployment
-
     Logger.info("Subscribing to events on container deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "container_deployments:#{id}")
+
+    Logger.info(
+      "Subscribing to status events of device #{device_id} for container deployment #{id}"
+    )
+
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -178,11 +206,12 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
         :check_deployment_state,
         %{container_deployment: container_deployment} = state
       ) do
-    container_deployment =
-      Ash.load!(container_deployment, :is_ready, tenant: container_deployment.tenant_id)
-
-    if container_deployment.is_ready do
+    # Here we have to compute readiness of the single `container deployment`
+    # resource. We cannot delegate this to the `is_ready` calculation as it
+    # computes global readiness for the public.
+    if ready?(container_deployment) do
       new_state = Map.put(state, :container_deployment, container_deployment)
+
       {:stop, :normal, new_state}
     else
       {:noreply, state, {:continue, :send}}
@@ -198,9 +227,7 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
 
     timeout = Core.timeout(state)
 
-    # Here we have to compute readiness of the single `container deployment`
-    # resource. We cannot delegate this to the `is_ready` calculation as it
-    # computes global readiness for the public.
+    # Again, we cannot use the `is_ready` calculation
     if ready?(container_deployment),
       do: {:stop, :normal, state},
       else: {:noreply, state, timeout}
@@ -239,20 +266,30 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
   # :data section. This container deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: container_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = container_deployment}},
+        state
+      ) do
     new_state = Map.put(state, :container_deployment, container_deployment)
 
     # check readiness, maybe terminate
     {:noreply, new_state, {:continue, :maybe_ready}}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
-    %{container_deployment: container_deployment} = state
-
-    %{id: id} = container_deployment
+    %{
+      container_deployment: %{id: id, device_id: device_id} = container_deployment
+    } = state
 
     topic = topic(container_deployment)
 
@@ -260,6 +297,38 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
 
     # Unsubscribe from events, we're terminating
     Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "container_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      container_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for container deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "container_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      container_deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for container deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -311,6 +380,16 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/container/deployment/provisioner/core.ex
+++ b/backend/lib/edgehog/containers/container/deployment/provisioner/core.ex
@@ -54,8 +54,8 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner.Core do
   Tries to reconcile the container deployment with the property set by the device.
 
   The device publishes the available containers, this function reads such property
-  and either founds a state, and sets the container deployment to that state or does
-  not found a valid state, therefore the device does not have such container
+  and either finds a state, and sets the container deployment to that state or does
+  not find a valid state, therefore the device does not have such container
   deployed, and the function returns :not_found
 
   Alternatively, if something went wrong while updating the container, an 

--- a/backend/lib/edgehog/containers/container/device_request/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/container/device_request/deployment/provisioner.ex
@@ -22,7 +22,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
   @moduledoc """
   A device request deployment provisioner.
 
-  Each and every time a devicemapping should be deployed, it can be done through this
+  Each and every time a device request should be deployed, it can be done through this
   provisioner. The provisioner sends the appropriate messages to the device and
   emits a `ready:device_request_deployments:id` event whenever device request is present in the
   device.
@@ -104,9 +104,27 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    device_request_deployment = Keyword.fetch!(args, :device_request_deployment)
+    device_request_deployment =
+      args |> Keyword.fetch!(:device_request_deployment) |> Ash.load!(:device)
+
+    args = Keyword.put(args, :device_request_deployment, device_request_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(device_request_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for a device request deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    device_request_deployment =
+      args |> Keyword.fetch!(:device_request_deployment) |> Ash.load!(:device)
+
+    args = Keyword.put(args, :device_request_deployment, device_request_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(device_request_deployment))
   end
 
   def name(%Deployment{id: id}) do
@@ -114,15 +132,15 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -137,31 +155,45 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      device_request_deployment
+
     state = %{
       device_request_deployment: device_request_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = device_request_deployment
-
     Logger.info("Subscribing to events on device request deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "device_request_deployments:#{id}")
+
+    Logger.info(
+      "Subscribing to status events of device #{device_id} for device request deployment #{id}"
+    )
+
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -216,7 +248,10 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
   # :data section. This device request deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: device_request_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = device_request_deployment}},
+        state
+      ) do
     # We can publish on readiness topic.
     id = device_request_deployment.id
 
@@ -233,21 +268,60 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
     {:stop, :normal, new_state}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
     %{
-      device_request_deployment: %{id: id},
+      device_request_deployment: %{id: id, device_id: device_id},
       retries: retries
     } = state
 
     Logger.info("""
-    device request deployment #{id} successfully provisioned after #{retries} retries.
+    Device Request deployment #{id} successfully provisioned after #{retries} retries.
     """)
 
     # Unsubscribe from events, we're terminating
-    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device request_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_request_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      device_request_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for device request deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_request_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      device_request_deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for device request deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -299,6 +373,16 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/container/device_request/deployment/provisioner/core.ex
+++ b/backend/lib/edgehog/containers/container/device_request/deployment/provisioner/core.ex
@@ -60,7 +60,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner.Core do
 
   The device publishes the available device requests, this function reads such property
   and either finds a state, and sets the device request deployment to that state or does
-  not found a valid state, therefore the device does not have such device request
+  not find a valid state, therefore the device does not have such device request
   deployed, and the function returns :not_found
 
   Alternatively, if something went wrong while updating the device request, an 

--- a/backend/lib/edgehog/containers/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/deployment/provisioner.ex
@@ -72,9 +72,23 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
   end
 
   def start_link(args) do
-    deployment = Keyword.fetch!(args, :deployment)
+    deployment = args |> Keyword.fetch!(:deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :deployment, deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(deployment))
+  end
+
+  @doc """
+  Starts a provisioner for an application deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    deployment = args |> Keyword.fetch!(:deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :deployment, deployment)
+
+    GenServer.start(__MODULE__, args, name: name(deployment))
   end
 
   @doc """
@@ -92,15 +106,15 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -114,30 +128,44 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      deployment
+
     state = %{
       deployment: deployment,
       tenant: tenant,
+      device_online?: device_online?,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = deployment
-
     Logger.info("Subscribing to events on deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "deployments:#{id}")
+
+    Logger.info(
+      "Subscribing to status events of device #{device_id} for (application) deployment #{id}"
+    )
+
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -145,10 +173,10 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
         :check_deployment_state,
         %{deployment: deployment} = state
       ) do
-    deployment =
-      Ash.load!(deployment, :is_ready, tenant: deployment.tenant_id)
-
-    if deployment.is_ready do
+    # Here we have to compute readiness of the single `deployment` resource. We
+    # cannot delegate this to the `is_ready` calculation as it computes global
+    # readiness for the public.
+    if ready?(deployment) do
       new_state = Map.put(state, :deployment, deployment)
       {:stop, :normal, new_state}
     else
@@ -165,9 +193,7 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
 
     timeout = Core.timeout(state)
 
-    # Here we have to compute readiness of the single `deployment` resource. We
-    # cannot delegate this to the `is_ready` calculation as it computes global
-    # readiness for the public.
+    # Again, we cannot use the `is_ready` calculation
     if ready?(deployment),
       do: {:stop, :normal, state},
       else: {:noreply, state, timeout}
@@ -206,20 +232,27 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
   # :data section. This deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: deployment}}, state) do
+  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = deployment}}, state) do
     new_state = Map.put(state, :deployment, deployment)
 
     # check readiness, maybe terminate
     {:noreply, new_state, {:continue, :maybe_ready}}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
-    %{deployment: deployment} = state
-
-    %{id: id} = deployment
+    %{
+      deployment: %{id: id, device_id: device_id} = deployment
+    } = state
 
     topic = topic(deployment)
 
@@ -227,6 +260,38 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
 
     # Unsubscribe from events, we're terminating
     Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for (application) deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for (application) deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -277,6 +342,16 @@ defmodule Edgehog.Containers.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/device_mapping/deployment/provisioner.ex
@@ -104,9 +104,27 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    device_mapping_deployment = Keyword.fetch!(args, :device_mapping_deployment)
+    device_mapping_deployment =
+      args |> Keyword.fetch!(:device_mapping_deployment) |> Ash.load!(:device)
+
+    args = Keyword.put(args, :device_mapping_deployment, device_mapping_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(device_mapping_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for a device mapping deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    device_mapping_deployment =
+      args |> Keyword.fetch!(:device_mapping_deployment) |> Ash.load!(:device)
+
+    args = Keyword.put(args, :device_mapping_deployment, device_mapping_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(device_mapping_deployment))
   end
 
   def name(%Deployment{id: id}) do
@@ -114,15 +132,15 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -137,31 +155,45 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      device_mapping_deployment
+
     state = %{
       device_mapping_deployment: device_mapping_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = device_mapping_deployment
-
     Logger.info("Subscribing to events on device mapping deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "device_mapping_deployments:#{id}")
+
+    Logger.info(
+      "Subscribing to status events of device #{device_id} for device mapping deployment #{id}"
+    )
+
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -216,7 +248,10 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
   # :data section. This device mapping deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: device_mapping_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = device_mapping_deployment}},
+        state
+      ) do
     # We can publish on readiness topic.
     id = device_mapping_deployment.id
 
@@ -233,12 +268,19 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     {:stop, :normal, new_state}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
     %{
-      device_mapping_deployment: %{id: id},
+      device_mapping_deployment: %{id: id, device_id: device_id},
       retries: retries
     } = state
 
@@ -247,7 +289,39 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     """)
 
     # Unsubscribe from events, we're terminating
-    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device mapping_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_mapping_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      device_mapping_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for device mapping deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "device_mapping_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      device_mapping_deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for device mapping deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -299,6 +373,16 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/image/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/image/deployment/provisioner.ex
@@ -69,7 +69,7 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
   @doc """
   Starts the provisioner of an image deployment.
 
-  Equivalent to starting the provisioner trough `start_link/1` with opts
+  Equivalent to starting the provisioner through `start_link/1` with opts
   ```
   [
     image_deployment: image_deployment,
@@ -101,16 +101,30 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
   - if a trigger reaches edgehog, it changes a property in the image deployment resource, emitting an event for the provsioner.
   - the provisioner understands that the image is ready, it then exits successfully.
 
-  - if the reconciler has no messages incoming after a timer defined trough the `timeout/1` function:
+  - if the reconciler has no messages incoming after a timer defined through the `timeout/1` function:
     + checks for readiness of the resource, maybe we just missed the message
     + queries astarte, maybe the trigger was missing
     + retries to send the message to the device.
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    image_deployment = Keyword.fetch!(args, :image_deployment)
+    image_deployment = args |> Keyword.fetch!(:image_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :image_deployment, image_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(image_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for an image deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    image_deployment = args |> Keyword.fetch!(:image_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :image_deployment, image_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(image_deployment))
   end
 
   def name(%Deployment{id: id}) do
@@ -118,15 +132,15 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -141,31 +155,42 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      image_deployment
+
     state = %{
       image_deployment: image_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = image_deployment
-
     Logger.info("Subscribing to events on image deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "image_deployments:#{id}")
+
+    Logger.info("Subscribing to status events of device #{device_id} for image deployment #{id}")
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -216,7 +241,10 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
   # :data section. This image deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: image_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = image_deployment}},
+        state
+      ) do
     # We can publish on readiness topic.
     id = image_deployment.id
 
@@ -233,12 +261,19 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
     {:stop, :normal, new_state}
   end
 
-  # NOTICE: we crash on messages that do not come from the notification system for the correct topic
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
+  # NOTICE: we crash on messages that do not come from the notification system for the correct topics
 
   @impl GenServer
   def terminate(:normal, state) do
     %{
-      image_deployment: %{id: id},
+      image_deployment: %{id: id, device_id: device_id},
       retries: retries
     } = state
 
@@ -248,6 +283,38 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
 
     # Unsubscribe from events, we're terminating
     Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "image_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      image_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for image deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "image_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      image_deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for image deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -299,6 +366,16 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/network/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/network/deployment/provisioner.ex
@@ -22,7 +22,7 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   @moduledoc """
   A network deployment provisioner.
 
-  Each and every time an network should be deployed, it can be done through this
+  Each and every time a network should be deployed, it can be done through this
   provisioner. The provisioner sends the appropriate messages to the device and
   emits a `ready:network_deployments:id` event whenever network is present in the
   device.
@@ -63,9 +63,9 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   #### API
 
   @doc """
-  Starts the provisioner of an network deployment.
+  Starts the provisioner of a network deployment.
 
-  Equivalent to starting the provisioner trough `start_link/1` with opts
+  Equivalent to starting the provisioner through `start_link/1` with opts
   ```
   [
     network_deployment: network_deployment,
@@ -85,7 +85,7 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   end
 
   @doc """
-  Starts a provisioner for an network deployment.
+  Starts a provisioner for a network deployment.
 
   A provision for this resource follows the following flow:
 
@@ -97,16 +97,30 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   - if a trigger reaches edgehog, it changes a property in the network deployment resource, emitting an event for the provsioner.
   - the provisioner understands that the network is ready, it then exits successfully.
 
-  - if the reconciler has no messages incoming after a timer defined trough the `timeout/1` function:
+  - if the reconciler has no messages incoming after a timer defined through the `timeout/1` function:
     + checks for readiness of the resource, maybe we just missed the message
     + queries astarte, maybe the trigger was missing
     + retries to send the message to the device.
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    network_deployment = Keyword.fetch!(args, :network_deployment)
+    network_deployment = args |> Keyword.fetch!(:network_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :network_deployment, network_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(network_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for a network deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    network_deployment = args |> Keyword.fetch!(:network_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :network_deployment, network_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(network_deployment))
   end
 
   def name(%Deployment{id: id}) do
@@ -114,15 +128,15 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -137,31 +151,45 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      network_deployment
+
     state = %{
       network_deployment: network_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = network_deployment
-
     Logger.info("Subscribing to events on network deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "network_deployments:#{id}")
+
+    Logger.info(
+      "Subscribing to status events of device #{device_id} for network deployment #{id}"
+    )
+
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -213,7 +241,10 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
   # :data section. This network deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: network_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = network_deployment}},
+        state
+      ) do
     # We can publish on readiness topic.
     id = network_deployment.id
 
@@ -230,12 +261,19 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
     {:stop, :normal, new_state}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
     %{
-      network_deployment: %{id: id},
+      network_deployment: %{id: id, device: %{id: device_id}},
       retries: retries
     } = state
 
@@ -245,6 +283,38 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
 
     # Unsubscribe from events, we're terminating
     Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "network_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      network_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for network deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "network_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      network_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for network deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -296,6 +366,16 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/containers/volume/deployment/provisioner.ex
+++ b/backend/lib/edgehog/containers/volume/deployment/provisioner.ex
@@ -22,7 +22,7 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
   @moduledoc """
   A volume deployment provisioner.
 
-  Each and every time an volume should be deployed, it can be done through this
+  Each and every time a volume should be deployed, it can be done through this
   provisioner. The provisioner sends the appropriate messages to the device and
   emits a `ready:volume_deployments:id` event whenever volume is present in the
   device.
@@ -63,7 +63,7 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
   #### API
 
   @doc """
-  Starts the provisioner of an volume deployment.
+  Starts the provisioner of a volume deployment.
 
   Equivalent to starting the provisioner trough `start_link/1` with opts
   ```
@@ -85,7 +85,7 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
   end
 
   @doc """
-  Starts a provisioner for an volume deployment.
+  Starts a provisioner for a volume deployment.
 
   A provision for this resource follows the following flow:
 
@@ -104,9 +104,23 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
     + loops with a new timeout set by the `timeout/1` function.
   """
   def start_link(args) do
-    volume_deployment = Keyword.fetch!(args, :volume_deployment)
+    volume_deployment = args |> Keyword.fetch!(:volume_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :volume_deployment, volume_deployment)
 
     GenServer.start_link(__MODULE__, args, name: name(volume_deployment))
+  end
+
+  @doc """
+  Starts a provisioner for a volume deployment, without linking it to the
+  current process.
+
+  See `start_link/1` docs for more information
+  """
+  def start(args) do
+    volume_deployment = args |> Keyword.fetch!(:volume_deployment) |> Ash.load!(:device)
+    args = Keyword.put(args, :volume_deployment, volume_deployment)
+
+    GenServer.start(__MODULE__, args, name: name(volume_deployment))
   end
 
   def name(%Deployment{id: id}) do
@@ -114,15 +128,15 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
   end
 
   # Test additional API
-  # In test environment, allow to start the process with a message, so that the
+  # In test environment, allow to run the process with a message, so that the
   # test process can attach and monitor it
   if @test do
-    def start(provisioner) do
-      GenServer.cast(provisioner, :start)
+    def run(provisioner) do
+      GenServer.cast(provisioner, :run)
     end
 
     @impl GenServer
-    def handle_cast(:start, state) do
+    def handle_cast(:run, state) do
       {:noreply, state, {:continue, :check_deployment_state}}
     end
   end
@@ -137,31 +151,42 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    %{id: id, device: %{id: device_id, online: device_online?}} =
+      volume_deployment
+
     state = %{
       volume_deployment: volume_deployment,
       deployment: deployment,
+      device_online?: device_online?,
       tenant: tenant,
       state: :init,
       mode: mode,
       retries: 0
     }
 
-    %{id: id} = volume_deployment
-
     Logger.info("Subscribing to events on volume deployment #{id}")
     Phoenix.PubSub.subscribe(Edgehog.PubSub, "volume_deployments:#{id}")
+
+    Logger.info("Subscribing to status events of device #{device_id} for volume deployment #{id}")
+    Phoenix.PubSub.subscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+
+    Logger.debug(
+      "Device #{device_id} is currently #{if device_online?, do: "online", else: "offline"}"
+    )
 
     {:ok, state, {:continue, :maybe_start}}
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :auto} = state) do
-    {:noreply, state, {:continue, :check_deployment_state}}
+    next_step = {:noreply, state, {:continue, :check_deployment_state}}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
   def handle_continue(:maybe_start, %{mode: :manual} = state) do
-    {:noreply, state}
+    next_step = {:noreply, state}
+    maybe_early_terminate(state, next_step)
   end
 
   @impl GenServer
@@ -213,7 +238,10 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
   # :data section. This volume deployment is more recent, as it comes from an
   # update in the database.
   @impl GenServer
-  def handle_info(%Phoenix.Socket.Broadcast{payload: %{data: volume_deployment}}, state) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{payload: %{data: %Deployment{} = volume_deployment}},
+        state
+      ) do
     # We can publish on readiness topic.
     id = volume_deployment.id
 
@@ -230,12 +258,19 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
     {:stop, :normal, new_state}
   end
 
+  @impl GenServer
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "devices:offline:" <> _id}, old_state) do
+    new_state = Map.put(old_state, :device_online?, false)
+
+    {:stop, {:shutdown, :device_offline}, new_state}
+  end
+
   # NOTICE: we crash on messages that do not come from the notification system for the correct topic
 
   @impl GenServer
   def terminate(:normal, state) do
     %{
-      volume_deployment: %{id: id},
+      volume_deployment: %{id: id, device_id: device_id},
       retries: retries
     } = state
 
@@ -245,6 +280,38 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
 
     # Unsubscribe from events, we're terminating
     Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "volume_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate({:shutdown, :device_offline}, state) do
+    %{
+      volume_deployment: %{id: id, device_id: device_id}
+    } = state
+
+    Logger.info("""
+    Device #{device_id} went offline. Provisioner for volume deployment #{id} terminating.
+    """)
+
+    # Unsubscribe from events, we're terminating
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "volume_deployments:#{id}")
+    Phoenix.PubSub.unsubscribe(Edgehog.PubSub, "devices:offline:#{device_id}")
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    %{
+      volume_deployment: %{id: id, device: %{id: device_id}}
+    } = state
+
+    Logger.warning(
+      """
+      Unexpectedly terminating provisioner for volume deployment #{id} on device #{device_id}.
+      Reason: #{inspect(reason)}
+      """,
+      reason: reason,
+      provisioner_state: state
+    )
   end
 
   #### Helper functions
@@ -296,6 +363,16 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner do
     )
 
     state
+  end
+
+  # Returns an early stop tuple if the device is offline, otherwise continues with
+  # the given `next_step`
+  defp maybe_early_terminate(%{device_online?: device_online?} = state, next_step) do
+    if device_online? do
+      next_step
+    else
+      {:stop, {:shutdown, :device_offline}, state}
+    end
   end
 
   # Update the state to increment the number of retries

--- a/backend/lib/edgehog/devices/device/device.ex
+++ b/backend/lib/edgehog/devices/device/device.ex
@@ -26,6 +26,9 @@ defmodule Edgehog.Devices.Device do
     domain: Edgehog.Devices,
     extensions: [
       AshGraphql.Resource
+    ],
+    notifiers: [
+      Ash.Notifier.PubSub
     ]
 
   alias Edgehog.Changes.NormalizeTagName
@@ -729,6 +732,25 @@ defmodule Edgehog.Devices.Device do
 
   identities do
     identity :unique_realm_device_id, [:device_id, :realm_id]
+  end
+
+  pub_sub do
+    module EdgehogWeb.Endpoint
+    prefix "devices"
+
+    publish_all "online_create", :create, ["online", :id], filter: &online_filter/1
+    publish "online_update", :from_device_status, ["online", :id], filter: &online_filter/1
+
+    publish_all "offline_create", :create, ["offline", :id], filter: &offline_filter/1
+    publish "offline_update", :from_device_status, ["offline", :id], filter: &offline_filter/1
+  end
+
+  defp online_filter(inp) do
+    Ash.Changeset.get_argument_or_attribute(inp.changeset, :online) == true
+  end
+
+  defp offline_filter(inp) do
+    Ash.Changeset.get_argument_or_attribute(inp.changeset, :online) == false
   end
 
   postgres do

--- a/backend/test/edgehog/containers/container/provisioner_test.exs
+++ b/backend/test/edgehog/containers/container/provisioner_test.exs
@@ -41,13 +41,28 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
       tenant = tenant_fixture()
       deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       [container_deployment] =
         deployment
         |> Ash.load!([container_deployments: [:container, :device]], tenant: tenant)
         |> Map.get(:container_deployments, [])
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           container_deployment: container_deployment,
           deployment: deployment,
@@ -98,7 +113,7 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -129,7 +144,7 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -162,9 +177,9 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
-      assert_receive {:ready, new_container_deployment}, 1000
+      assert_receive {:ready, new_container_deployment}, 2000
 
       assert new_container_deployment.id == container_deployment.id
       assert new_container_deployment.is_ready
@@ -196,7 +211,7 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_received, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_container_deployment}, 1000
@@ -242,7 +257,7 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
       ready_topic = Provisioner.topic(container_deployment)
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_container_deployment}, 3000
@@ -251,6 +266,78 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
       assert new_container_deployment.is_ready
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
+    end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateContainerRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_container_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateContainerRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_container_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
     end
   end
 
@@ -343,4 +430,6 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
   defp normalize(value), do: value
   defp normalize_memory_swap(nil), do: -2
   defp normalize_memory_swap(value), do: value
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/deployment/provisioner_test.exs
+++ b/backend/test/edgehog/containers/deployment/provisioner_test.exs
@@ -44,8 +44,23 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
         |> deployment_fixture()
         |> Ash.load!(:device, tenant: tenant)
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           deployment: deployment,
           mode: :manual
@@ -119,7 +134,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -165,7 +180,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       # 2000 as the retry might happen between 0 and 1 second
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
@@ -215,7 +230,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_deployment}, 1000
 
@@ -249,7 +264,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_stopped, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_deployment}, 1000
@@ -295,7 +310,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
       ready_topic = Provisioner.topic(deployment)
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_deployment}, 3000
@@ -305,5 +320,79 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateDeploymentRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_deployment_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateDeploymentRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_deployment_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
+++ b/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
@@ -47,6 +47,21 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
           release_opts: [containers: 1, container_params: [device_mappings: [device_mapping.id]]]
         )
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       [device_mapping_deployments] =
         deployment
         |> Ash.load!(
@@ -59,7 +74,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
       [device_mapping_deployment] = device_mapping_deployments
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           device_mapping_deployment: device_mapping_deployment,
           deployment: deployment,
@@ -122,7 +137,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -167,7 +182,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -213,7 +228,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
         "ready:device_mapping_deployments:#{device_mapping_deployment.id}"
       )
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_device_mapping_deployment}, 1000
 
@@ -250,7 +265,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_present, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_device_mapping_deployment}, 1000
@@ -296,7 +311,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
       ready_topic = "ready:device_mapping_deployments:#{device_mapping_deployment.id}"
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_device_mapping_deployment}, 1000
@@ -306,5 +321,79 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateDeviceMappingRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_device_mapping_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateDeviceMappingRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_device_mapping_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/device_request/provisioner_test.exs
+++ b/backend/test/edgehog/containers/device_request/provisioner_test.exs
@@ -46,6 +46,21 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
           release_opts: [containers: 1, container_params: [device_requests: [device_request.id]]]
         )
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       [device_request_deployments] =
         deployment
         |> Ash.load!(
@@ -62,7 +77,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
       [device_request_deployment] = device_request_deployments
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           device_request_deployment: device_request_deployment,
           deployment: deployment,
@@ -136,7 +151,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -190,7 +205,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -247,7 +262,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
         "ready:device_request_deployments:#{device_request_deployment.id}"
       )
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_device_request_deployment}, 1000
 
@@ -284,7 +299,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_present, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_device_request_deployment}, 1000
@@ -330,7 +345,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
       ready_topic = "ready:device_request_deployments:#{device_request_deployment.id}"
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_device_request_deployment}, 1000
@@ -340,5 +355,79 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateDeviceRequestRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_device_request_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateDeviceRequestRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_device_request_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/image/provisioner_test.exs
+++ b/backend/test/edgehog/containers/image/provisioner_test.exs
@@ -40,6 +40,21 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
       tenant = tenant_fixture()
       deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       [image_deployment] =
         deployment
         |> Ash.load!([container_deployments: [image_deployment: [:image, :device]]],
@@ -49,7 +64,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
         |> Enum.map(&Map.get(&1, :image_deployment))
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           image_deployment: image_deployment,
           deployment: deployment,
@@ -110,7 +125,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -151,7 +166,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -188,7 +203,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.subscribe(Edgehog.PubSub, "ready:image_deployments:#{image_deployment.id}")
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_image_deployment}, 1000
 
@@ -222,7 +237,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_unpulled, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_image_deployment}, 1000
@@ -268,7 +283,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
       ready_topic = "ready:image_deployments:#{image_deployment.id}"
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_image_deployment}, 1000
@@ -278,5 +293,79 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateImageRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_image_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateImageRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_image_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/network/provisioner_test.exs
+++ b/backend/test/edgehog/containers/network/provisioner_test.exs
@@ -46,6 +46,21 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
           release_opts: [containers: 1, container_params: [networks: [network.id]]]
         )
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       [network_deployments] =
         deployment
         |> Ash.load!(
@@ -60,7 +75,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
       [network_deployment] = network_deployments
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           network_deployment: network_deployment,
           deployment: deployment,
@@ -124,7 +139,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -169,7 +184,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -217,7 +232,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
         "ready:network_deployments:#{network_deployment.id}"
       )
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_network_deployment}, 1000
 
@@ -254,7 +269,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_available, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_network_deployment}, 1000
@@ -300,7 +315,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
       ready_topic = "ready:network_deployments:#{network_deployment.id}"
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_network_deployment}, 1000
@@ -310,5 +325,79 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateNetworkRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_network_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateNetworkRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_network_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end

--- a/backend/test/edgehog/containers/volume/provisioner_test.exs
+++ b/backend/test/edgehog/containers/volume/provisioner_test.exs
@@ -45,16 +45,31 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
           release_opts: [containers: 1, container_params: [volumes: 1]]
         )
 
+      timestamp = now()
+
+      opts = %{
+        online: true,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      deployment =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+        |> then(&Map.put(deployment, :device, &1))
+
       volume_deployment =
         deployment
-        |> Ash.load!(container_deployments: [volume_deployments: [:device, :volume]])
+        |> Ash.load!(container_deployments: [volume_deployments: [:volume, :device]])
         |> Map.get(:container_deployments, [])
         |> List.first()
         |> Map.get(:volume_deployments, [])
         |> List.first()
 
       provisioner =
-        Provisioner.start_link(
+        Provisioner.start(
           tenant: tenant,
           volume_deployment: volume_deployment,
           deployment: deployment,
@@ -117,7 +132,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
 
       Sandbox.allow(Edgehog.Repo, self(), provisioner)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
     end
@@ -158,7 +173,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
         :ok
       end)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 2000
     end
@@ -200,7 +215,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
         "ready:volume_deployments:#{volume_deployment.id}"
       )
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:ready, new_volume_deployment}, 1000
 
@@ -237,7 +252,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
         |> Ash.Changeset.for_update(:mark_as_unavailable, %{})
         |> Ash.update!(tenant: tenant)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
       assert_receive {:ready, new_volume_deployment}, 1000
@@ -283,7 +298,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
       ready_topic = "ready:volume_deployments:#{volume_deployment.id}"
       Phoenix.PubSub.subscribe(Edgehog.PubSub, ready_topic)
 
-      Provisioner.start(provisioner)
+      Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 3000
       assert_receive {:ready, new_volume_deployment}, 1000
@@ -293,5 +308,79 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
 
       Phoenix.PubSub.unsubscribe(Edgehog.PubSub, ready_topic)
     end
+
+    test "stops if device goes offline", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      test_process = self()
+
+      timestamp = now()
+
+      CreateVolumeRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_volume_request, fn _, _, _ -> :ok end)
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+      Provisioner.run(provisioner)
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "immediately stops if device is offline at startup", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref,
+        tenant: tenant
+      } = context
+
+      timestamp = now()
+
+      opts = %{
+        online: false,
+        last_connection: timestamp,
+        last_disconnection: timestamp
+      }
+
+      device =
+        deployment
+        |> Map.get(:device)
+        |> Ash.Changeset.for_update(:from_device_status, opts)
+        |> Ash.update!(tenant: tenant)
+
+      refute device.online
+
+      test_process = self()
+
+      Sandbox.allow(Edgehog.Repo, test_process, provisioner)
+
+      CreateVolumeRequest
+      |> allow(test_process, provisioner)
+      |> reject(:send_create_volume_request, 3)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
   end
+
+  defp now, do: DateTime.now!("Etc/UTC")
 end


### PR DESCRIPTION
#### What this PR does / why we need it:

If a device goes offline, the provisioners should stop, and the supervisor
should start new ones when the device comes back online.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
Publish notifications on the pubsub when a device goes online/offline.

Signed-off-by: Damiano Mason <damiano.mason@secomind.com>