### PR TITLE
chore(backend): add deployment telemetry in `Edgehog.Containers`

### DIFF
--- a/backend/lib/edgehog/config.ex
+++ b/backend/lib/edgehog/config.ex
@@ -61,6 +61,22 @@ defmodule Edgehog.Config do
     type: :boolean,
     default: false
 
+  @envdoc """
+  Whether containers telemetry events should include high-cardinality
+  identifier labels (deployment_id, resource_id, device_id).
+
+  These labels allow filtering the metrics per specific deployment, resource or
+  device (e.g. in Grafana), at the cost of a higher number of Prometheus time
+  series. Disable them if you are not filtering on them and want to keep the
+  cardinality low.
+  """
+  app_env :containers_telemetry_include_identifiers,
+          :edgehog,
+          :containers_telemetry_include_identifiers,
+          os_env: "CONTAINERS_TELEMETRY_INCLUDE_IDENTIFIERS",
+          type: :boolean,
+          default: true
+
   @envdoc "The API key for the ipbase.com geolocation provider."
   app_env :ipbase_api_key, :edgehog, :ipbase_api_key,
     os_env: "IPBASE_API_KEY",

--- a/backend/lib/edgehog/containers/container/deployment/orchestrator.ex
+++ b/backend/lib/edgehog/containers/container/deployment/orchestrator.ex
@@ -53,6 +53,7 @@ defmodule Edgehog.Containers.Container.Deployment.Orchestrator do
   alias Edgehog.Containers.DeviceRequest
   alias Edgehog.Containers.Image
   alias Edgehog.Containers.Network
+  alias Edgehog.Containers.Telemetry
   alias Edgehog.Containers.Volume
 
   require Logger
@@ -142,11 +143,14 @@ defmodule Edgehog.Containers.Container.Deployment.Orchestrator do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    started_at = Telemetry.container_deployment_started(container_deployment, deployment)
+
     state = %{
       container_deployment: container_deployment,
       deployment: deployment,
       tenant: tenant,
-      mode: mode
+      mode: mode,
+      started_at: started_at
     }
 
     {:ok, state, {:continue, :maybe_load_resources}}
@@ -206,6 +210,12 @@ defmodule Edgehog.Containers.Container.Deployment.Orchestrator do
     } = state
 
     if Core.ready?(state) do
