### PR TITLE
fix(frontend): fix oversized folder icon

### DIFF
--- a/frontend/src/components/FileDropzone.tsx
+++ b/frontend/src/components/FileDropzone.tsx
@@ -225,7 +225,7 @@ const FileDropzone = ({
         {files.length === 0 ? (
           <div className="py-2">
             <div className="mb-2 text-secondary">
-              <Icon icon="folder" size="3x" />
+              <Icon icon="folder" size="3em" />
             </div>
             <p className="mb-1 text-muted">
               {allowMultiple ? (


### PR DESCRIPTION


#### What this PR does / why we need it:
Changes folder icon size from 3x to 3em to fix rendering size with Lucide icons.
The 3x size wasn't applied correctly with Lucide icons, causing the size class to be ignored and the icon to render much larger than intended:
<img width="2279" height="1313" alt="image" src="https://github.com/user-attachments/assets/53e65f9a-57b4-4151-be91-cf588c9805ce" />

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
