### PR TITLE
refactor(backend): provisioner fail on unsolvable API errors

### DIFF
--- a/backend/lib/edgehog/containers/provisioner.ex
+++ b/backend/lib/edgehog/containers/provisioner.ex
@@ -101,6 +101,8 @@ defmodule Edgehog.Containers.Provisioner do
         end
       end
 
+      @known_shutdown_reasons [:max_retries, :device_offline, :timeout_hit, :unsolvable_api_error]
+
       @behaviour Provisioner.Behaviour
 
       #### API
@@ -303,7 +305,7 @@ defmodule Edgehog.Containers.Provisioner do
 
       @impl GenServer
       def terminate({:shutdown, reason}, %{resource: resource})
-          when reason in [:max_retries, :device_offline, :timeout_hit] do
+          when reason in @known_shutdown_reasons do
         %{id: id, device_id: device_id} = resource
 
         Logger.info("""
@@ -358,22 +360,32 @@ defmodule Edgehog.Containers.Provisioner do
 
         opts = [tenant: tenant] ++ context
 
-        new_state =
-          case Core.send_to_device(resource, opts) do
-            :ok ->
-              Map.put(state, :state, :sent)
+        case Core.send_to_device(resource, opts) do
+          :ok ->
+            new_state = Map.put(state, :state, :sent)
+            timeout = timeout(new_state)
+            {:noreply, new_state, timeout}
 
-            error ->
-              Logger.warning(
-                "Error while sending the resource #{resource.id}: #{inspect(error)}. The operation will be retried shortly."
-              )
+          error ->
+            log_api_error(error, resource.id)
+            timeout = timeout(state)
 
-              state
-          end
+            if Core.temporary_error?(error),
+              do: {:noreply, state, timeout},
+              else: {:stop, {:shutdown, :unsolvable_api_error}, state}
+        end
+      end
 
-        timeout = timeout(new_state)
-
-        {:noreply, new_state, timeout}
+      defp log_api_error(error, resource_id) do
+        if Core.temporary_error?(error) do
+          Logger.warning(
+            "Error while sending the resource #{resource_id}: #{inspect(error)}. The operation will be retried shortly."
+          )
+        else
+          Logger.error(
+            "Unrecoverable error while sending the resource #{resource_id}: #{inspect(error)}. Terminating."
+          )
+        end
       end
 
       defp increase_retries(state) do

--- a/backend/lib/edgehog/containers/provisioner/core.ex
+++ b/backend/lib/edgehog/containers/provisioner/core.ex
@@ -47,7 +47,31 @@ defmodule Edgehog.Containers.Provisioner.Core do
 
   defmacro __using__(_opts) do
     quote do
-      @behaviour Edgehog.Containers.Provisioner.Core.Behaviour
+      alias Edgehog.Containers.Provisioner.Core
+
+      @behaviour Core.Behaviour
+
+      @impl Core.Behaviour
+      def temporary_error?(error)
+
+      def temporary_error?({:error, error}), do: temporary_error?(error)
+
+      def temporary_error?(%{errors: errors}) when is_list(errors) and errors != [],
+        do: Enum.any?(errors, &temporary_error?/1)
+
+      def temporary_error?("connection refused"), do: true
+
+      def temporary_error?(%Astarte.Client.APIError{status: status}) when status in 500..599,
+        do: true
+
+      def temporary_error?(%Edgehog.Error.AstarteAPIError{status: status})
+          when status in 500..599, do: true
+
+      def temporary_error?(%Edgehog.Error.DeviceOffline{}), do: true
+
+      def temporary_error?(_error), do: false
+
+      defoverridable temporary_error?: 1
     end
   end
 end

--- a/backend/lib/edgehog/containers/provisioner/core/behaviour.ex
+++ b/backend/lib/edgehog/containers/provisioner/core/behaviour.ex
@@ -98,6 +98,13 @@ defmodule Edgehog.Containers.Provisioner.Core.Behaviour do
   """
   @callback subscribe_topic(resource()) :: String.t()
 
+  @doc """
+  Checks whether an error returned by `send_to_device/3` from Astarte APIs is
+  temporary (i.e.: can be retried in a bit), or if it's not, and should thus cause
+  a failure of the Provisioner.
+  """
+  @callback temporary_error?(error()) :: boolean()
+
   @type ash_action_return() ::
           {:ok, Ash.Resource.record()}
           | {:ok, Ash.Resource.record(), [Ash.Notifier.Notification.t()]}
@@ -118,4 +125,6 @@ defmodule Edgehog.Containers.Provisioner.Core.Behaviour do
   @type provisioner_registry() :: term()
 
   @type id() :: term()
+
+  @type error() :: term()
 end

--- a/backend/test/edgehog/containers/container/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/container/provisioner/core_test.exs
@@ -129,5 +129,37 @@ defmodule Edgehog.Containers.Container.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(container_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/container/provisioner_test.exs
+++ b/backend/test/edgehog/containers/container/provisioner_test.exs
@@ -132,7 +132,7 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
       CreateContainerRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_container_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_container_request, fn _, _, data ->
         assert data == expected_data(container_deployment, deployment)
@@ -338,6 +338,38 @@ defmodule Edgehog.Containers.Container.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        container_deployment: container_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(container_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateContainerRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_container_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == container_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/deployment/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/deployment/provisioner/core_test.exs
@@ -117,5 +117,37 @@ defmodule Edgehog.Containers.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/deployment/provisioner_test.exs
+++ b/backend/test/edgehog/containers/deployment/provisioner_test.exs
@@ -152,7 +152,7 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
       CreateDeploymentRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_deployment_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_deployment_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateDeploymentRequest.RequestData{
@@ -391,6 +391,38 @@ defmodule Edgehog.Containers.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        deployment: deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateDeploymentRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_deployment_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/device_mapping/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/device_mapping/provisioner/core_test.exs
@@ -142,5 +142,37 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(device_mapping_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
+++ b/backend/test/edgehog/containers/device_mapping/provisioner_test.exs
@@ -156,7 +156,7 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
       CreateDeviceMappingRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_device_mapping_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_device_mapping_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateDeviceMappingRequest.RequestData{
@@ -392,6 +392,38 @@ defmodule Edgehog.Containers.DeviceMapping.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        device_mapping_deployment: device_mapping_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(device_mapping_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateDeviceMappingRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_device_mapping_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == device_mapping_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/device_request/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/device_request/provisioner/core_test.exs
@@ -142,5 +142,37 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(device_request_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/device_request/provisioner_test.exs
+++ b/backend/test/edgehog/containers/device_request/provisioner_test.exs
@@ -170,7 +170,7 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
       CreateDeviceRequestRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_device_request_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_device_request_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateDeviceRequestRequest.RequestData{
@@ -426,6 +426,38 @@ defmodule Edgehog.Containers.DeviceRequest.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        device_request_deployment: device_request_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(device_request_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateDeviceRequestRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_device_request_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == device_request_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/image/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/image/provisioner/core_test.exs
@@ -130,5 +130,37 @@ defmodule Edgehog.Containers.Image.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(image_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/image/provisioner_test.exs
+++ b/backend/test/edgehog/containers/image/provisioner_test.exs
@@ -158,7 +158,7 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
       CreateImageRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_image_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_image_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateImageRequest.RequestData{
@@ -378,6 +378,38 @@ defmodule Edgehog.Containers.Image.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        image_deployment: image_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(image_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateImageRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_image_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == image_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/network/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/network/provisioner/core_test.exs
@@ -136,5 +136,37 @@ defmodule Edgehog.Containers.Network.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(network_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/network/provisioner_test.exs
+++ b/backend/test/edgehog/containers/network/provisioner_test.exs
@@ -158,7 +158,7 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
       CreateNetworkRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_network_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_network_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateNetworkRequest.RequestData{
@@ -396,6 +396,38 @@ defmodule Edgehog.Containers.Network.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        network_deployment: network_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(network_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateNetworkRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_network_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == network_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 

--- a/backend/test/edgehog/containers/volume/provisioner/core_test.exs
+++ b/backend/test/edgehog/containers/volume/provisioner/core_test.exs
@@ -132,5 +132,37 @@ defmodule Edgehog.Containers.Volume.Deployment.Provisioner.CoreTest do
 
       assert :not_found == Core.reconcile(volume_deployment, tenant: tenant)
     end
+
+    test "temporary_error?/1 correctly recurses on nested errors", _context do
+      error = "connection refused"
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = %{errors: ["unknown error"]}
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+
+      error = :other
+      assert Core.temporary_error?({:error, error}) == Core.temporary_error?(error)
+    end
+
+    test "temporary_error?/1 returns true for \"connection refused\" errors", _context do
+      assert Core.temporary_error?("connection refused")
+    end
+
+    test "temporary_error?/1 returns true for 5xx responses", _context do
+      assert Core.temporary_error?(%Astarte.Client.APIError{
+               status: Enum.random(500..599),
+               response: "server error"
+             })
+
+      assert Core.temporary_error?(%Edgehog.Error.AstarteAPIError{status: Enum.random(500..599)})
+    end
+
+    test "temporary_error?/1 returns true for Edgehog.Error.DeviceOffline errors", _context do
+      assert Core.temporary_error?(%Edgehog.Error.DeviceOffline{})
+    end
+
+    test "temporary_error?/1 returns false for other unspecified errors", _context do
+      refute Core.temporary_error?(:other_unspecified_error)
+    end
   end
 end

--- a/backend/test/edgehog/containers/volume/provisioner_test.exs
+++ b/backend/test/edgehog/containers/volume/provisioner_test.exs
@@ -151,7 +151,7 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
       CreateVolumeRequest
       |> allow(test_process, provisioner)
       |> expect(:send_create_volume_request, fn _, _, _ ->
-        {:error, %Astarte.Client.APIError{status: 500, response: "some error message"}}
+        {:error, %Edgehog.Error.AstarteAPIError{status: 500, response: "some error message"}}
       end)
       |> expect(:send_create_volume_request, fn _, _, data ->
         %Edgehog.Astarte.Device.CreateVolumeRequest.RequestData{
@@ -379,6 +379,38 @@ defmodule Edgehog.Containers.Volume.Deployment.ProvisionerTest do
       Provisioner.run(provisioner)
 
       assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :device_offline}}, 2000
+    end
+
+    test "stops on unsolvable, non-temporary errors", context do
+      %{
+        volume_deployment: volume_deployment,
+        provisioner: provisioner,
+        provisioner_ref: ref
+      } = context
+
+      test_process = self()
+
+      topic = Provisioner.Core.topic(volume_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      CreateVolumeRequest
+      |> allow(test_process, provisioner)
+      |> expect(:send_create_volume_request, fn _, _, _ ->
+        {:error, %Edgehog.Error.AstarteAPIError{status: 400, response: "some error message"}}
+      end)
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, {:shutdown, :unsolvable_api_error}},
+                     2000
+
+      assert_receive {:failure, failed_resource}, 2000
+      assert failed_resource.id == volume_deployment.id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
     end
   end
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Properly parse errors returned by `Core.send_to_device/2`, and fail if
the error cannot be solved by a timeout/retry combo.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

Based on #1599 

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md