+      Telemetry.container_deployment_completed(
+        state.container_deployment,
+        state.deployment,
+        state.started_at
+      )
+
       topic = topic(container_deployment)
 
       event = %Phoenix.Socket.Broadcast{
@@ -281,12 +291,16 @@ defmodule Edgehog.Containers.Container.Deployment.Orchestrator do
 
   defp fail_container(state) do
     %{
-      container_deployment: container_deployment
+      container_deployment: container_deployment,
+      deployment: deployment,
+      started_at: started_at
     } = state
 
     %{id: id} = container_deployment
 
     Logger.warning("Container deployment #{id} provisioning failed.")
+
+    Telemetry.container_deployment_failed(container_deployment, deployment, started_at)
 
     topic = topic(container_deployment)
 

--- a/backend/lib/edgehog/containers/deployment/orchestrator.ex
+++ b/backend/lib/edgehog/containers/deployment/orchestrator.ex
@@ -49,6 +49,7 @@ defmodule Edgehog.Containers.Deployment.Orchestrator do
   alias Edgehog.Containers.Deployment
   alias Edgehog.Containers.Deployment.Orchestrator.Core
   alias Edgehog.Containers.Deployment.Orchestrator.Registry, as: DeploymentOrchestratorRegistry
+  alias Edgehog.Containers.Telemetry
 
   require Logger
 
@@ -139,10 +140,13 @@ defmodule Edgehog.Containers.Deployment.Orchestrator do
 
     mode = Keyword.get(args, :mode, :auto)
 
+    started_at = Telemetry.deployment_started(deployment)
+
     state = %{
       deployment: deployment,
       tenant: tenant,
-      mode: mode
+      mode: mode,
+      started_at: started_at
     }
 
     %{id: id} = deployment
@@ -262,7 +266,8 @@ defmodule Edgehog.Containers.Deployment.Orchestrator do
   def terminate(:normal, state) do
     %{
       deployment: deployment,
-      tenant: tenant
+      tenant: tenant,
+      started_at: started_at
     } = state
 
     %{id: id} = deployment
@@ -270,6 +275,8 @@ defmodule Edgehog.Containers.Deployment.Orchestrator do
     Logger.debug(
       "Terminating deployment orchestrator for deployment #{id}. The deployment is ready."
     )
+
+    Telemetry.deployment_completed(deployment, started_at)
 
     readiness_topic = topic(deployment)
 
@@ -314,12 +321,15 @@ defmodule Edgehog.Containers.Deployment.Orchestrator do
   defp fail_deployment(state) do
     %{
       deployment: deployment,
-      tenant: tenant
+      tenant: tenant,
+      started_at: started_at
     } = state
 
     %{id: id} = deployment
 
     Logger.warning("Deployment #{id} provisioning failed. Marking it as timed out.")
+
+    Telemetry.deployment_failed(deployment, started_at)
 
     # Mark the deployment as timed out. This also publishes on the
     # deployments:timeout:id topic through the Ash notifier.

--- a/backend/lib/edgehog/containers/prom_ex_plugin.ex
+++ b/backend/lib/edgehog/containers/prom_ex_plugin.ex
@@ -1,0 +1,198 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.PromExPlugin do
+  @moduledoc """
+  PromEx plugin for the Edgehog containers feature.
+
+  Exposes the following metric groups:
+
+  - `:containers_provisioning_event_metrics` exposing, for every resource type
+    provisioned on a device (image deployments, volume deployments, network
+    deployments, device mapping deployments, device request deployments,
+    container deployments and deployments), the provisioning lifecycle:
+    - `edgehog_containers_provisioning_started_total`
+    - `edgehog_containers_provisioning_completed_total` (labeled by `result`)
+    - `edgehog_containers_provisioning_duration_seconds` (labeled by `result`)
+    - `edgehog_containers_provisioning_retries`
+
+  - `:containers_deployment_event_metrics` exposing the end-to-end lifecycle of
+    an application deployment:
+    - `edgehog_containers_deployment_started_total`
+    - `edgehog_containers_deployment_completed_total` (labeled by `result`)
+    - `edgehog_containers_deployment_duration_seconds`
+
+  - `:containers_container_deployment_event_metrics` exposing the lifecycle of a
+    single container deployment:
+    - `edgehog_containers_container_deployment_started_total`
+    - `edgehog_containers_container_deployment_completed_total` (labeled by `result`)
+    - `edgehog_containers_container_deployment_duration_seconds`
+
+  The provisioning metrics carry `resource_type`, `result` and `reason` labels,
+  which are low cardinality. Additionally, unless the
+  `:containers_telemetry_include_identifiers` configuration option is set to
+  `false`, the metrics also carry the high cardinality identifier labels
+  `deployment_id`, `resource_id` and `device_id`, so that the metrics can be
+  filtered per specific deployment, resource or device in Grafana (e.g. using a
+  dashboard variable resolved to the device ids of a device group).
+  """
+
+  use PromEx.Plugin
+
+  alias Edgehog.Containers.Telemetry
+
+  @impl PromEx.Plugin
+  def event_metrics(_opts) do
+    [
+      provisioning_event_metrics(),
+      deployment_event_metrics(),
+      container_deployment_event_metrics()
+    ]
+  end
+
+  defp provisioning_event_metrics do
+    metric_prefix = [:edgehog, :containers, :provisioning]
+
+    Event.build(
+      :containers_provisioning_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:started, :total],
+          event_name: Telemetry.provisioning_start_event(),
+          measurement: :count,
+          description: "Number of provisioning operations started for a resource on a device.",
+          tags: [:resource_type, :resource_id, :deployment_id, :device_id],
+          tag_values: &identifiers_tag_values/1
+        ),
+        counter(
+          metric_prefix ++ [:completed, :total],
+          event_name: Telemetry.provisioning_stop_event(),
+          measurement: :count,
+          description: "Number of provisioning operations completed for a resource on a device.",
+          tags: [:resource_type, :resource_id, :deployment_id, :device_id, :result, :reason],
+          tag_values: &identifiers_tag_values/1
+        ),
+        distribution(
+          metric_prefix ++ [:duration, :seconds],
+          event_name: Telemetry.provisioning_stop_event(),
+          measurement: :duration,
+          description: "The time it took for a provisioning operation to complete.",
+          tags: [:resource_type, :deployment_id, :device_id, :result, :reason],
+          tag_values: &identifiers_tag_values/1,
+          reporter_options: [buckets: [100, 250, 500, 1000, 2500, 5000, 10_000, 60_000]],
+          unit: {:native, :second}
+        ),
+        distribution(
+          metric_prefix ++ [:retries],
+          event_name: Telemetry.provisioning_stop_event(),
+          measurement: :retries,
+          description: "The number of retries of a provisioning operation.",
+          tags: [:result, :reason],
+          tag_values: &identifiers_tag_values/1,
+          reporter_options: [buckets: [0, 1, 2, 3, 4, 5, 10, 25, 50, 100]]
+        )
+      ]
+    )
+  end
+
+  defp deployment_event_metrics do
+    metric_prefix = [:edgehog, :containers, :deployment]
+
+    Event.build(
+      :containers_deployment_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:started, :total],
+          event_name: Telemetry.deployment_start_event(),
+          measurement: :count,
+          description: "Number of application deployments started.",
+          tags: [:deployment_id, :device_id],
+          tag_values: &identifiers_tag_values/1
+        ),
+        counter(
+          metric_prefix ++ [:completed, :total],
+          event_name: Telemetry.deployment_stop_event(),
+          measurement: :count,
+          description: "Number of application deployments completed, either successfully or not.",
+          tags: [:deployment_id, :device_id, :result],
+          tag_values: &identifiers_tag_values/1
+        ),
+        distribution(
+          metric_prefix ++ [:duration, :seconds],
+          event_name: Telemetry.deployment_stop_event(),
+          measurement: :duration,
+          description: "The time it took for an application deployment to complete.",
+          tags: [:deployment_id, :device_id, :result],
+          tag_values: &identifiers_tag_values/1,
+          reporter_options: [buckets: [1000, 2500, 5000, 10_000, 60_000, 300_000, 600_000]],
+          unit: {:native, :second}
+        )
+      ]
+    )
+  end
+
+  defp container_deployment_event_metrics do
+    metric_prefix = [:edgehog, :containers, :container_deployment]
+
+    Event.build(
+      :containers_container_deployment_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:started, :total],
+          event_name: Telemetry.container_deployment_start_event(),
+          measurement: :count,
+          description: "Number of container deployments started.",
+          tags: [:container_deployment_id, :deployment_id, :device_id],
+          tag_values: &identifiers_tag_values/1
+        ),
+        counter(
+          metric_prefix ++ [:completed, :total],
+          event_name: Telemetry.container_deployment_stop_event(),
+          measurement: :count,
+          description: "Number of container deployments completed, either successfully or not.",
+          tags: [:container_deployment_id, :deployment_id, :device_id, :result],
+          tag_values: &identifiers_tag_values/1
+        ),
+        distribution(
+          metric_prefix ++ [:duration, :seconds],
+          event_name: Telemetry.container_deployment_stop_event(),
+          measurement: :duration,
+          description: "The time it took for a container deployment to complete.",
+          tags: [:container_deployment_id, :deployment_id, :device_id, :result],
+          tag_values: &identifiers_tag_values/1,
+          reporter_options: [buckets: [100, 250, 500, 1000, 2500, 5000, 10_000, 60_000]],
+          unit: {:native, :second}
+        )
+      ]
+    )
+  end
+
+  defp identifiers_tag_values(metadata) do
+    Map.take(metadata, [
+      :resource_type,
+      :resource_id,
+      :deployment_id,
+      :device_id,
+      :container_deployment_id,
+      :result,
+      :reason
+    ])
+  end
+end

