### PR TITLE
fix: clear dependencies when container selection changes in release form

### DIFF
--- a/frontend/src/forms/CreateRelease.tsx
+++ b/frontend/src/forms/CreateRelease.tsx
@@ -99,6 +99,7 @@ const CreateRelease = ({
     register,
     handleSubmit,
     control,
+    setValue,
     formState: { errors },
   } = useForm<ReleaseFormData>({
     mode: "onTouched",
@@ -265,6 +266,12 @@ const CreateRelease = ({
                         control={control}
                         options={availableContainers}
                         name={`containerDependencies.${i}.containerId`}
+                        onChange={() => {
+                          setValue(
+                            `containerDependencies.${i}.dependencies`,
+                            [],
+                          );
+                        }}
                       />
                       <FormFeedback feedback={error?.containerId?.message} />
                     </Col>


### PR DESCRIPTION

#### What this PR does / why we need it:
When switching the container in a dependency row, stale dependency values remained selected, causing self-dependency validation errors and triggering the MultiSelectFormField fallback to display raw IDs instead of labels.

<img width="1623" height="455" alt="image" src="https://github.com/user-attachments/assets/25184b4a-5b2e-40e0-989d-8f24d82c4c8c" />


Fixed by resetting the dependencies field to an empty array on container change.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