--- a/backend/lib/edgehog/containers/provisioner.ex
+++ b/backend/lib/edgehog/containers/provisioner.ex
@@ -77,6 +77,7 @@ defmodule Edgehog.Containers.Provisioner do
 
       alias Edgehog.Config
       alias Edgehog.Containers.Provisioner
+      alias Edgehog.Containers.Telemetry
       alias unquote(core_module), as: Core
       alias unquote(resource_module), as: Resource
 
@@ -165,6 +166,8 @@ defmodule Edgehog.Containers.Provisioner do
 
         %{id: id, device: %{id: device_id, online: device_online?}} = resource
 
+        started_at = Telemetry.provisioning_started(resource, context)
+
         state = %{
           resource: resource,
           tenant: tenant,
@@ -172,7 +175,8 @@ defmodule Edgehog.Containers.Provisioner do
           device_online?: device_online?,
           state: :init,
           mode: mode,
-          retries: 0
+          retries: 0,
+          started_at: started_at
         }
 
         topic = Core.subscribe_topic(resource)
@@ -212,7 +216,8 @@ defmodule Edgehog.Containers.Provisioner do
       @impl GenServer
       def handle_continue(:check_state, %{resource: resource} = state) do
         if Core.ready?(resource) do
-          {:stop, :normal, state}
+          new_state = Map.put(state, :result, :already_ready)
+          {:stop, :normal, new_state}
         else
           {:noreply, state, {:continue, :send}}
         end
@@ -272,6 +277,7 @@ defmodule Edgehog.Containers.Provisioner do
         # The resource has been updated, check if it's ready and, in that case,
         # terminate gracefully. Otherwise keep waiting with a new timeout.
         if Core.ready?(resource) do
+          new_state = Map.put(new_state, :result, :ready)
           {:stop, :normal, new_state}
         else
           {:noreply, new_state, timeout(new_state)}
@@ -289,11 +295,19 @@ defmodule Edgehog.Containers.Provisioner do
 
       @impl GenServer
       def terminate(:normal, state) do
-        %{resource: %{id: id, device_id: device_id} = resource} = state
+        %{
+          resource: %{id: id, device_id: device_id} = resource,
+          context: context,
+          started_at: started_at,
+          retries: retries,
+          result: result
+        } = state
 
         Logger.info("""
-        Resource #{id} successfully provisioned after #{state.retries} retries.
+        Resource #{id} successfully provisioned after #{retries} retries.
         """)
+
+        Telemetry.provisioning_completed(resource, context, started_at, retries, result)
 
         # Broadcast readiness so that the orchestrator can proceed
         Phoenix.PubSub.broadcast(Edgehog.PubSub, Core.topic(resource), {:ready, resource})
@@ -304,13 +318,20 @@ defmodule Edgehog.Containers.Provisioner do
       end
 
       @impl GenServer
-      def terminate({:shutdown, reason}, %{resource: resource})
+      def terminate({:shutdown, reason}, state)
           when reason in @known_shutdown_reasons do
-        %{id: id, device_id: device_id} = resource
+        %{
+          resource: %{id: id, device_id: device_id} = resource,
+          context: context,
+          started_at: started_at,
+          retries: retries
+        } = state
 
         Logger.info("""
         Provisioner for resource #{id} gave up with reason #{inspect(reason)}.
         """)
+
+        Telemetry.provisioning_failed(resource, context, started_at, retries, reason)
 
         # Broadcast failure so that the orchestrator can react
         Phoenix.PubSub.broadcast(Edgehog.PubSub, Core.topic(resource), {:failure, resource})
@@ -322,7 +343,14 @@ defmodule Edgehog.Containers.Provisioner do
 
       @impl GenServer
       def terminate(reason, state) do
-        %{resource: %{id: id, device: %{id: device_id}}} = state
+        %{
+          resource: %{id: id, device: %{id: device_id}} = resource,
+          context: context,
+          started_at: started_at,
+          retries: retries
+        } = state
+
+        Telemetry.provisioning_failed(resource, context, started_at, retries, :unexpected)
 
         Logger.warning(
           """

--- a/backend/lib/edgehog/containers/telemetry.ex
+++ b/backend/lib/edgehog/containers/telemetry.ex
@@ -1,0 +1,297 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Telemetry do
+  @moduledoc """
+  Emits the telemetry events of the containers feature.
+
+  Events can be emitted on the following topics:
+
+  - `[:edgehog, :containers, :provisioning, :start]` when a provisioner
+    starts provisioning a resource. Metadata contains `resource_type`,
+    `resource_id`, `deployment_id` and `device_id`.
+  - `[:edgehog, :containers, :provisioning, :stop]` when a provisioner
+    terminates, either successfully or with a failure. Metadata contains
+    `resource_type`, `resource_id`, `deployment_id`, `device_id`, `result`
+    (either `:ok` or `:error`) and `reason` (either the provisioning outcome,
+    e.g. `:ready` or `:already_ready`, or the failure reason). Measurements
+    contain `duration` (native time) and `retries`.
+  - `[:edgehog, :containers, :deployment, :start]` when a deployment
+    orchestrator starts conducting a deployment. Metadata contains
+    `deployment_id` and `device_id`.
+  - `[:edgehog, :containers, :deployment, :stop]` when a deployment
+    orchestrator terminates, either successfully or with a failure. Metadata
+    contains `deployment_id`, `device_id` and `result`. Measurements contain
+    `duration` (native time).
+  - `[:edgehog, :containers, :container_deployment, :start]` when a container
+    deployment orchestrator starts conducting a container deployment. Metadata
+    contains `container_deployment_id`, `deployment_id` and `device_id`.
+  - `[:edgehog, :containers, :container_deployment, :stop]` when a container
+    deployment orchestrator terminates, either successfully or with a failure.
+    Metadata contains `container_deployment_id`, `deployment_id`, `device_id`
+    and `result`. Measurements contain `duration` (native time).
+  """
+
+  alias Edgehog.Config
+  alias Edgehog.Containers.Deployment
+
+  @provisioning_start [:edgehog, :containers, :provisioning, :start]
+  @provisioning_stop [:edgehog, :containers, :provisioning, :stop]
+  @deployment_start [:edgehog, :containers, :deployment, :start]
+  @deployment_stop [:edgehog, :containers, :deployment, :stop]
+  @container_deployment_start [:edgehog, :containers, :container_deployment, :start]
+  @container_deployment_stop [:edgehog, :containers, :container_deployment, :stop]
+
+  def provisioning_start_event, do: @provisioning_start
+
+  def provisioning_stop_event, do: @provisioning_stop
+
+  def deployment_start_event, do: @deployment_start
+
+  def deployment_stop_event, do: @deployment_stop
+
+  def container_deployment_start_event, do: @container_deployment_start
+
+  def container_deployment_stop_event, do: @container_deployment_stop
+
+  @doc """
+  Emits a provisioning start event and returns the monotonic time the
+  provisioning started, to be used when emitting the corresponding stop event.
+
+  Returns the start time, computed with `System.monotonic_time/0`
+  """
+  def provisioning_started(resource, context) do
+    start = System.monotonic_time()
+
+    metadata =
+      [started_at: start]
+      |> Keyword.merge(base_metadata(resource, context))
+      |> Map.new()
+
+    :telemetry.execute(@provisioning_start, %{count: 1}, metadata)
+
+    start
+  end
+
+  @doc """
+  Emits a successful provisioning stop event.
+  """
+  def provisioning_completed(resource, context, started_at, retries, reason) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [
+        result: :ok,
+        reason: reason,
+        duration: duration,
+        duration_unit: :native
+      ]
+      |> Keyword.merge(base_metadata(resource, context))
+      |> Map.new()
+
+    :telemetry.execute(
+      @provisioning_stop,
+      %{count: 1, duration: duration, retries: retries},
+      metadata
+    )
+  end
+
+  @doc """
+  Emits a failed provisioning stop event.
+  """
+  def provisioning_failed(resource, context, started_at, retries, reason) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [
+        result: :error,
+        reason: reason,
+        duration: duration,
+        duration_unit: :native
+      ]
+      |> Keyword.merge(base_metadata(resource, context))
+      |> Map.new()
+
+    :telemetry.execute(
+      @provisioning_stop,
+      %{count: 1, duration: duration, retries: retries},
+      metadata
+    )
+  end
+
+  @doc """
+  Emits a deployment orchestration start event and returns the monotonic time
+  the orchestration started, to be used when emitting the corresponding stop
+  event.
+
+  Returns the start time, computed with `System.monotonic_time/0`
+  """
+  def deployment_started(deployment) do
+    start = System.monotonic_time()
+
+    metadata =
+      [started_at: start]
+      |> Keyword.merge(deployment_metadata(deployment))
+      |> Map.new()
+
+    :telemetry.execute(@deployment_start, %{count: 1}, metadata)
+
+    start
+  end
+
+  @doc """
+  Emits a successful deployment orchestration stop event.
+  """
+  def deployment_completed(deployment, started_at) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [result: :ok, duration: duration, duration_unit: :native]
+      |> Keyword.merge(deployment_metadata(deployment))
+      |> Map.new()
+
+    :telemetry.execute(@deployment_stop, %{count: 1, duration: duration}, metadata)
+  end
+
+  @doc """
+  Emits a failed deployment orchestration stop event.
+  """
+  def deployment_failed(deployment, started_at) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [result: :error, duration: duration, duration_unit: :native]
+      |> Keyword.merge(deployment_metadata(deployment))
+      |> Map.new()
+
+    :telemetry.execute(@deployment_stop, %{count: 1, duration: duration}, metadata)
+  end
+
+  @doc """
+  Emits a container deployment orchestration start event and returns the
+  monotonic time the orchestration started, to be used when emitting the
+  corresponding stop event.
+
+  Returns the start time, computed with `System.monotonic_time/0`
+  """
+  def container_deployment_started(container_deployment, deployment) do
+    start = System.monotonic_time()
+
+    metadata =
+      [started_at: start]
+      |> Keyword.merge(container_deployment_metadata(container_deployment, deployment))
+      |> Map.new()
+
+    :telemetry.execute(@container_deployment_start, %{count: 1}, metadata)
+
+    start
+  end
+
+  @doc """
+  Emits a successful container deployment orchestration stop event.
+  """
+  def container_deployment_completed(container_deployment, deployment, started_at) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [result: :ok, duration: duration, duration_unit: :native]
+      |> Keyword.merge(container_deployment_metadata(container_deployment, deployment))
+      |> Map.new()
+
+    :telemetry.execute(@container_deployment_stop, %{count: 1, duration: duration}, metadata)
+  end
+
+  @doc """
+  Emits a failed container deployment orchestration stop event.
+  """
+  def container_deployment_failed(container_deployment, deployment, started_at) do
+    duration = System.monotonic_time() - started_at
+
+    metadata =
+      [result: :error, duration: duration, duration_unit: :native]
+      |> Keyword.merge(container_deployment_metadata(container_deployment, deployment))
+      |> Map.new()
+
+    :telemetry.execute(@container_deployment_stop, %{count: 1, duration: duration}, metadata)
+  end
+
+  def resource_type(%module{}) do
+    module
+    |> Module.split()
+    |> Enum.drop(2)
+    |> Enum.map_join("_", &Macro.underscore/1)
+  end
+
+  def include_identifiers?, do: Config.containers_telemetry_include_identifiers!()
+
+  defp base_metadata(resource, context) do
+    resource_metadata(resource) ++ deployment_id_metadata(resource, context)
+  end
+
+  defp deployment_metadata(deployment) do
+    identifiers =
+      if include_identifiers?() do
+        [
+          deployment_id: Map.get(deployment, :id),
+          device_id: Map.get(deployment, :device_id)
+        ]
+      else
+        []
+      end
+
+    identifiers
+  end
+
+  defp container_deployment_metadata(container_deployment, deployment) do
+    identifier =
+      if include_identifiers?() do
+        [container_deployment_id: Map.get(container_deployment, :id)]
+      else
+        []
+      end
+
+    identifier ++ deployment_metadata(deployment)
+  end
+
+  defp resource_metadata(resource) do
+    resource_type = resource_type(resource)
+
+    identifiers =
+      if include_identifiers?() do
+        [
+          resource_id: Map.get(resource, :id),
+          device_id: Map.get(resource, :device_id)
+        ]
+      else
+        []
+      end
+
+    [resource_type: resource_type] ++ identifiers
+  end
+
+  defp deployment_id_metadata(%Deployment{id: id}, _context), do: [deployment_id: id]
+
+  defp deployment_id_metadata(_resource, context) do
+    case Keyword.get(context, :deployment) do
+      %{id: deployment_id} -> [deployment_id: deployment_id]
+      _ -> [deployment_id: nil]
+    end
+  end
+end

--- a/backend/lib/edgehog/prom_ex.ex
+++ b/backend/lib/edgehog/prom_ex.ex
@@ -1,7 +1,6 @@
-#
 # This file is part of Edgehog.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022 - 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 defmodule Edgehog.PromEx do
   @moduledoc """
@@ -86,11 +84,10 @@ defmodule Edgehog.PromEx do
       Plugins.Ecto,
       # Plugins.Oban,
       # Plugins.PhoenixLiveView,
-      Plugins.Absinthe
+      Plugins.Absinthe,
       # Plugins.Broadway,
 
-      # Add your own PromEx metrics plugins
-      # Edgehog.Users.PromExPlugin
+      Edgehog.Containers.PromExPlugin
     ]
   end
 

--- a/backend/test/edgehog/containers/telemetry/orchestrators_test.exs
+++ b/backend/test/edgehog/containers/telemetry/orchestrators_test.exs
@@ -1,0 +1,351 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Telemetry.OrchestratorsTest do
+  @moduledoc """
+  Tests for the deployment and container deployment orchestrator telemetry events.
+  """
+
+  use Edgehog.DataCase, async: false
+
+  import Edgehog.ContainersFixtures
+  import Edgehog.TenantsFixtures
+  import Edgehog.TelemetryCapture
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Edgehog.Containers.Container.Deployment.Orchestrator, as: ContainerOrchestrator
+  alias Edgehog.Containers.Container.Deployment.Provisioner, as: ContainerProvisioner
+  alias Edgehog.Containers.Deployment.Orchestrator, as: DeploymentOrchestrator
+  alias Edgehog.Containers.Deployment.Provisioner, as: DeploymentProvisioner
+  alias Edgehog.Containers.Image.Deployment.Provisioner, as: ImageProvisioner
+  alias Edgehog.Containers.Telemetry
+
+  @moduletag :telemetry
+
+  describe "Deployment orchestrator telemetry" do
+    test "emits a successful deployment event when everything is ready" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.deployment_start_event(),
+        Telemetry.deployment_stop_event()
+      ])
+
+      %{tenant: tenant, deployment: deployment} = deployment_ready_fixture()
+
+      {:ok, orchestrator} = DeploymentOrchestrator.conduct(deployment, tenant)
+
+      Sandbox.allow(Edgehog.Repo, self(), orchestrator)
+
+      global_supervisor = Process.whereis(Edgehog.Containers.Deployment.Orchestrator.Supervisor)
+      Sandbox.allow(Edgehog.Repo, self(), global_supervisor)
+
+      ref = Process.monitor(orchestrator)
+
+      {measurements, metadata} = assert_receive_event(Telemetry.deployment_start_event())
+
+      assert measurements.count == 1
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      # The provisioners are already satisfied (the deployment is ready), so the
+      # orchestrator terminates normally as soon as they all report readiness
+      assert_receive {:DOWN, ^ref, :process, ^orchestrator, :normal}, 5000
+
+      {measurements, metadata} = assert_receive_event(Telemetry.deployment_stop_event())
+
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :ok
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+    end
+
+    test "emits a failed deployment event when a container reports a failure" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.deployment_start_event(),
+        Telemetry.deployment_stop_event()
+      ])
+
+      %{tenant: tenant, deployment: deployment} = deployment_ready_fixture()
+
+      topic = DeploymentOrchestrator.topic(deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      {:ok, deployment_orchestrator} =
+        DeploymentOrchestrator.conduct(deployment, tenant, mode: :manual)
+
+      {measurements, metadata} = assert_receive_event(Telemetry.deployment_start_event())
+
+      assert measurements.count == 1
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      test_process = self()
+
+      [container_deployment] =
+        deployment
+        |> Ash.load!(:container_deployments, tenant: tenant)
+        |> Map.get(:container_deployments)
+
+      container_topic = ContainerOrchestrator.topic(container_deployment)
+
+      # The container orchestrator reports a failure while the deployment is
+      # being provisioned, so the deployment is failed. The container
+      # orchestrator is started through its global dynamic supervisor, so we
+      # need to allow that process to use the stub as well
+      ContainerOrchestrator
+      |> allow(test_process, deployment_orchestrator)
+      |> expect(:conduct, fn _container_deployment, _deployment, _tenant ->
+        Phoenix.PubSub.broadcast!(
+          Edgehog.PubSub,
+          container_topic,
+          %Phoenix.Socket.Broadcast{
+            topic: container_topic,
+            event: :failure,
+            payload: container_deployment
+          }
+        )
+
+        {:ok, self()}
+      end)
+
+      # The deployment provisioner is not needed for this test, stub it so that
+      # no real provisioner is started
+      DeploymentProvisioner
+      |> allow(test_process, deployment_orchestrator)
+      |> stub(:provision, fn _deployment, _tenant -> {:ok, self()} end)
+
+      ref = Process.monitor(deployment_orchestrator)
+
+      DeploymentOrchestrator.start(deployment_orchestrator)
+
+      assert_receive {:DOWN, ^ref, :process, ^deployment_orchestrator,
+                      {:shutdown, :deployment_failed}},
+                     2000
+
+      {measurements, metadata} = assert_receive_event(Telemetry.deployment_stop_event())
+
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :error
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
+    end
+  end
+
+  describe "Container deployment orchestrator telemetry" do
+    test "emits a successful container deployment event when everything is ready" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.container_deployment_start_event(),
+        Telemetry.container_deployment_stop_event()
+      ])
+
+      %{
+        tenant: tenant,
+        deployment: deployment,
+        container_deployment: container_deployment
+      } = container_deployment_ready_fixture()
+
+      topic = ContainerOrchestrator.topic(container_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      # Start the container orchestrator in manual mode, so that we can allow
+      # the whole tree to the sandbox before any provisioning step reads from
+      # the database
+      {:ok, orchestrator} =
+        ContainerOrchestrator.conduct(container_deployment, deployment, tenant, mode: :manual)
+
+      {measurements, metadata} =
+        assert_receive_event(Telemetry.container_deployment_start_event())
+
+      assert measurements.count == 1
+      assert metadata.container_deployment_id == container_deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Sandbox.allow(Edgehog.Repo, self(), orchestrator)
+
+      ContainerOrchestrator.start(orchestrator)
+
+      # Wait for processes to start and register on each registry
+      Process.sleep(500)
+
+      # Drive each provisioner: they all find their resource already ready, so
+      # they report readiness and let the orchestrator proceed
+      image_provisioner =
+        container_deployment.image_deployment
+        |> ImageProvisioner.Core.name()
+        |> via_pid!()
+
+      Sandbox.allow(Edgehog.Repo, self(), image_provisioner)
+      ImageProvisioner.run(image_provisioner)
+
+      container_provisioner =
+        container_deployment
+        |> ContainerProvisioner.Core.name()
+        |> via_pid!()
+
+      Sandbox.allow(Edgehog.Repo, self(), container_provisioner)
+      ContainerProvisioner.run(container_provisioner)
+
+      # When all the provisioners are satisfied, the container orchestrator
+      # broadcasts the readiness of the container deployment
+      assert_receive %Phoenix.Socket.Broadcast{event: :ready, payload: new_container_deployment},
+                     5000
+
+      assert new_container_deployment.id == container_deployment.id
+
+      {measurements, metadata} = assert_receive_event(Telemetry.container_deployment_stop_event())
+
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :ok
+      assert metadata.container_deployment_id == container_deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
+    end
+
+    test "emits a failed container deployment event when a leaf provisioner cannot be started" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.container_deployment_start_event(),
+        Telemetry.container_deployment_stop_event()
+      ])
+
+      %{
+        tenant: tenant,
+        deployment: deployment,
+        container_deployment: container_deployment
+      } = container_deployment_ready_fixture()
+
+      topic = ContainerOrchestrator.topic(container_deployment)
+
+      Phoenix.PubSub.subscribe(Edgehog.PubSub, topic)
+
+      {:ok, container_orchestrator} =
+        ContainerOrchestrator.conduct(container_deployment, deployment, tenant, mode: :manual)
+
+      {measurements, metadata} =
+        assert_receive_event(Telemetry.container_deployment_start_event())
+
+      assert measurements.count == 1
+      assert metadata.container_deployment_id == container_deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Sandbox.allow(Edgehog.Repo, self(), container_orchestrator)
+
+      orchestrator =
+        container_deployment
+        |> ContainerOrchestrator.name()
+        |> via_pid!()
+
+      test_process = self()
+
+      # The image provisioner fails to start, so the container deployment is
+      # failed. The leaf provisioner is started through its global dynamic
+      # supervisor, so we need to allow that process to use the stub as well
+      image_supervisor = Process.whereis(Edgehog.Containers.Image.Provisioner.Supervisor)
+
+      ImageProvisioner
+      |> allow(test_process, image_supervisor)
+      |> stub(:start_link, fn _args -> {:error, :mocked_failure} end)
+
+      ref = Process.monitor(orchestrator)
+
+      ContainerOrchestrator.start(orchestrator)
+
+      assert_receive {:DOWN, ^ref, :process, ^orchestrator, {:shutdown, :container_failed}}, 2000
+
+      {measurements, metadata} = assert_receive_event(Telemetry.container_deployment_stop_event())
+
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :error
+      assert metadata.container_deployment_id == container_deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Phoenix.PubSub.unsubscribe(Edgehog.PubSub, topic)
+    end
+  end
+
+  defp deployment_ready_fixture do
+    tenant = tenant_fixture()
+    deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
+
+    deployment = make_deployment_ready!(deployment, tenant)
+    mark_device_online!(deployment, tenant)
+
+    %{tenant: tenant, deployment: deployment}
+  end
+
+  defp container_deployment_ready_fixture do
+    tenant = tenant_fixture()
+    deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
+
+    deployment = make_deployment_ready!(deployment, tenant)
+
+    [container_deployment] =
+      deployment
+      |> Ash.load!(
+        [container_deployments: [:container, :image_deployment]],
+        tenant: tenant
+      )
+      |> Map.get(:container_deployments, [])
+
+    mark_device_online!(deployment, tenant)
+
+    %{
+      tenant: tenant,
+      deployment: deployment,
+      container_deployment: container_deployment
+    }
+  end
+
+  defp via_pid!({:via, Registry, {registry, key}}) do
+    case Registry.lookup(registry, key) do
+      [{pid, _value}] ->
+        pid
+
+      _other ->
+        raise "no process registered for #{inspect(key)} in #{inspect(registry)}"
+    end
+  end
+
+  defp mark_device_online!(deployment, tenant) do
+    timestamp = DateTime.now!("Etc/UTC")
+
+    opts = %{
+      online: true,
+      last_connection: timestamp,
+      last_disconnection: timestamp
+    }
+
+    deployment
+    |> Map.get(:device)
+    |> Ash.Changeset.for_update(:from_device_status, opts)
+    |> Ash.update!(tenant: tenant)
+  end
+end

--- a/backend/test/edgehog/containers/telemetry/provisioning_test.exs
+++ b/backend/test/edgehog/containers/telemetry/provisioning_test.exs
@@ -1,0 +1,190 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.Containers.Telemetry.ProvisioningTest do
+  @moduledoc """
+  Tests for the provisioning telemetry events.
+  """
+
+  use Edgehog.DataCase, async: false
+
+  import Edgehog.ContainersFixtures
+  import Edgehog.TenantsFixtures
+  import Edgehog.TelemetryCapture
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Edgehog.Containers.Deployment.Provisioner
+  alias Edgehog.Containers.Telemetry
+
+  @moduletag :telemetry
+
+  describe "Provisioning telemetry" do
+    test "emits a start and successful stop event when the resource is already ready" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.provisioning_start_event(),
+        Telemetry.provisioning_stop_event()
+      ])
+
+      %{tenant: tenant, deployment: deployment} = deployment_context(ready: true)
+
+      provisioner =
+        case Provisioner.start(
+               tenant: tenant,
+               resource: deployment,
+               mode: :manual
+             ) do
+          {:ok, pid} -> pid
+          {:error, {:already_started, pid}} -> pid
+        end
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+      ref = Process.monitor(provisioner)
+
+      {measurements, metadata} = assert_receive_event(Telemetry.provisioning_start_event())
+
+      assert measurements.count == 1
+      assert metadata.resource_type == "deployment"
+      assert metadata.resource_id == deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      Provisioner.run(provisioner)
+
+      assert_receive {:DOWN, ^ref, :process, ^provisioner, :normal}, 1000
+
+      {measurements, metadata} = assert_receive_event(Telemetry.provisioning_stop_event())
+
+      assert measurements.count == 1
+      assert measurements.retries == 0
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :ok
+      assert metadata.reason == :already_ready
+      assert metadata.resource_type == "deployment"
+      assert metadata.resource_id == deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+    end
+
+    test "emits a failed stop event when the device is offline at startup" do
+      Edgehog.TelemetryCapture.start_capture([
+        Telemetry.provisioning_start_event(),
+        Telemetry.provisioning_stop_event()
+      ])
+
+      %{tenant: tenant, deployment: deployment} =
+        deployment_context(ready: true, device_offline: true)
+
+      provisioner =
+        case Provisioner.start(
+               tenant: tenant,
+               resource: deployment,
+               mode: :manual
+             ) do
+          {:ok, pid} -> pid
+          {:error, {:already_started, pid}} -> pid
+        end
+
+      Sandbox.allow(Edgehog.Repo, self(), provisioner)
+
+      {_measurements, metadata} = assert_receive_event(Telemetry.provisioning_start_event())
+
+      assert metadata.resource_type == "deployment"
+      assert metadata.resource_id == deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+
+      # The device is offline at startup, so the provisioner gives up immediately
+      # and the stop event is emitted
+      {measurements, metadata} = assert_receive_event(Telemetry.provisioning_stop_event())
+
+      assert measurements.count == 1
+      assert measurements.retries == 0
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert metadata.duration_unit == :native
+      assert metadata.result == :error
+      assert metadata.reason == :device_offline
+      assert metadata.resource_type == "deployment"
+      assert metadata.resource_id == deployment.id
+      assert metadata.deployment_id == deployment.id
+      assert metadata.device_id == deployment.device_id
+    end
+  end
+
+  defp deployment_context(opts) do
+    ready? = Keyword.get(opts, :ready, false)
+    device_offline? = Keyword.get(opts, :device_offline, false)
+
+    tenant = tenant_fixture()
+    deployment = deployment_fixture(tenant: tenant, release_opts: [containers: 1])
+
+    deployment =
+      if ready? do
+        make_deployment_ready!(deployment, tenant)
+      else
+        deployment
+      end
+
+    deployment =
+      if device_offline? do
+        mark_device_offline!(deployment, tenant)
+      else
+        mark_device_online!(deployment, tenant)
+      end
+
+    %{tenant: tenant, deployment: deployment}
+  end
+
+  defp mark_device_online!(deployment, tenant) do
+    timestamp = now()
+
+    opts = %{
+      online: true,
+      last_connection: timestamp,
+      last_disconnection: timestamp
+    }
+
+    deployment
+    |> Map.get(:device)
+    |> Ash.Changeset.for_update(:from_device_status, opts)
+    |> Ash.update!(tenant: tenant)
+    |> then(&Map.put(deployment, :device, &1))
+  end
+
+  defp mark_device_offline!(deployment, tenant) do
+    timestamp = now()
+
+    opts = %{
+      online: false,
+      last_connection: timestamp,
+      last_disconnection: timestamp
+    }
+
+    deployment
+    |> Map.get(:device)
+    |> Ash.Changeset.for_update(:from_device_status, opts)
+    |> Ash.update!(tenant: tenant)
+    |> then(&Map.put(deployment, :device, &1))
+  end
+
+  defp now, do: DateTime.now!("Etc/UTC")
+end

--- a/backend/test/support/telemetry_capture.ex
+++ b/backend/test/support/telemetry_capture.ex
@@ -1,0 +1,63 @@
+#
+# This file is part of Edgehog.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Edgehog.TelemetryCapture do
+  @moduledoc """
+  Helper to attach and assert telemetry events in tests.
+  """
+
+  import ExUnit.Assertions
+  import ExUnit.Callbacks
+
+  @doc """
+  Attaches a handler that forwards the events in `events` to the current
+  process as `{:telemetry_event, event, measurements, metadata}` messages.
+  """
+  def start_capture(events) do
+    parent = self()
+
+    handler_ids =
+      for event <- events do
+        handler_id = {__MODULE__, event, make_ref()}
+
+        :telemetry.attach(
+          handler_id,
+          event,
+          fn event, measurements, metadata, _config ->
+            send(parent, {:telemetry_event, event, measurements, metadata})
+          end,
+          nil
+        )
+
+        handler_id
+      end
+
+    on_exit(fn -> Enum.each(handler_ids, &:telemetry.detach/1) end)
+  end
+
+  @doc """
+  Asserts that an event with the given name was received, returning the
+  measurements and metadata of the received event.
+  """
+  def assert_receive_event(event, timeout \\ 1000) do
+    assert_receive {:telemetry_event, ^event, measurements, metadata}, timeout
+    {measurements, metadata}
+  end
+end


### PR DESCRIPTION
Edgehog's current telemetry is only based around BEAM stats.

We introduce some telemetry around application deployment, for more insight in the provisioning process.

#### What this PR does / why we need it:

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Edgehog development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.edgehog.io/snapshot/edgehog_just_in_time.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
